### PR TITLE
biuld_n_push job checks docker relevant dirs

### DIFF
--- a/.github/workflows/build-n-push-ci-image.yaml
+++ b/.github/workflows/build-n-push-ci-image.yaml
@@ -7,6 +7,7 @@ on:
       - '**'
     paths:
       - '.env.testing-artifacts'
+      - 'test_environment/*'
 
 jobs:
   build-and-push:

--- a/.github/workflows/build-n-push-ci-image.yaml
+++ b/.github/workflows/build-n-push-ci-image.yaml
@@ -30,7 +30,7 @@ jobs:
       id: taggen
       run: |
         source .env.testing-artifacts
-        export RUST_VERSION ZCASH_VERSION ZEBRA_VERSION DOCKER_DIR_HASH
+        export RUST_VERSION ZCASH_VERSION ZEBRA_VERSION
         TAG=$(./utils/get-ci-image-tag.sh)
         echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
This should ensure the build-n-push job for ci docker image does check all the relevant directories for a build trigger.

pd: build_n_push is the job that checks if the SoT for the CI image (artifact versions and dockerfile and entrypoint) have changed, then it builds and pushes the ci image with the appropiate tag