### PR TITLE
remove printlns from zaino-fetch

### DIFF
--- a/zaino-fetch/src/chain/transaction.rs
+++ b/zaino-fetch/src/chain/transaction.rs
@@ -1232,8 +1232,6 @@ mod tests {
                 "Transparent outputs mismatch for v1 transaction #{i}"
             );
         }
-
-        println!("Successfully parsed {} v1 test vectors", v1_vectors.len());
     }
 
     /// Test parsing v2 transactions using test vectors.
@@ -1286,8 +1284,6 @@ mod tests {
                 "Transparent outputs mismatch for v2 transaction #{i}"
             );
         }
-
-        println!("Successfully parsed {} v2 test vectors", v2_vectors.len());
     }
 
     /// Test parsing v3 transactions using test vectors.
@@ -1340,8 +1336,6 @@ mod tests {
                 "Transparent outputs mismatch for v3 transaction #{i}"
             );
         }
-
-        println!("Successfully parsed {} v3 test vectors", v3_vectors.len());
     }
 
     /// Test parsing v4 transactions using test vectors.
@@ -1394,7 +1388,5 @@ mod tests {
                 "Transparent outputs mismatch for v4 transaction #{i}"
             );
         }
-
-        println!("Successfully parsed {} v4 test vectors", v4_vectors.len());
     }
 }

--- a/zaino-fetch/src/jsonrpsee/response.rs
+++ b/zaino-fetch/src/jsonrpsee/response.rs
@@ -1049,8 +1049,6 @@ impl<'de> serde::Deserialize<'de> for GetTransactionResponse {
 
         let tx_value = serde_json::Value::deserialize(deserializer)?;
 
-        println!("got txvalue");
-
         if let Some(hex_value) = tx_value.get("hex") {
             let hex_str = hex_value
                 .as_str()
@@ -1121,8 +1119,6 @@ impl<'de> serde::Deserialize<'de> for GetTransactionResponse {
                 let block_hash: String = tx_value["blockhash"];
                 let block_time: i64 = tx_value["blocktime"];
             }
-
-            println!("got fields");
 
             let txid = txid.ok_or(DeserError::missing_field("txid"))?;
 


### PR DESCRIPTION
Fixes #513

Only removing active `println!`s in `zaino-fetch`.