### PR TITLE
prefer traits from infrastructure to begin upgrading test code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9087,7 +9087,7 @@ dependencies = [
 [[package]]
 name = "zcash_local_net"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?branch=simplify_validator_trait#c02f130d7afdeaf97d0d59130d614ef91b70000a"
+source = "git+https://github.com/zingolabs/infrastructure.git?branch=simplify_validator_trait#5fdc6c6d270c18bc68adf9341c55fd0a2be1e44a"
 dependencies = [
  "getset",
  "hex",
@@ -10255,7 +10255,7 @@ dependencies = [
 [[package]]
 name = "zingo_test_vectors"
 version = "0.0.1"
-source = "git+https://github.com/zingolabs/infrastructure.git?branch=simplify_validator_trait#c02f130d7afdeaf97d0d59130d614ef91b70000a"
+source = "git+https://github.com/zingolabs/infrastructure.git?branch=simplify_validator_trait#5fdc6c6d270c18bc68adf9341c55fd0a2be1e44a"
 dependencies = [
  "bip0039",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2964,6 +2964,7 @@ dependencies = [
  "zaino-proto",
  "zaino-state",
  "zaino-testutils",
+ "zcash_local_net",
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -802,6 +802,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bounded-vec"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dc0086e469182132244e9b8d313a0742e1132da43a08c24b9dd3c18e0faf3a"
+dependencies = [
+ "thiserror 2.0.16",
+]
+
+[[package]]
 name = "bounded-vec-deque"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2700,7 +2709,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -2954,7 +2963,7 @@ dependencies = [
  "anyhow",
  "core2 0.4.0",
  "futures",
- "prost",
+ "prost 0.13.5",
  "serde_json",
  "tempfile",
  "tokio",
@@ -2965,9 +2974,9 @@ dependencies = [
  "zaino-state",
  "zaino-testutils",
  "zcash_local_net",
- "zebra-chain",
- "zebra-rpc",
- "zebra-state",
+ "zebra-chain 2.0.0",
+ "zebra-rpc 2.0.1",
+ "zebra-state 2.0.0",
  "zip32",
 ]
 
@@ -3307,6 +3316,19 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libzcash_script"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8ce05b56f3cbc65ec7d0908adb308ed91281e022f61c8c3a0c9388b5380b17"
+dependencies = [
+ "bindgen 0.72.1",
+ "cc",
+ "thiserror 2.0.16",
+ "tracing",
+ "zcash_script 0.4.2",
 ]
 
 [[package]]
@@ -4425,7 +4447,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.1",
 ]
 
 [[package]]
@@ -4441,8 +4473,30 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "regex",
+ "syn 2.0.106",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost 0.14.1",
+ "prost-types 0.14.1",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.106",
  "tempfile",
@@ -4462,12 +4516,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost",
+ "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+dependencies = [
+ "prost 0.14.1",
 ]
 
 [[package]]
@@ -4504,6 +4580,26 @@ checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
 dependencies = [
  "idna",
  "psl-types",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+dependencies = [
+ "bitflags 2.9.4",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "21.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5b6a0769a491a08b31ea5c62494a8f144ee0987d86d670a8af4df1e1b7cde75"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]
@@ -4560,7 +4656,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.32",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -4597,7 +4693,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6177,6 +6273,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tklog"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9f3abb3fcc49882b5d32abfc11cf804768b54e6b73d210c6bb5ec6f123a9f"
+dependencies = [
+ "chrono",
+ "crossbeam-channel",
+ "flate2",
+ "log",
+ "once_cell",
+ "regex",
+ "tokio",
+]
+
+[[package]]
 name = "tokio"
 version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6354,7 +6465,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
@@ -6385,7 +6496,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "socket2 0.5.10",
  "tokio",
  "tokio-rustls",
@@ -6398,6 +6509,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
+dependencies = [
+ "async-trait",
+ "axum 0.8.6",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.0",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tonic-build"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6405,8 +6545,8 @@ checksum = "9557ce109ea773b399c9b9e5dca39294110b74f1f342cb347a80d1fce8c26a11"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build",
- "prost-types",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
  "quote",
  "syn 2.0.106",
 ]
@@ -6419,10 +6559,49 @@ checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build",
- "prost-types",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c40aaccc9f9eccf2cd82ebc111adc13030d23e887244bc9cfa5d1d636049de3"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+dependencies = [
+ "bytes",
+ "prost 0.14.1",
+ "tonic 0.14.2",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a16cba4043dc3ff43fcb3f96b4c5c154c64cbd18ca8dce2ab2c6a451d058a2"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build 0.14.1",
+ "prost-types 0.14.1",
+ "quote",
+ "syn 2.0.106",
+ "tempfile",
+ "tonic-build 0.14.2",
 ]
 
 [[package]]
@@ -6431,11 +6610,25 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "878d81f52e7fcfd80026b7fdb6a9b578b3c3653ba987f87f0dce4b64043cba27"
 dependencies = [
- "prost",
- "prost-types",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
  "tokio",
  "tokio-stream",
  "tonic 0.12.3",
+]
+
+[[package]]
+name = "tonic-reflection"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34da53e8387581d66db16ff01f98a70b426b091fdf76856e289d5c1bd386ed7b"
+dependencies = [
+ "prost 0.14.1",
+ "prost-types 0.14.1",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.14.2",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -7347,6 +7540,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-batch-control"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe651be646060d75570d5819bbdac919478f438fc814c247300f34b38d1bd0e9"
+dependencies = [
+ "futures",
+ "futures-core",
+ "pin-project",
+ "rayon",
+ "tokio",
+ "tokio-util",
+ "tower 0.4.13",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
 name = "tower-fallback"
 version = "0.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7568,6 +7778,12 @@ checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
 dependencies = [
  "version_check",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
@@ -8383,7 +8599,7 @@ version = "0.1.2"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
- "zebra-chain",
+ "zebra-chain 2.0.0",
 ]
 
 [[package]]
@@ -8397,7 +8613,7 @@ dependencies = [
  "http",
  "indexmap 2.11.4",
  "jsonrpsee-types",
- "prost",
+ "prost 0.13.5",
  "reqwest",
  "serde",
  "serde_json",
@@ -8409,15 +8625,15 @@ dependencies = [
  "url",
  "zaino-proto",
  "zaino-testvectors",
- "zebra-chain",
- "zebra-rpc",
+ "zebra-chain 2.0.0",
+ "zebra-rpc 2.0.1",
 ]
 
 [[package]]
 name = "zaino-proto"
 version = "0.1.2"
 dependencies = [
- "prost",
+ "prost 0.13.5",
  "tonic 0.12.3",
  "tonic-build 0.12.3",
  "which 4.4.2",
@@ -8438,8 +8654,8 @@ dependencies = [
  "zaino-fetch",
  "zaino-proto",
  "zaino-state",
- "zebra-chain",
- "zebra-rpc",
+ "zebra-chain 2.0.0",
+ "zebra-rpc 2.0.1",
 ]
 
 [[package]]
@@ -8464,7 +8680,7 @@ dependencies = [
  "nonempty",
  "once_cell",
  "primitive-types 0.13.1",
- "prost",
+ "prost 0.13.5",
  "reqwest",
  "serde",
  "serde_json",
@@ -8487,9 +8703,9 @@ dependencies = [
  "zcash_primitives 0.24.1",
  "zcash_protocol 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_transparent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zebra-chain",
- "zebra-rpc",
- "zebra-state",
+ "zebra-chain 2.0.0",
+ "zebra-rpc 2.0.1",
+ "zebra-state 2.0.0",
 ]
 
 [[package]]
@@ -8512,10 +8728,10 @@ dependencies = [
  "zcash_client_backend 0.19.1 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
  "zcash_local_net",
  "zcash_protocol 0.6.1 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
- "zebra-chain",
+ "zebra-chain 2.0.0",
  "zingo_common_components 0.1.0 (git+https://github.com/zingolabs/zingo-common.git?tag=zingo_common_components_v0.1.0)",
  "zingo_netutils 0.1.0 (git+https://github.com/zingolabs/zingo-common.git?tag=zingo_common_components_v0.1.0)",
- "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?tag=zcash_local_net_v0.1.0)",
+ "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?branch=simplify_validator_trait)",
  "zingolib",
  "zip32",
 ]
@@ -8544,8 +8760,8 @@ dependencies = [
  "zaino-fetch",
  "zaino-serve",
  "zaino-state",
- "zebra-chain",
- "zebra-state",
+ "zebra-chain 2.0.0",
+ "zebra-state 2.0.0",
 ]
 
 [[package]]
@@ -8590,6 +8806,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_address"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4491dddd232de02df42481757054dc19c8bc51cf709cfec58feebfef7c3c9a"
+dependencies = [
+ "bech32",
+ "bs58",
+ "core2 0.3.3",
+ "f4jumble 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.7.1",
+]
+
+[[package]]
 name = "zcash_client_backend"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8617,7 +8847,7 @@ dependencies = [
  "orchard",
  "pasta_curves",
  "percent-encoding",
- "prost",
+ "prost 0.13.5",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rayon",
@@ -8680,7 +8910,7 @@ dependencies = [
  "orchard",
  "pasta_curves",
  "percent-encoding",
- "prost",
+ "prost 0.13.5",
  "rand 0.8.5",
  "rand_core 0.6.4",
  "rayon",
@@ -8829,9 +9059,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_keys"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c115531caa1b7ca5ccd82dc26dbe3ba44b7542e928a3f77cd04abbe3cde4a4f2"
+dependencies = [
+ "bech32",
+ "blake2b_simd",
+ "bls12_381",
+ "bs58",
+ "core2 0.3.3",
+ "document-features",
+ "group",
+ "memuse",
+ "nonempty",
+ "rand_core 0.6.4",
+ "secrecy",
+ "subtle",
+ "tracing",
+ "zcash_address 0.10.1",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.7.1",
+ "zcash_transparent 0.6.1",
+ "zip32",
+]
+
+[[package]]
 name = "zcash_local_net"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?tag=zcash_local_net_v0.1.0#9f479fe8610ac15bb67f06d9e65ee37bcfebd228"
+source = "git+https://github.com/zingolabs/infrastructure.git?branch=simplify_validator_trait#c02f130d7afdeaf97d0d59130d614ef91b70000a"
 dependencies = [
  "getset",
  "hex",
@@ -8841,14 +9097,16 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",
+ "tklog",
  "tokio",
  "tracing",
  "tracing-subscriber",
- "zcash_protocol 0.6.1 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
- "zebra-chain",
- "zebra-node-services",
- "zebra-rpc",
- "zingo_common_components 0.1.0 (git+https://github.com/zingolabs/zingo-common.git?rev=23814ee904ee64913585c0b8f871c6dbd94504c6)",
+ "zcash_protocol 0.7.1",
+ "zebra-chain 3.0.0",
+ "zebra-node-services 2.0.0",
+ "zebra-rpc 3.0.0",
+ "zingo_common_components 0.1.0 (git+https://github.com/zingolabs/zingo-common.git?branch=dev)",
+ "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?branch=simplify_validator_trait)",
 ]
 
 [[package]]
@@ -8990,6 +9248,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_primitives"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0e6912efdae984166ec0dc580049699026795328dcea4fc8cc077d51fce350c"
+dependencies = [
+ "bip32",
+ "blake2b_simd",
+ "block-buffer 0.11.0-rc.3",
+ "bs58",
+ "core2 0.3.3",
+ "crypto-common 0.2.0-rc.1",
+ "document-features",
+ "equihash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ff",
+ "fpe",
+ "getset",
+ "group",
+ "hex",
+ "incrementalmerkletree",
+ "jubjub",
+ "memuse",
+ "nonempty",
+ "orchard",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "ripemd 0.1.3",
+ "sapling-crypto",
+ "secp256k1",
+ "sha2 0.10.9",
+ "subtle",
+ "tracing",
+ "zcash_address 0.10.1",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_note_encryption",
+ "zcash_protocol 0.7.1",
+ "zcash_script 0.4.2",
+ "zcash_spec",
+ "zcash_transparent 0.6.1",
+ "zip32",
+]
+
+[[package]]
 name = "zcash_proofs"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9036,6 +9337,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_proofs"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a2c13bb673d542608a0e6502ac5494136e7ce4ce97e92dd239489b2523eed9"
+dependencies = [
+ "bellman",
+ "blake2b_simd",
+ "bls12_381",
+ "document-features",
+ "group",
+ "home",
+ "jubjub",
+ "known-folders",
+ "lazy_static",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "tracing",
+ "wagyu-zcash-parameters",
+ "xdg",
+ "zcash_primitives 0.26.1",
+]
+
+[[package]]
 name = "zcash_protocol"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9071,6 +9396,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_protocol"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb4c8d0530fd7a3d65358010f1e0a1ccfe6cc5f1ad63447af089ccc82ae9edf"
+dependencies = [
+ "core2 0.3.3",
+ "document-features",
+ "hex",
+ "memuse",
+]
+
+[[package]]
 name = "zcash_script"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9086,6 +9423,23 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 2.0.16",
  "tracing",
+]
+
+[[package]]
+name = "zcash_script"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bed6cf5b2b4361105d4ea06b2752f0c8af4641756c7fbc9858a80af186c234f"
+dependencies = [
+ "bip32",
+ "bitflags 2.9.4",
+ "bounded-vec",
+ "hex",
+ "ripemd 0.1.3",
+ "secp256k1",
+ "sha1",
+ "sha2 0.10.9",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -9168,6 +9522,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_transparent"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4a3a377d478f94e4a00ff36a4963dc641ccd8ed2455554b8cb6914721562"
+dependencies = [
+ "bip32",
+ "blake2b_simd",
+ "bs58",
+ "core2 0.3.3",
+ "document-features",
+ "getset",
+ "hex",
+ "ripemd 0.1.3",
+ "secp256k1",
+ "sha2 0.10.9",
+ "subtle",
+ "zcash_address 0.10.1",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_protocol 0.7.1",
+ "zcash_script 0.4.2",
+ "zcash_spec",
+ "zip32",
+]
+
+[[package]]
 name = "zebra-chain"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9227,6 +9606,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zebra-chain"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e10d4094ae02f982e254ec4fee0802c62540b5b366d994608f732f1fe5834b"
+dependencies = [
+ "bech32",
+ "bitflags 2.9.4",
+ "bitflags-serde-legacy",
+ "bitvec",
+ "blake2b_simd",
+ "blake2s_simd",
+ "bs58",
+ "byteorder",
+ "chrono",
+ "derive-getters",
+ "dirs",
+ "ed25519-zebra",
+ "equihash 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures",
+ "group",
+ "halo2_proofs",
+ "hex",
+ "humantime",
+ "incrementalmerkletree",
+ "itertools 0.14.0",
+ "jubjub",
+ "lazy_static",
+ "num-integer",
+ "orchard",
+ "primitive-types 0.12.2",
+ "rand_core 0.6.4",
+ "rayon",
+ "reddsa",
+ "redjubjub",
+ "ripemd 0.1.3",
+ "sapling-crypto",
+ "secp256k1",
+ "serde",
+ "serde-big-array",
+ "serde_json",
+ "serde_with",
+ "sha2 0.10.9",
+ "sinsemilla",
+ "static_assertions",
+ "tempfile",
+ "thiserror 2.0.16",
+ "tokio",
+ "tracing",
+ "uint 0.10.0",
+ "x25519-dalek",
+ "zcash_address 0.10.1",
+ "zcash_encoding 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_history",
+ "zcash_note_encryption",
+ "zcash_primitives 0.26.1",
+ "zcash_protocol 0.7.1",
+ "zcash_script 0.4.2",
+ "zcash_transparent 0.6.1",
+]
+
+[[package]]
 name = "zebra-consensus"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9252,16 +9692,55 @@ dependencies = [
  "thiserror 2.0.16",
  "tokio",
  "tower 0.4.13",
- "tower-batch-control",
+ "tower-batch-control 0.2.41",
  "tower-fallback",
  "tracing",
  "tracing-futures",
  "wagyu-zcash-parameters",
  "zcash_proofs 0.24.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zebra-chain",
- "zebra-node-services",
- "zebra-script",
- "zebra-state",
+ "zebra-chain 2.0.0",
+ "zebra-node-services 1.0.1",
+ "zebra-script 2.0.0",
+ "zebra-state 2.0.0",
+]
+
+[[package]]
+name = "zebra-consensus"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0193612e78338a596fb35dfce2b6461c2a811b7e77f60243eab4b8cbd158cb46"
+dependencies = [
+ "bellman",
+ "blake2b_simd",
+ "bls12_381",
+ "chrono",
+ "derive-getters",
+ "futures",
+ "futures-util",
+ "halo2_proofs",
+ "jubjub",
+ "lazy_static",
+ "metrics",
+ "mset",
+ "once_cell",
+ "orchard",
+ "rand 0.8.5",
+ "rayon",
+ "sapling-crypto",
+ "serde",
+ "thiserror 2.0.16",
+ "tokio",
+ "tower 0.4.13",
+ "tower-batch-control 1.0.0",
+ "tower-fallback",
+ "tracing",
+ "tracing-futures",
+ "zcash_proofs 0.26.1",
+ "zcash_protocol 0.7.1",
+ "zebra-chain 3.0.0",
+ "zebra-node-services 2.0.0",
+ "zebra-script 3.0.0",
+ "zebra-state 3.0.0",
 ]
 
 [[package]]
@@ -9298,7 +9777,44 @@ dependencies = [
  "tracing",
  "tracing-error",
  "tracing-futures",
- "zebra-chain",
+ "zebra-chain 2.0.0",
+]
+
+[[package]]
+name = "zebra-network"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "542a036cbd491d2ffbf011cfa5b90d30ff8aacc5a35d8fe9cd7709e719752747"
+dependencies = [
+ "bitflags 2.9.4",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "dirs",
+ "futures",
+ "hex",
+ "humantime-serde",
+ "indexmap 2.11.4",
+ "itertools 0.14.0",
+ "lazy_static",
+ "metrics",
+ "num-integer",
+ "ordered-map",
+ "pin-project",
+ "rand 0.8.5",
+ "rayon",
+ "regex",
+ "serde",
+ "tempfile",
+ "thiserror 2.0.16",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower 0.4.13",
+ "tracing",
+ "tracing-error",
+ "tracing-futures",
+ "zebra-chain 3.0.0",
 ]
 
 [[package]]
@@ -9313,7 +9829,22 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "zebra-chain",
+ "zebra-chain 2.0.0",
+]
+
+[[package]]
+name = "zebra-node-services"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1a5293d992264b1482ca66d9e4950201927b940013a06bd5f0da3ccdf217b3"
+dependencies = [
+ "color-eyre",
+ "jsonrpsee-types",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "zebra-chain 3.0.0",
 ]
 
 [[package]]
@@ -9336,7 +9867,7 @@ dependencies = [
  "jsonrpsee-proc-macros",
  "jsonrpsee-types",
  "nix",
- "prost",
+ "prost 0.13.5",
  "rand 0.8.5",
  "semver",
  "serde",
@@ -9346,7 +9877,7 @@ dependencies = [
  "tokio-stream",
  "tonic 0.12.3",
  "tonic-build 0.12.3",
- "tonic-reflection",
+ "tonic-reflection 0.12.3",
  "tower 0.4.13",
  "tracing",
  "which 8.0.0",
@@ -9355,12 +9886,62 @@ dependencies = [
  "zcash_primitives 0.24.1",
  "zcash_protocol 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "zcash_transparent 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "zebra-chain",
- "zebra-consensus",
- "zebra-network",
- "zebra-node-services",
- "zebra-script",
- "zebra-state",
+ "zebra-chain 2.0.0",
+ "zebra-consensus 2.0.0",
+ "zebra-network 1.1.0",
+ "zebra-node-services 1.0.1",
+ "zebra-script 2.0.0",
+ "zebra-state 2.0.0",
+]
+
+[[package]]
+name = "zebra-rpc"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b8e1900e33dcaaad05b0ac5bd35c1bb4e3eb8d96b8cf513ad1399c3f34e8227"
+dependencies = [
+ "base64",
+ "chrono",
+ "color-eyre",
+ "derive-getters",
+ "derive-new",
+ "futures",
+ "hex",
+ "http-body-util",
+ "hyper",
+ "indexmap 2.11.4",
+ "jsonrpsee",
+ "jsonrpsee-proc-macros",
+ "jsonrpsee-types",
+ "nix",
+ "prost 0.14.1",
+ "rand 0.8.5",
+ "sapling-crypto",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "tokio",
+ "tokio-stream",
+ "tonic 0.14.2",
+ "tonic-prost",
+ "tonic-prost-build",
+ "tonic-reflection 0.14.2",
+ "tower 0.4.13",
+ "tracing",
+ "which 8.0.0",
+ "zcash_address 0.10.1",
+ "zcash_keys 0.12.0",
+ "zcash_primitives 0.26.1",
+ "zcash_protocol 0.7.1",
+ "zcash_script 0.4.2",
+ "zcash_transparent 0.6.1",
+ "zebra-chain 3.0.0",
+ "zebra-consensus 3.0.0",
+ "zebra-network 2.0.0",
+ "zebra-node-services 2.0.0",
+ "zebra-script 3.0.0",
+ "zebra-state 3.0.0",
 ]
 
 [[package]]
@@ -9371,8 +9952,21 @@ checksum = "a76a2e972e414caa3635b8c2d21f20c21a71c69f76b37bf7419d97ed0c2277e7"
 dependencies = [
  "thiserror 2.0.16",
  "zcash_primitives 0.24.1",
- "zcash_script",
- "zebra-chain",
+ "zcash_script 0.3.2",
+ "zebra-chain 2.0.0",
+]
+
+[[package]]
+name = "zebra-script"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87f361fc4fb831020cf85de879467fac181328d808e21d1b2267264776964c"
+dependencies = [
+ "libzcash_script",
+ "thiserror 2.0.16",
+ "zcash_primitives 0.26.1",
+ "zcash_script 0.4.2",
+ "zebra-chain 3.0.0",
 ]
 
 [[package]]
@@ -9406,7 +10000,44 @@ dependencies = [
  "tokio",
  "tower 0.4.13",
  "tracing",
- "zebra-chain",
+ "zebra-chain 2.0.0",
+]
+
+[[package]]
+name = "zebra-state"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f694bf023271dec800a81e999abba66df6828187c094c7bbfa1a128c89864ea5"
+dependencies = [
+ "bincode",
+ "chrono",
+ "crossbeam-channel",
+ "derive-getters",
+ "derive-new",
+ "dirs",
+ "futures",
+ "hex",
+ "hex-literal",
+ "human_bytes",
+ "humantime-serde",
+ "indexmap 2.11.4",
+ "itertools 0.14.0",
+ "lazy_static",
+ "metrics",
+ "mset",
+ "rayon",
+ "regex",
+ "rlimit",
+ "rocksdb",
+ "sapling-crypto",
+ "semver",
+ "serde",
+ "tempfile",
+ "thiserror 2.0.16",
+ "tokio",
+ "tower 0.4.13",
+ "tracing",
+ "zebra-chain 3.0.0",
 ]
 
 [[package]]
@@ -9523,9 +10154,9 @@ dependencies = [
  "tracing-subscriber",
  "zcash_primitives 0.24.0",
  "zcash_protocol 0.6.1 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
- "zebra-chain",
- "zebra-node-services",
- "zebra-rpc",
+ "zebra-chain 2.0.0",
+ "zebra-node-services 1.0.1",
+ "zebra-rpc 2.0.1",
 ]
 
 [[package]]
@@ -9570,15 +10201,15 @@ name = "zingo_common_components"
 version = "0.1.0"
 source = "git+https://github.com/zingolabs/zingo-common.git?tag=zingo_common_components_v0.1.0#7407028a9c561561d174740e70170c4c20529bcd"
 dependencies = [
- "zebra-chain",
+ "zebra-chain 2.0.0",
 ]
 
 [[package]]
 name = "zingo_common_components"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingo-common.git?rev=23814ee904ee64913585c0b8f871c6dbd94504c6#23814ee904ee64913585c0b8f871c6dbd94504c6"
+source = "git+https://github.com/zingolabs/zingo-common.git?branch=dev#af95bcbf6aadbfa8056d54e89dca442ef8555b9a"
 dependencies = [
- "zebra-chain",
+ "zebra-chain 3.0.0",
 ]
 
 [[package]]
@@ -9610,7 +10241,7 @@ dependencies = [
  "hyper",
  "hyper-rustls",
  "hyper-util",
- "prost",
+ "prost 0.13.5",
  "thiserror 1.0.69",
  "time",
  "time-core",
@@ -9624,7 +10255,7 @@ dependencies = [
 [[package]]
 name = "zingo_test_vectors"
 version = "0.0.1"
-source = "git+https://github.com/zingolabs/infrastructure.git?tag=zcash_local_net_v0.1.0#9f479fe8610ac15bb67f06d9e65ee37bcfebd228"
+source = "git+https://github.com/zingolabs/infrastructure.git?branch=simplify_validator_trait#c02f130d7afdeaf97d0d59130d614ef91b70000a"
 dependencies = [
  "bip0039",
 ]
@@ -9665,7 +10296,7 @@ dependencies = [
  "orchard",
  "pepper-sync",
  "portpicker",
- "prost",
+ "prost 0.13.5",
  "rand 0.8.5",
  "ring 0.17.14",
  "rust-embed",
@@ -9693,7 +10324,7 @@ dependencies = [
  "zcash_proofs 0.24.0 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
  "zcash_protocol 0.6.1 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
  "zcash_transparent 0.4.0 (git+https://github.com/zcash/librustzcash?rev=d387aed7e04e881dbe30c6ff8b26a96c834c094b)",
- "zebra-chain",
+ "zebra-chain 2.0.0",
  "zingo-infra-services",
  "zingo-memo",
  "zingo-price",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2709,7 +2709,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4656,7 +4656,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.32",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -4693,7 +4693,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6271,21 +6271,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tklog"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9f3abb3fcc49882b5d32abfc11cf804768b54e6b73d210c6bb5ec6f123a9f"
-dependencies = [
- "chrono",
- "crossbeam-channel",
- "flate2",
- "log",
- "once_cell",
- "regex",
- "tokio",
-]
 
 [[package]]
 name = "tokio"
@@ -8731,7 +8716,7 @@ dependencies = [
  "zebra-chain 2.0.0",
  "zingo_common_components 0.1.0 (git+https://github.com/zingolabs/zingo-common.git?tag=zingo_common_components_v0.1.0)",
  "zingo_netutils 0.1.0 (git+https://github.com/zingolabs/zingo-common.git?tag=zingo_common_components_v0.1.0)",
- "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?branch=simplify_validator_trait)",
+ "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?tag=zcash_local_net_v0.3.0)",
  "zingolib",
  "zip32",
 ]
@@ -9087,7 +9072,7 @@ dependencies = [
 [[package]]
 name = "zcash_local_net"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/infrastructure.git?branch=simplify_validator_trait#5fdc6c6d270c18bc68adf9341c55fd0a2be1e44a"
+source = "git+https://github.com/zingolabs/infrastructure.git?tag=zcash_local_net_v0.3.0#7d833158da3b7f6656b5459fbda618e8ebbca49e"
 dependencies = [
  "getset",
  "hex",
@@ -9097,7 +9082,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",
- "tklog",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -9106,7 +9090,7 @@ dependencies = [
  "zebra-node-services 2.0.0",
  "zebra-rpc 3.0.0",
  "zingo_common_components 0.1.0 (git+https://github.com/zingolabs/zingo-common.git?branch=dev)",
- "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?branch=simplify_validator_trait)",
+ "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?tag=zcash_local_net_v0.3.0)",
 ]
 
 [[package]]
@@ -10255,7 +10239,7 @@ dependencies = [
 [[package]]
 name = "zingo_test_vectors"
 version = "0.0.1"
-source = "git+https://github.com/zingolabs/infrastructure.git?branch=simplify_validator_trait#5fdc6c6d270c18bc68adf9341c55fd0a2be1e44a"
+source = "git+https://github.com/zingolabs/infrastructure.git?tag=zcash_local_net_v0.3.0#7d833158da3b7f6656b5459fbda618e8ebbca49e"
 dependencies = [
  "bip0039",
 ]

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -33,4 +33,4 @@ tower = { workspace = true, features = ["buffer", "util"] }
 
 # Runtime
 tokio = { workspace = true }
-zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", tag = "zcash_local_net_v0.1.0" }
+zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", tag = "zcash_local_net_v0.3.0" }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -33,3 +33,4 @@ tower = { workspace = true, features = ["buffer", "util"] }
 
 # Runtime
 tokio = { workspace = true }
+zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", tag = "zcash_local_net_v0.1.0" }

--- a/integration-tests/tests/chain_cache.rs
+++ b/integration-tests/tests/chain_cache.rs
@@ -251,7 +251,7 @@ mod chain_query_interface {
                 .await;
 
         // this delay had to increase. Maybe we tweak sync loop rerun time?
-        test_manager.local_net.generate_blocks_with_delay(5).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(5).await;
         let snapshot = indexer.snapshot_nonfinalized_state();
         assert_eq!(snapshot.as_ref().blocks.len(), 8);
         let range = indexer
@@ -294,7 +294,7 @@ mod chain_query_interface {
                 .await;
 
         // this delay had to increase. Maybe we tweak sync loop rerun time?
-        test_manager.local_net.generate_blocks_with_delay(5).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(5).await;
         let snapshot = indexer.snapshot_nonfinalized_state();
         assert_eq!(snapshot.as_ref().blocks.len(), 8);
         for block_hash in snapshot.heights_to_hashes.values() {
@@ -327,7 +327,7 @@ mod chain_query_interface {
                 .await;
 
         // this delay had to increase. Maybe we tweak sync loop rerun time?
-        test_manager.local_net.generate_blocks_with_delay(5).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(5).await;
         let snapshot = indexer.snapshot_nonfinalized_state();
         assert_eq!(snapshot.as_ref().blocks.len(), 8);
         for (txid, height) in snapshot.blocks.values().flat_map(|block| {
@@ -386,7 +386,7 @@ mod chain_query_interface {
         assert_eq!(snapshot.as_ref().blocks.len(), 3);
 
         // this delay had to increase. Maybe we tweak sync loop rerun time?
-        test_manager.local_net.generate_blocks_with_delay(5).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(5).await;
         let snapshot = indexer.snapshot_nonfinalized_state();
         assert_eq!(snapshot.as_ref().blocks.len(), 8);
         for (txid, height, block_hash) in snapshot.blocks.values().flat_map(|block| {
@@ -423,7 +423,7 @@ mod chain_query_interface {
                 .await;
 
         // this delay had to increase. Maybe we tweak sync loop rerun time?
-        test_manager.local_net.generate_blocks_with_delay(5).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(5).await;
         {
             let chain_height =
                 Height::try_from(json_service.get_blockchain_info().await.unwrap().blocks.0)
@@ -432,7 +432,7 @@ mod chain_query_interface {
             assert_eq!(chain_height, indexer_height);
         }
 
-        test_manager.local_net.generate_blocks_with_delay(150).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(150).await;
 
         tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
 

--- a/integration-tests/tests/chain_cache.rs
+++ b/integration-tests/tests/chain_cache.rs
@@ -3,7 +3,7 @@ use zaino_fetch::jsonrpsee::connector::{test_node_and_return_url, JsonRpSeeConne
 use zaino_state::BackendType;
 use zaino_testutils::{TestManager, ValidatorKind};
 
-async fn create_test_manager_and_connector<T: zcash_local_net::validator::Validator>(
+async fn create_test_manager_and_connector<T: zcash_local_net::validator::ControlChain>(
     validator: &ValidatorKind,
     activation_heights: Option<ActivationHeights>,
     chain_cache: Option<std::path::PathBuf>,
@@ -66,8 +66,7 @@ mod chain_query_interface {
         },
         Height, StateService, StateServiceConfig, ZcashService as _,
     };
-    use zaino_testutils::Validator;
-    use zcash_local_net::validator::{Zcashd, Zebrad};
+    use zcash_local_net::validator::{zcashd::ZcashdManager, zebrad::ZebradManager, ControlChain};
     use zebra_chain::{
         parameters::NetworkKind,
         serialization::{ZcashDeserialize, ZcashDeserializeInto},
@@ -75,7 +74,7 @@ mod chain_query_interface {
 
     use super::*;
 
-    async fn create_test_manager_and_chain_index<V: Validator>(
+    async fn create_test_manager_and_chain_index<C: ControlChain>(
         validator: &ValidatorKind,
         chain_cache: Option<std::path::PathBuf>,
         enable_zaino: bool,
@@ -118,7 +117,7 @@ mod chain_query_interface {
             },
         };
 
-        let (test_manager, json_service) = create_test_manager_and_connector::<V>(
+        let (test_manager, json_service) = create_test_manager_and_connector::<C>(
             validator,
             Some(activation_heights),
             chain_cache.clone(),
@@ -243,17 +242,17 @@ mod chain_query_interface {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn get_block_range_zebrad() {
-        get_block_range::<Zebrad>(&ValidatorKind::Zebrad).await
+        get_block_range::<ZebradManager>(&ValidatorKind::Zebrad).await
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn get_block_range_zcashd() {
-        get_block_range::<Zcashd>(&ValidatorKind::Zcashd).await
+        get_block_range::<ZcashdManager>(&ValidatorKind::Zcashd).await
     }
 
-    async fn get_block_range<V: Validator>(validator: &ValidatorKind) {
+    async fn get_block_range<C: ControlChain>(validator: &ValidatorKind) {
         let (test_manager, _json_service, _option_state_service, _chain_index, indexer) =
-            create_test_manager_and_chain_index::<V>(validator, None, false, false, false, false)
+            create_test_manager_and_chain_index::<C>(validator, None, false, false, false, false)
                 .await;
 
         // this delay had to increase. Maybe we tweak sync loop rerun time?
@@ -291,10 +290,10 @@ mod chain_query_interface {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn find_fork_point_zcashd() {
-        find_fork_point::<Zcashd>(&ValidatorKind::Zcashd).await
+        find_fork_point::<ZcashdManager>(&ValidatorKind::Zcashd).await
     }
 
-    async fn find_fork_point<V: Validator>(validator: &ValidatorKind) {
+    async fn find_fork_point<C: ControlChain>(validator: &ValidatorKind) {
         let (test_manager, _json_service, _option_state_service, _chain_index, indexer) =
             create_test_manager_and_chain_index::<V>(validator, None, false, false, false, false)
                 .await;
@@ -324,10 +323,10 @@ mod chain_query_interface {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn get_raw_transaction_zcashd() {
-        get_raw_transaction::<Zcashd>(&ValidatorKind::Zcashd).await
+        get_raw_transaction::<ZcashdManager>(&ValidatorKind::Zcashd).await
     }
 
-    async fn get_raw_transaction<V: Validator>(validator: &ValidatorKind) {
+    async fn get_raw_transaction<C: ControlChain>(validator: &ValidatorKind) {
         let (test_manager, _json_service, _option_state_service, _chain_index, indexer) =
             create_test_manager_and_chain_index::<V>(validator, None, false, false, false, false)
                 .await;
@@ -379,10 +378,10 @@ mod chain_query_interface {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn get_transaction_status_zcashd() {
-        get_transaction_status::<Zcashd>(&ValidatorKind::Zcashd).await
+        get_transaction_status::<ZcashdManager>(&ValidatorKind::Zcashd).await
     }
 
-    async fn get_transaction_status<V: Validator>(validator: &ValidatorKind) {
+    async fn get_transaction_status<C: ControlChain>(validator: &ValidatorKind) {
         let (test_manager, _json_service, _option_state_service, _chain_index, indexer) =
             create_test_manager_and_chain_index::<V>(validator, None, false, false, false, false)
                 .await;
@@ -420,10 +419,10 @@ mod chain_query_interface {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn sync_large_chain_zcashd() {
-        sync_large_chain::<Zcashd>(&ValidatorKind::Zcashd).await
+        sync_large_chain::<ZcashdManager>(&ValidatorKind::Zcashd).await
     }
 
-    async fn sync_large_chain<V: Validator>(validator: &ValidatorKind) {
+    async fn sync_large_chain<C: ControlChain>(validator: &ValidatorKind) {
         let (test_manager, json_service, _option_state_service, _chain_index, indexer) =
             create_test_manager_and_chain_index::<V>(validator, None, false, false, false, false)
                 .await;

--- a/integration-tests/tests/chain_cache.rs
+++ b/integration-tests/tests/chain_cache.rs
@@ -251,7 +251,7 @@ mod chain_query_interface {
                 .await;
 
         // this delay had to increase. Maybe we tweak sync loop rerun time?
-        test_manager.generate_blocks_with_delay(5).await;
+        test_manager.local_net.generate_blocks_with_delay(5).await;
         let snapshot = indexer.snapshot_nonfinalized_state();
         assert_eq!(snapshot.as_ref().blocks.len(), 8);
         let range = indexer
@@ -290,11 +290,11 @@ mod chain_query_interface {
 
     async fn find_fork_point<C: Validator>(validator: &ValidatorKind) {
         let (test_manager, _json_service, _option_state_service, _chain_index, indexer) =
-            create_test_manager_and_chain_index::<V>(validator, None, false, false, false, false)
+            create_test_manager_and_chain_index::<C>(validator, None, false, false, false, false)
                 .await;
 
         // this delay had to increase. Maybe we tweak sync loop rerun time?
-        test_manager.generate_blocks_with_delay(5).await;
+        test_manager.local_net.generate_blocks_with_delay(5).await;
         let snapshot = indexer.snapshot_nonfinalized_state();
         assert_eq!(snapshot.as_ref().blocks.len(), 8);
         for block_hash in snapshot.heights_to_hashes.values() {
@@ -323,11 +323,11 @@ mod chain_query_interface {
 
     async fn get_raw_transaction<C: Validator>(validator: &ValidatorKind) {
         let (test_manager, _json_service, _option_state_service, _chain_index, indexer) =
-            create_test_manager_and_chain_index::<V>(validator, None, false, false, false, false)
+            create_test_manager_and_chain_index::<C>(validator, None, false, false, false, false)
                 .await;
 
         // this delay had to increase. Maybe we tweak sync loop rerun time?
-        test_manager.generate_blocks_with_delay(5).await;
+        test_manager.local_net.generate_blocks_with_delay(5).await;
         let snapshot = indexer.snapshot_nonfinalized_state();
         assert_eq!(snapshot.as_ref().blocks.len(), 8);
         for (txid, height) in snapshot.blocks.values().flat_map(|block| {
@@ -378,7 +378,7 @@ mod chain_query_interface {
 
     async fn get_transaction_status<C: Validator>(validator: &ValidatorKind) {
         let (test_manager, _json_service, _option_state_service, _chain_index, indexer) =
-            create_test_manager_and_chain_index::<V>(validator, None, false, false, false, false)
+            create_test_manager_and_chain_index::<C>(validator, None, false, false, false, false)
                 .await;
         let snapshot = indexer.snapshot_nonfinalized_state();
         // I don't know where this second block is generated. Somewhere in the
@@ -386,7 +386,7 @@ mod chain_query_interface {
         assert_eq!(snapshot.as_ref().blocks.len(), 3);
 
         // this delay had to increase. Maybe we tweak sync loop rerun time?
-        test_manager.generate_blocks_with_delay(5).await;
+        test_manager.local_net.generate_blocks_with_delay(5).await;
         let snapshot = indexer.snapshot_nonfinalized_state();
         assert_eq!(snapshot.as_ref().blocks.len(), 8);
         for (txid, height, block_hash) in snapshot.blocks.values().flat_map(|block| {
@@ -419,11 +419,11 @@ mod chain_query_interface {
 
     async fn sync_large_chain<C: Validator>(validator: &ValidatorKind) {
         let (test_manager, json_service, _option_state_service, _chain_index, indexer) =
-            create_test_manager_and_chain_index::<V>(validator, None, false, false, false, false)
+            create_test_manager_and_chain_index::<C>(validator, None, false, false, false, false)
                 .await;
 
         // this delay had to increase. Maybe we tweak sync loop rerun time?
-        test_manager.generate_blocks_with_delay(5).await;
+        test_manager.local_net.generate_blocks_with_delay(5).await;
         {
             let chain_height =
                 Height::try_from(json_service.get_blockchain_info().await.unwrap().blocks.0)
@@ -432,7 +432,7 @@ mod chain_query_interface {
             assert_eq!(chain_height, indexer_height);
         }
 
-        test_manager.generate_blocks_with_delay(150).await;
+        test_manager.local_net.generate_blocks_with_delay(150).await;
 
         tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
 

--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -26,8 +26,8 @@ async fn create_test_manager_and_fetch_service<V: Validator>(
     zaino_no_sync: bool,
     zaino_no_db: bool,
     enable_clients: bool,
-) -> (TestManager, FetchService, FetchServiceSubscriber) {
-    let test_manager = TestManager::launch_with_default_activation_heights::<V>(
+) -> (TestManager<V>, FetchService, FetchServiceSubscriber) {
+    let test_manager = TestManager::<V>::launch_with_default_activation_heights(
         validator,
         &BackendType::Fetch,
         None,
@@ -1473,7 +1473,7 @@ async fn assert_fetch_service_getnetworksols_matches_rpc<V: Validator>(validator
 mod zcashd {
 
     use super::*;
-    use zcash_local_net::validator::Zcashd;
+    use zcash_local_net::validator::zcashd::Zcashd;
 
     mod launch {
 
@@ -1689,7 +1689,7 @@ mod zcashd {
 mod zebrad {
 
     use super::*;
-    use zcash_local_net::validator::Zebrad;
+    use zcash_local_net::validator::zebrad::Zebrad;
 
     mod launch {
 

--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -28,7 +28,7 @@ async fn create_test_manager_and_fetch_service<V: Validator>(
     _zaino_no_sync: bool,
     enable_clients: bool,
 ) -> (TestManager<V>, FetchService, FetchServiceSubscriber) {
-    let test_manager = TestManager::<V>::launch_with_default_activation_heights(
+    let test_manager = TestManager::<V>::launch(
         validator,
         &BackendType::Fetch,
         None,
@@ -67,7 +67,8 @@ async fn launch_fetch_service<V: Validator>(
     chain_cache: Option<std::path::PathBuf>,
 ) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service::<V>(validator, chain_cache, false, true, false).await;
+        create_test_manager_and_fetch_service::<V>(validator, chain_cache, false, true, false)
+            .await;
     assert_eq!(fetch_service_subscriber.status(), StatusType::Ready);
     dbg!(fetch_service_subscriber.data.clone());
     dbg!(fetch_service_subscriber.get_info().await.unwrap());

--- a/integration-tests/tests/fetch_service.rs
+++ b/integration-tests/tests/fetch_service.rs
@@ -12,14 +12,14 @@ use zaino_state::{
     BackendType, FetchService, FetchServiceConfig, FetchServiceSubscriber, LightWalletIndexer,
     StatusType, ZcashIndexer, ZcashService as _,
 };
-use zaino_testutils::Validator as _;
 use zaino_testutils::{TestManager, ValidatorKind};
+use zcash_local_net::validator::Validator;
 use zebra_chain::subtree::NoteCommitmentSubtreeIndex;
 use zebra_rpc::client::ValidateAddressResponse;
 use zebra_rpc::methods::{AddressStrings, GetAddressTxIdsRequest, GetBlock, GetBlockHash};
 use zip32::AccountId;
 
-async fn create_test_manager_and_fetch_service(
+async fn create_test_manager_and_fetch_service<V: Validator>(
     validator: &ValidatorKind,
     chain_cache: Option<std::path::PathBuf>,
     enable_zaino: bool,
@@ -27,7 +27,7 @@ async fn create_test_manager_and_fetch_service(
     zaino_no_db: bool,
     enable_clients: bool,
 ) -> (TestManager, FetchService, FetchServiceSubscriber) {
-    let test_manager = TestManager::launch_with_default_activation_heights(
+    let test_manager = TestManager::launch_with_default_activation_heights::<V>(
         validator,
         &BackendType::Fetch,
         None,
@@ -51,12 +51,7 @@ async fn create_test_manager_and_fetch_service(
         ServiceConfig::default(),
         StorageConfig {
             database: DatabaseConfig {
-                path: test_manager
-                    .local_net
-                    .data_dir()
-                    .path()
-                    .to_path_buf()
-                    .join("zaino"),
+                path: test_manager.data_dir.as_path().to_path_buf().join("zaino"),
                 ..Default::default()
             },
             ..Default::default()
@@ -71,10 +66,20 @@ async fn create_test_manager_and_fetch_service(
     (test_manager, fetch_service, subscriber)
 }
 
-async fn launch_fetch_service(validator: &ValidatorKind, chain_cache: Option<std::path::PathBuf>) {
+async fn launch_fetch_service<V: Validator>(
+    validator: &ValidatorKind,
+    chain_cache: Option<std::path::PathBuf>,
+) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, chain_cache, false, true, true, false)
-            .await;
+        create_test_manager_and_fetch_service::<V>(
+            validator,
+            chain_cache,
+            false,
+            true,
+            true,
+            false,
+        )
+        .await;
     assert_eq!(fetch_service_subscriber.status(), StatusType::Ready);
     dbg!(fetch_service_subscriber.data.clone());
     dbg!(fetch_service_subscriber.get_info().await.unwrap());
@@ -87,9 +92,9 @@ async fn launch_fetch_service(validator: &ValidatorKind, chain_cache: Option<std
     test_manager.close().await;
 }
 
-async fn fetch_service_get_address_balance(validator: &ValidatorKind) {
+async fn fetch_service_get_address_balance<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let mut clients = test_manager
         .clients
@@ -151,9 +156,9 @@ async fn fetch_service_get_address_balance(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_block_raw(validator: &ValidatorKind) {
+async fn fetch_service_get_block_raw<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, false, true, true, false).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, false, true, true, false).await;
 
     dbg!(fetch_service_subscriber
         .z_get_block("1".to_string(), Some(0))
@@ -163,9 +168,9 @@ async fn fetch_service_get_block_raw(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_block_object(validator: &ValidatorKind) {
+async fn fetch_service_get_block_object<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, false, true, true, false).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, false, true, true, false).await;
 
     dbg!(fetch_service_subscriber
         .z_get_block("1".to_string(), Some(1))
@@ -175,9 +180,9 @@ async fn fetch_service_get_block_object(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_raw_mempool(validator: &ValidatorKind) {
+async fn fetch_service_get_raw_mempool<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
     let mut clients = test_manager
         .clients
         .take()
@@ -247,9 +252,9 @@ async fn fetch_service_get_raw_mempool(validator: &ValidatorKind) {
 }
 
 // `getmempoolinfo` computed from local Broadcast state for all validators
-pub async fn test_get_mempool_info(validator: &ValidatorKind) {
+pub async fn test_get_mempool_info<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let mut clients = test_manager
         .clients
@@ -330,9 +335,9 @@ pub async fn test_get_mempool_info(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_z_get_treestate(validator: &ValidatorKind) {
+async fn fetch_service_z_get_treestate<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let mut clients = test_manager
         .clients
@@ -369,9 +374,9 @@ async fn fetch_service_z_get_treestate(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_z_get_subtrees_by_index(validator: &ValidatorKind) {
+async fn fetch_service_z_get_subtrees_by_index<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let mut clients = test_manager
         .clients
@@ -408,9 +413,9 @@ async fn fetch_service_z_get_subtrees_by_index(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_raw_transaction(validator: &ValidatorKind) {
+async fn fetch_service_get_raw_transaction<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let mut clients = test_manager
         .clients
@@ -447,9 +452,9 @@ async fn fetch_service_get_raw_transaction(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_address_tx_ids(validator: &ValidatorKind) {
+async fn fetch_service_get_address_tx_ids<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let mut clients = test_manager
         .clients
@@ -502,9 +507,9 @@ async fn fetch_service_get_address_tx_ids(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_address_utxos(validator: &ValidatorKind) {
+async fn fetch_service_get_address_utxos<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let mut clients = test_manager
         .clients
@@ -547,9 +552,9 @@ async fn fetch_service_get_address_utxos(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_latest_block(validator: &ValidatorKind) {
+async fn fetch_service_get_latest_block<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
     test_manager.local_net.generate_blocks(1).await.unwrap();
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
@@ -587,9 +592,9 @@ async fn fetch_service_get_latest_block(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn assert_fetch_service_difficulty_matches_rpc(validator: &ValidatorKind) {
+async fn assert_fetch_service_difficulty_matches_rpc<V: Validator>(validator: &ValidatorKind) {
     let (test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let fetch_service_get_difficulty = fetch_service_subscriber.get_difficulty().await.unwrap();
 
@@ -612,9 +617,9 @@ async fn assert_fetch_service_difficulty_matches_rpc(validator: &ValidatorKind) 
     assert_eq!(fetch_service_get_difficulty, rpc_difficulty_response.0);
 }
 
-async fn assert_fetch_service_mininginfo_matches_rpc(validator: &ValidatorKind) {
+async fn assert_fetch_service_mininginfo_matches_rpc<V: Validator>(validator: &ValidatorKind) {
     let (test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let fetch_service_mining_info = fetch_service_subscriber.get_mining_info().await.unwrap();
 
@@ -637,9 +642,9 @@ async fn assert_fetch_service_mininginfo_matches_rpc(validator: &ValidatorKind) 
     assert_eq!(fetch_service_mining_info, rpc_mining_info_response);
 }
 
-async fn assert_fetch_service_peerinfo_matches_rpc(validator: &ValidatorKind) {
+async fn assert_fetch_service_peerinfo_matches_rpc<V: Validator>(validator: &ValidatorKind) {
     let (test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let fetch_service_get_peer_info = fetch_service_subscriber.get_peer_info().await.unwrap();
 
@@ -665,9 +670,9 @@ async fn assert_fetch_service_peerinfo_matches_rpc(validator: &ValidatorKind) {
     assert_eq!(fetch_service_get_peer_info, rpc_peer_info_response);
 }
 
-async fn fetch_service_get_block_subsidy(validator: &ValidatorKind) {
+async fn fetch_service_get_block_subsidy<V: Validator>(validator: &ValidatorKind) {
     let (test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     const BLOCK_LIMIT: u32 = 10;
 
@@ -697,9 +702,9 @@ async fn fetch_service_get_block_subsidy(validator: &ValidatorKind) {
     }
 }
 
-async fn fetch_service_get_block(validator: &ValidatorKind) {
+async fn fetch_service_get_block<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let block_id = BlockId {
         height: 1,
@@ -725,9 +730,9 @@ async fn fetch_service_get_block(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_best_blockhash(validator: &ValidatorKind) {
+async fn fetch_service_get_best_blockhash<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     test_manager.local_net.generate_blocks(5).await.unwrap();
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
@@ -754,9 +759,9 @@ async fn fetch_service_get_best_blockhash(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_block_count(validator: &ValidatorKind) {
+async fn fetch_service_get_block_count<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     test_manager.local_net.generate_blocks(5).await.unwrap();
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
@@ -774,9 +779,9 @@ async fn fetch_service_get_block_count(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_validate_address(validator: &ValidatorKind) {
+async fn fetch_service_validate_address<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     // scriptpubkey: "76a914000000000000000000000000000000000000000088ac"
     let expected_validation = ValidateAddressResponse::new(
@@ -811,9 +816,9 @@ async fn fetch_service_validate_address(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_block_nullifiers(validator: &ValidatorKind) {
+async fn fetch_service_get_block_nullifiers<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let block_id = BlockId {
         height: 1,
@@ -830,9 +835,9 @@ async fn fetch_service_get_block_nullifiers(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_block_range(validator: &ValidatorKind) {
+async fn fetch_service_get_block_range<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
     test_manager.local_net.generate_blocks(10).await.unwrap();
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
@@ -863,9 +868,9 @@ async fn fetch_service_get_block_range(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_block_range_nullifiers(validator: &ValidatorKind) {
+async fn fetch_service_get_block_range_nullifiers<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
     test_manager.local_net.generate_blocks(10).await.unwrap();
     tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
 
@@ -896,9 +901,9 @@ async fn fetch_service_get_block_range_nullifiers(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_transaction_mined(validator: &ValidatorKind) {
+async fn fetch_service_get_transaction_mined<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let mut clients = test_manager
         .clients
@@ -942,9 +947,9 @@ async fn fetch_service_get_transaction_mined(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_transaction_mempool(validator: &ValidatorKind) {
+async fn fetch_service_get_transaction_mempool<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let mut clients = test_manager
         .clients
@@ -988,9 +993,9 @@ async fn fetch_service_get_transaction_mempool(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_taddress_txids(validator: &ValidatorKind) {
+async fn fetch_service_get_taddress_txids<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let mut clients = test_manager
         .clients
@@ -1058,9 +1063,9 @@ async fn fetch_service_get_taddress_txids(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_taddress_balance(validator: &ValidatorKind) {
+async fn fetch_service_get_taddress_balance<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let mut clients = test_manager
         .clients
@@ -1113,9 +1118,9 @@ async fn fetch_service_get_taddress_balance(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_mempool_tx(validator: &ValidatorKind) {
+async fn fetch_service_get_mempool_tx<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let mut clients = test_manager
         .clients
@@ -1206,9 +1211,9 @@ async fn fetch_service_get_mempool_tx(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_mempool_stream(validator: &ValidatorKind) {
+async fn fetch_service_get_mempool_stream<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let mut clients = test_manager
         .clients
@@ -1272,9 +1277,9 @@ async fn fetch_service_get_mempool_stream(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_tree_state(validator: &ValidatorKind) {
+async fn fetch_service_get_tree_state<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let block_id = BlockId {
         height: 1,
@@ -1291,9 +1296,9 @@ async fn fetch_service_get_tree_state(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_latest_tree_state(validator: &ValidatorKind) {
+async fn fetch_service_get_latest_tree_state<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     dbg!(fetch_service_subscriber
         .get_latest_tree_state()
@@ -1303,9 +1308,9 @@ async fn fetch_service_get_latest_tree_state(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_subtree_roots(validator: &ValidatorKind) {
+async fn fetch_service_get_subtree_roots<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let subtree_roots_arg = GetSubtreeRootsArg {
         start_index: 0,
@@ -1329,9 +1334,9 @@ async fn fetch_service_get_subtree_roots(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_taddress_utxos(validator: &ValidatorKind) {
+async fn fetch_service_get_taddress_utxos<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let mut clients = test_manager
         .clients
@@ -1376,9 +1381,9 @@ async fn fetch_service_get_taddress_utxos(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_taddress_utxos_stream(validator: &ValidatorKind) {
+async fn fetch_service_get_taddress_utxos_stream<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let mut clients = test_manager
         .clients
@@ -1428,18 +1433,18 @@ async fn fetch_service_get_taddress_utxos_stream(validator: &ValidatorKind) {
     test_manager.close().await;
 }
 
-async fn fetch_service_get_lightd_info(validator: &ValidatorKind) {
+async fn fetch_service_get_lightd_info<V: Validator>(validator: &ValidatorKind) {
     let (mut test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     dbg!(fetch_service_subscriber.get_lightd_info().await.unwrap());
 
     test_manager.close().await;
 }
 
-async fn assert_fetch_service_getnetworksols_matches_rpc(validator: &ValidatorKind) {
+async fn assert_fetch_service_getnetworksols_matches_rpc<V: Validator>(validator: &ValidatorKind) {
     let (test_manager, _fetch_service, fetch_service_subscriber) =
-        create_test_manager_and_fetch_service(validator, None, true, true, true, true).await;
+        create_test_manager_and_fetch_service::<V>(validator, None, true, true, true, true).await;
 
     let fetch_service_get_networksolps = fetch_service_subscriber
         .get_network_sol_ps(None, None)
@@ -1468,6 +1473,7 @@ async fn assert_fetch_service_getnetworksols_matches_rpc(validator: &ValidatorKi
 mod zcashd {
 
     use super::*;
+    use zcash_local_net::validator::Zcashd;
 
     mod launch {
 
@@ -1475,13 +1481,13 @@ mod zcashd {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn regtest_no_cache() {
-            launch_fetch_service(&ValidatorKind::Zcashd, None).await;
+            launch_fetch_service::<Zcashd>(&ValidatorKind::Zcashd, None).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         #[ignore = "We no longer use chain caches. See zcashd::launch::regtest_no_cache."]
         pub(crate) async fn regtest_with_cache() {
-            launch_fetch_service(
+            launch_fetch_service::<Zcashd>(
                 &ValidatorKind::Zcashd,
                 zaino_testutils::ZCASHD_CHAIN_CACHE_DIR.clone(),
             )
@@ -1495,7 +1501,7 @@ mod zcashd {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn validate_address() {
-            fetch_service_validate_address(&ValidatorKind::Zcashd).await;
+            fetch_service_validate_address::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
     }
 
@@ -1505,27 +1511,27 @@ mod zcashd {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn address_balance() {
-            fetch_service_get_address_balance(&ValidatorKind::Zcashd).await;
+            fetch_service_get_address_balance::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_raw() {
-            fetch_service_get_block_raw(&ValidatorKind::Zcashd).await;
+            fetch_service_get_block_raw::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_object() {
-            fetch_service_get_block_object(&ValidatorKind::Zcashd).await;
+            fetch_service_get_block_object::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn raw_mempool() {
-            fetch_service_get_raw_mempool(&ValidatorKind::Zcashd).await;
+            fetch_service_get_raw_mempool::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn mempool_info() {
-            test_get_mempool_info(&ValidatorKind::Zcashd).await;
+            test_get_mempool_info::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         mod z {
@@ -1534,148 +1540,148 @@ mod zcashd {
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn get_treestate() {
-                fetch_service_z_get_treestate(&ValidatorKind::Zcashd).await;
+                fetch_service_z_get_treestate::<Zcashd>(&ValidatorKind::Zcashd).await;
             }
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn subtrees_by_index() {
-                fetch_service_z_get_subtrees_by_index(&ValidatorKind::Zcashd).await;
+                fetch_service_z_get_subtrees_by_index::<Zcashd>(&ValidatorKind::Zcashd).await;
             }
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn raw_transaction() {
-            fetch_service_get_raw_transaction(&ValidatorKind::Zcashd).await;
+            fetch_service_get_raw_transaction::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn address_tx_ids() {
-            fetch_service_get_address_tx_ids(&ValidatorKind::Zcashd).await;
+            fetch_service_get_address_tx_ids::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn address_utxos() {
-            fetch_service_get_address_utxos(&ValidatorKind::Zcashd).await;
+            fetch_service_get_address_utxos::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn latest_block() {
-            fetch_service_get_latest_block(&ValidatorKind::Zcashd).await;
+            fetch_service_get_latest_block::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block() {
-            fetch_service_get_block(&ValidatorKind::Zcashd).await;
+            fetch_service_get_block::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn difficulty() {
-            assert_fetch_service_difficulty_matches_rpc(&ValidatorKind::Zcashd).await;
+            assert_fetch_service_difficulty_matches_rpc::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn mining_info() {
-            assert_fetch_service_mininginfo_matches_rpc(&ValidatorKind::Zcashd).await;
+            assert_fetch_service_mininginfo_matches_rpc::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn peer_info() {
-            assert_fetch_service_peerinfo_matches_rpc(&ValidatorKind::Zcashd).await;
+            assert_fetch_service_peerinfo_matches_rpc::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_subsidy() {
-            fetch_service_get_block_subsidy(&ValidatorKind::Zcashd).await;
+            fetch_service_get_block_subsidy::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn best_blockhash() {
-            fetch_service_get_best_blockhash(&ValidatorKind::Zcashd).await;
+            fetch_service_get_best_blockhash::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_count() {
-            fetch_service_get_block_count(&ValidatorKind::Zcashd).await;
+            fetch_service_get_block_count::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_nullifiers() {
-            fetch_service_get_block_nullifiers(&ValidatorKind::Zcashd).await;
+            fetch_service_get_block_nullifiers::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_range() {
-            fetch_service_get_block_range(&ValidatorKind::Zcashd).await;
+            fetch_service_get_block_range::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_range_nullifiers() {
-            fetch_service_get_block_range_nullifiers(&ValidatorKind::Zcashd).await;
+            fetch_service_get_block_range_nullifiers::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn transaction_mined() {
-            fetch_service_get_transaction_mined(&ValidatorKind::Zcashd).await;
+            fetch_service_get_transaction_mined::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn transaction_mempool() {
-            fetch_service_get_transaction_mempool(&ValidatorKind::Zcashd).await;
+            fetch_service_get_transaction_mempool::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn taddress_txids() {
-            fetch_service_get_taddress_txids(&ValidatorKind::Zcashd).await;
+            fetch_service_get_taddress_txids::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn taddress_balance() {
-            fetch_service_get_taddress_balance(&ValidatorKind::Zcashd).await;
+            fetch_service_get_taddress_balance::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn mempool_tx() {
-            fetch_service_get_mempool_tx(&ValidatorKind::Zcashd).await;
+            fetch_service_get_mempool_tx::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn mempool_stream() {
-            fetch_service_get_mempool_stream(&ValidatorKind::Zcashd).await;
+            fetch_service_get_mempool_stream::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn tree_state() {
-            fetch_service_get_tree_state(&ValidatorKind::Zcashd).await;
+            fetch_service_get_tree_state::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn latest_tree_state() {
-            fetch_service_get_latest_tree_state(&ValidatorKind::Zcashd).await;
+            fetch_service_get_latest_tree_state::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn subtree_roots() {
-            fetch_service_get_subtree_roots(&ValidatorKind::Zcashd).await;
+            fetch_service_get_subtree_roots::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn taddress_utxos() {
-            fetch_service_get_taddress_utxos(&ValidatorKind::Zcashd).await;
+            fetch_service_get_taddress_utxos::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn taddress_utxos_stream() {
-            fetch_service_get_taddress_utxos_stream(&ValidatorKind::Zcashd).await;
+            fetch_service_get_taddress_utxos_stream::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn lightd_info() {
-            fetch_service_get_lightd_info(&ValidatorKind::Zcashd).await;
+            fetch_service_get_lightd_info::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
 
         #[tokio::test]
         pub(crate) async fn get_network_sol_ps() {
-            assert_fetch_service_getnetworksols_matches_rpc(&ValidatorKind::Zcashd).await;
+            assert_fetch_service_getnetworksols_matches_rpc::<Zcashd>(&ValidatorKind::Zcashd).await;
         }
     }
 }
@@ -1683,6 +1689,7 @@ mod zcashd {
 mod zebrad {
 
     use super::*;
+    use zcash_local_net::validator::Zebrad;
 
     mod launch {
 
@@ -1690,13 +1697,13 @@ mod zebrad {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn regtest_no_cache() {
-            launch_fetch_service(&ValidatorKind::Zebrad, None).await;
+            launch_fetch_service::<Zebrad>(&ValidatorKind::Zebrad, None).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         #[ignore = "We no longer use chain caches. See zebrad::launch::regtest_no_cache."]
         pub(crate) async fn regtest_with_cache() {
-            launch_fetch_service(
+            launch_fetch_service::<Zebrad>(
                 &ValidatorKind::Zebrad,
                 zaino_testutils::ZEBRAD_CHAIN_CACHE_DIR.clone(),
             )
@@ -1710,7 +1717,7 @@ mod zebrad {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn validate_address() {
-            fetch_service_validate_address(&ValidatorKind::Zebrad).await;
+            fetch_service_validate_address::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
     }
 
@@ -1720,27 +1727,27 @@ mod zebrad {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn address_balance() {
-            fetch_service_get_address_balance(&ValidatorKind::Zebrad).await;
+            fetch_service_get_address_balance::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_raw() {
-            fetch_service_get_block_raw(&ValidatorKind::Zebrad).await;
+            fetch_service_get_block_raw::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_object() {
-            fetch_service_get_block_object(&ValidatorKind::Zebrad).await;
+            fetch_service_get_block_object::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn raw_mempool() {
-            fetch_service_get_raw_mempool(&ValidatorKind::Zebrad).await;
+            fetch_service_get_raw_mempool::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn mempool_info() {
-            test_get_mempool_info(&ValidatorKind::Zebrad).await;
+            test_get_mempool_info::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         mod z {
@@ -1749,148 +1756,149 @@ mod zebrad {
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn treestate() {
-                fetch_service_z_get_treestate(&ValidatorKind::Zebrad).await;
+                fetch_service_z_get_treestate::<Zebrad>(&ValidatorKind::Zebrad).await;
             }
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn subtrees_by_index() {
-                fetch_service_z_get_subtrees_by_index(&ValidatorKind::Zebrad).await;
+                fetch_service_z_get_subtrees_by_index::<Zebrad>(&ValidatorKind::Zebrad).await;
             }
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn raw_transaction() {
-            fetch_service_get_raw_transaction(&ValidatorKind::Zebrad).await;
+            fetch_service_get_raw_transaction::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn address_tx_ids() {
-            fetch_service_get_address_tx_ids(&ValidatorKind::Zebrad).await;
+            fetch_service_get_address_tx_ids::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn address_utxos() {
-            fetch_service_get_address_utxos(&ValidatorKind::Zebrad).await;
+            fetch_service_get_address_utxos::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn latest_block() {
-            fetch_service_get_latest_block(&ValidatorKind::Zebrad).await;
+            fetch_service_get_latest_block::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block() {
-            fetch_service_get_block(&ValidatorKind::Zebrad).await;
+            fetch_service_get_block::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn difficulty() {
-            assert_fetch_service_difficulty_matches_rpc(&ValidatorKind::Zebrad).await;
+            assert_fetch_service_difficulty_matches_rpc::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn mining_info() {
-            assert_fetch_service_mininginfo_matches_rpc(&ValidatorKind::Zebrad).await;
+            assert_fetch_service_mininginfo_matches_rpc::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn peer_info() {
-            assert_fetch_service_peerinfo_matches_rpc(&ValidatorKind::Zebrad).await;
+            assert_fetch_service_peerinfo_matches_rpc::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+        #[ignore = "Zebra does not support block subsidies before first halving (block 287 in regtest). See state_service::zebrad::get::block_subsidy_fails_before_first_halving for expected error test."]
         pub(crate) async fn block_subsidy() {
-            fetch_service_get_block_subsidy(&ValidatorKind::Zcashd).await;
+            fetch_service_get_block_subsidy::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn best_blockhash() {
-            fetch_service_get_best_blockhash(&ValidatorKind::Zebrad).await;
+            fetch_service_get_best_blockhash::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_count() {
-            fetch_service_get_block_count(&ValidatorKind::Zebrad).await;
+            fetch_service_get_block_count::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_nullifiers() {
-            fetch_service_get_block_nullifiers(&ValidatorKind::Zebrad).await;
+            fetch_service_get_block_nullifiers::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_range() {
-            fetch_service_get_block_range(&ValidatorKind::Zebrad).await;
+            fetch_service_get_block_range::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn block_range_nullifiers() {
-            fetch_service_get_block_range_nullifiers(&ValidatorKind::Zebrad).await;
+            fetch_service_get_block_range_nullifiers::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn transaction_mined() {
-            fetch_service_get_transaction_mined(&ValidatorKind::Zebrad).await;
+            fetch_service_get_transaction_mined::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn transaction_mempool() {
-            fetch_service_get_transaction_mempool(&ValidatorKind::Zebrad).await;
+            fetch_service_get_transaction_mempool::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn taddress_txids() {
-            fetch_service_get_taddress_txids(&ValidatorKind::Zebrad).await;
+            fetch_service_get_taddress_txids::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn taddress_balance() {
-            fetch_service_get_taddress_balance(&ValidatorKind::Zebrad).await;
+            fetch_service_get_taddress_balance::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn mempool_tx() {
-            fetch_service_get_mempool_tx(&ValidatorKind::Zebrad).await;
+            fetch_service_get_mempool_tx::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn mempool_stream() {
-            fetch_service_get_mempool_stream(&ValidatorKind::Zebrad).await;
+            fetch_service_get_mempool_stream::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn tree_state() {
-            fetch_service_get_tree_state(&ValidatorKind::Zebrad).await;
+            fetch_service_get_tree_state::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn latest_tree_state() {
-            fetch_service_get_latest_tree_state(&ValidatorKind::Zebrad).await;
+            fetch_service_get_latest_tree_state::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn subtree_roots() {
-            fetch_service_get_subtree_roots(&ValidatorKind::Zebrad).await;
+            fetch_service_get_subtree_roots::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn taddress_utxos() {
-            fetch_service_get_taddress_utxos(&ValidatorKind::Zebrad).await;
+            fetch_service_get_taddress_utxos::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn taddress_utxos_stream() {
-            fetch_service_get_taddress_utxos_stream(&ValidatorKind::Zebrad).await;
+            fetch_service_get_taddress_utxos_stream::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn lightd_info() {
-            fetch_service_get_lightd_info(&ValidatorKind::Zebrad).await;
+            fetch_service_get_lightd_info::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
 
         #[tokio::test]
         pub(crate) async fn get_network_sol_ps() {
-            assert_fetch_service_getnetworksols_matches_rpc(&ValidatorKind::Zebrad).await;
+            assert_fetch_service_getnetworksols_matches_rpc::<Zebrad>(&ValidatorKind::Zebrad).await;
         }
     }
 }

--- a/integration-tests/tests/json_server.rs
+++ b/integration-tests/tests/json_server.rs
@@ -6,24 +6,26 @@ use zaino_state::{
     BackendType, FetchService, FetchServiceConfig, FetchServiceSubscriber, ZcashIndexer,
     ZcashService as _,
 };
-use zaino_testutils::{from_inputs, Validator as _};
+use zaino_testutils::from_inputs;
 use zaino_testutils::{TestManager, ValidatorKind};
-use zcash_local_net::validator::Zcashd;
+use zcash_local_net::logs::LogsToStdoutAndStderr as _;
+use zcash_local_net::validator::zcashd::Zcashd;
+use zcash_local_net::validator::Validator as _;
 use zebra_chain::subtree::NoteCommitmentSubtreeIndex;
 use zebra_rpc::methods::{AddressStrings, GetAddressTxIdsRequest, GetInfo};
 
-async fn create_test_manager_and_fetch_services(
+async fn create_zcashd_test_manager_and_fetch_services(
     enable_cookie_auth: bool,
     clients: bool,
 ) -> (
-    TestManager,
+    TestManager<Zcashd>,
     FetchService,
     FetchServiceSubscriber,
     FetchService,
     FetchServiceSubscriber,
 ) {
     println!("Launching test manager..");
-    let test_manager = TestManager::launch_with_default_activation_heights::<Zcashd>(
+    let test_manager = TestManager::<Zcashd>::launch_with_default_activation_heights(
         &ValidatorKind::Zcashd,
         &BackendType::Fetch,
         None,
@@ -116,7 +118,7 @@ async fn create_test_manager_and_fetch_services(
 
 async fn launch_json_server_check_info(enable_cookie_auth: bool) {
     let (mut test_manager, _zcashd_service, zcashd_subscriber, _zaino_service, zaino_subscriber) =
-        create_test_manager_and_fetch_services(enable_cookie_auth, false).await;
+        create_zcashd_test_manager_and_fetch_services(enable_cookie_auth, false).await;
 
     let zcashd_info = dbg!(zcashd_subscriber.get_info().await.unwrap());
     let zcashd_blockchain_info = dbg!(zcashd_subscriber.get_blockchain_info().await.unwrap());
@@ -222,7 +224,7 @@ async fn launch_json_server_check_info(enable_cookie_auth: bool) {
 
 async fn get_best_blockhash_inner() {
     let (mut test_manager, _zcashd_service, zcashd_subscriber, _zaino_service, zaino_subscriber) =
-        create_test_manager_and_fetch_services(false, false).await;
+        create_zcashd_test_manager_and_fetch_services(false, false).await;
 
     let zcashd_bbh = dbg!(zcashd_subscriber.get_best_blockhash().await.unwrap());
     let zaino_bbh = dbg!(zaino_subscriber.get_best_blockhash().await.unwrap());
@@ -234,7 +236,7 @@ async fn get_best_blockhash_inner() {
 
 async fn get_block_count_inner() {
     let (mut test_manager, _zcashd_service, zcashd_subscriber, _zaino_service, zaino_subscriber) =
-        create_test_manager_and_fetch_services(false, false).await;
+        create_zcashd_test_manager_and_fetch_services(false, false).await;
 
     let zcashd_block_count = dbg!(zcashd_subscriber.get_block_count().await.unwrap());
     let zaino_block_count = dbg!(zaino_subscriber.get_block_count().await.unwrap());
@@ -246,7 +248,7 @@ async fn get_block_count_inner() {
 
 async fn validate_address_inner() {
     let (mut test_manager, _zcashd_service, zcashd_subscriber, _zaino_service, zaino_subscriber) =
-        create_test_manager_and_fetch_services(false, false).await;
+        create_zcashd_test_manager_and_fetch_services(false, false).await;
 
     // Using a testnet transparent address
     let address_string = "tmHMBeeYRuc2eVicLNfP15YLxbQsooCA6jb";
@@ -285,7 +287,7 @@ async fn validate_address_inner() {
 
 async fn z_get_address_balance_inner() {
     let (mut test_manager, _zcashd_service, zcashd_subscriber, _zaino_service, zaino_subscriber) =
-        create_test_manager_and_fetch_services(false, true).await;
+        create_zcashd_test_manager_and_fetch_services(false, true).await;
 
     let mut clients = test_manager
         .clients
@@ -346,7 +348,7 @@ async fn z_get_address_balance_inner() {
 
 async fn z_get_block_inner() {
     let (mut test_manager, _zcashd_service, zcashd_subscriber, _zaino_service, zaino_subscriber) =
-        create_test_manager_and_fetch_services(false, false).await;
+        create_zcashd_test_manager_and_fetch_services(false, false).await;
 
     let zcashd_block_raw = dbg!(zcashd_subscriber
         .z_get_block("1".to_string(), Some(0))
@@ -387,7 +389,7 @@ async fn z_get_block_inner() {
 
 async fn get_raw_mempool_inner() {
     let (mut test_manager, _zcashd_service, zcashd_subscriber, _zaino_service, zaino_subscriber) =
-        create_test_manager_and_fetch_services(false, true).await;
+        create_zcashd_test_manager_and_fetch_services(false, true).await;
 
     let mut clients = test_manager
         .clients
@@ -426,7 +428,7 @@ async fn get_raw_mempool_inner() {
 
 async fn get_mempool_info_inner() {
     let (mut test_manager, _zcashd_service, zcashd_subscriber, _zaino_service, zaino_subscriber) =
-        create_test_manager_and_fetch_services(false, true).await;
+        create_zcashd_test_manager_and_fetch_services(false, true).await;
 
     let mut clients = test_manager
         .clients
@@ -462,7 +464,7 @@ async fn get_mempool_info_inner() {
 
 async fn z_get_treestate_inner() {
     let (mut test_manager, _zcashd_service, zcashd_subscriber, _zaino_service, zaino_subscriber) =
-        create_test_manager_and_fetch_services(false, true).await;
+        create_zcashd_test_manager_and_fetch_services(false, true).await;
 
     let mut clients = test_manager
         .clients
@@ -496,7 +498,7 @@ async fn z_get_treestate_inner() {
 
 async fn z_get_subtrees_by_index_inner() {
     let (mut test_manager, _zcashd_service, zcashd_subscriber, _zaino_service, zaino_subscriber) =
-        create_test_manager_and_fetch_services(false, true).await;
+        create_zcashd_test_manager_and_fetch_services(false, true).await;
 
     let mut clients = test_manager
         .clients
@@ -530,7 +532,7 @@ async fn z_get_subtrees_by_index_inner() {
 
 async fn get_raw_transaction_inner() {
     let (mut test_manager, _zcashd_service, zcashd_subscriber, _zaino_service, zaino_subscriber) =
-        create_test_manager_and_fetch_services(false, true).await;
+        create_zcashd_test_manager_and_fetch_services(false, true).await;
 
     let mut clients = test_manager
         .clients
@@ -566,7 +568,7 @@ async fn get_raw_transaction_inner() {
 
 async fn get_address_tx_ids_inner() {
     let (mut test_manager, _zcashd_service, zcashd_subscriber, _zaino_service, zaino_subscriber) =
-        create_test_manager_and_fetch_services(false, true).await;
+        create_zcashd_test_manager_and_fetch_services(false, true).await;
 
     let mut clients = test_manager
         .clients
@@ -623,7 +625,7 @@ async fn get_address_tx_ids_inner() {
 
 async fn z_get_address_utxos_inner() {
     let (mut test_manager, _zcashd_service, zcashd_subscriber, _zaino_service, zaino_subscriber) =
-        create_test_manager_and_fetch_services(false, true).await;
+        create_zcashd_test_manager_and_fetch_services(false, true).await;
 
     let mut clients = test_manager
         .clients
@@ -711,7 +713,7 @@ mod zcashd {
                 zcashd_subscriber,
                 _zaino_service,
                 zaino_subscriber,
-            ) = create_test_manager_and_fetch_services(false, false).await;
+            ) = create_zcashd_test_manager_and_fetch_services(false, false).await;
 
             const BLOCK_LIMIT: i32 = 10;
 
@@ -735,7 +737,7 @@ mod zcashd {
                 zcashd_subscriber,
                 _zaino_service,
                 zaino_subscriber,
-            ) = create_test_manager_and_fetch_services(false, false).await;
+            ) = create_zcashd_test_manager_and_fetch_services(false, false).await;
 
             const BLOCK_LIMIT: i32 = 10;
 
@@ -759,7 +761,7 @@ mod zcashd {
                 zcashd_subscriber,
                 _zaino_service,
                 zaino_subscriber,
-            ) = create_test_manager_and_fetch_services(false, false).await;
+            ) = create_zcashd_test_manager_and_fetch_services(false, false).await;
 
             let zcashd_peer_info = zcashd_subscriber.get_peer_info().await.unwrap();
             let zaino_peer_info = zaino_subscriber.get_peer_info().await.unwrap();
@@ -779,7 +781,7 @@ mod zcashd {
                 zcashd_subscriber,
                 _zaino_service,
                 zaino_subscriber,
-            ) = create_test_manager_and_fetch_services(false, false).await;
+            ) = create_zcashd_test_manager_and_fetch_services(false, false).await;
 
             test_manager.local_net.generate_blocks(1).await.unwrap();
 

--- a/integration-tests/tests/json_server.rs
+++ b/integration-tests/tests/json_server.rs
@@ -8,6 +8,7 @@ use zaino_state::{
 };
 use zaino_testutils::{from_inputs, Validator as _};
 use zaino_testutils::{TestManager, ValidatorKind};
+use zcash_local_net::validator::Zcashd;
 use zebra_chain::subtree::NoteCommitmentSubtreeIndex;
 use zebra_rpc::methods::{AddressStrings, GetAddressTxIdsRequest, GetInfo};
 
@@ -22,7 +23,7 @@ async fn create_test_manager_and_fetch_services(
     FetchServiceSubscriber,
 ) {
     println!("Launching test manager..");
-    let test_manager = TestManager::launch_with_default_activation_heights(
+    let test_manager = TestManager::launch_with_default_activation_heights::<Zcashd>(
         &ValidatorKind::Zcashd,
         &BackendType::Fetch,
         None,

--- a/integration-tests/tests/local_cache.rs
+++ b/integration-tests/tests/local_cache.rs
@@ -17,7 +17,7 @@ async fn create_test_manager_and_block_cache<V: Validator>(
     zaino_no_db: bool,
     enable_clients: bool,
 ) -> (
-    TestManager,
+    TestManager<V>,
     JsonRpSeeConnector,
     BlockCache,
     BlockCacheSubscriber,
@@ -27,7 +27,7 @@ async fn create_test_manager_and_block_cache<V: Validator>(
         ValidatorKind::Zcashd => ActivationHeights::default(),
     };
 
-    let test_manager = TestManager::launch::<V>(
+    let test_manager = TestManager::<V>::launch(
         validator,
         &BackendType::Fetch,
         None,
@@ -168,7 +168,7 @@ async fn launch_local_cache_process_n_block_batches<V: Validator>(
 
 mod zcashd {
     use zaino_testutils::ValidatorKind;
-    use zcash_local_net::validator::Zcashd;
+    use zcash_local_net::validator::zcashd::Zcashd;
 
     use crate::{launch_local_cache, launch_local_cache_process_n_block_batches};
 
@@ -195,7 +195,7 @@ mod zcashd {
 
 mod zebrad {
     use zaino_testutils::ValidatorKind;
-    use zcash_local_net::validator::Zebrad;
+    use zcash_local_net::validator::zebrad::Zebrad;
 
     use crate::{launch_local_cache, launch_local_cache_process_n_block_batches};
 

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -7,7 +7,7 @@ use zaino_state::{
 };
 use zaino_testutils::from_inputs;
 use zaino_testutils::{TestManager, ValidatorKind, ZEBRAD_TESTNET_CACHE_DIR};
-use zcash_local_net::validator::{Validator, Zebrad};
+use zcash_local_net::validator::{zebrad::Zebrad, Validator};
 use zebra_chain::parameters::NetworkKind;
 use zebra_chain::subtree::NoteCommitmentSubtreeIndex;
 use zebra_rpc::methods::{AddressStrings, GetAddressTxIdsRequest, GetInfo};
@@ -20,13 +20,13 @@ async fn create_test_manager_and_services<V: Validator>(
     enable_clients: bool,
     network: Option<NetworkKind>,
 ) -> (
-    TestManager,
+    TestManager<V>,
     FetchService,
     FetchServiceSubscriber,
     StateService,
     StateServiceSubscriber,
 ) {
-    let test_manager = TestManager::launch_with_default_activation_heights::<V>(
+    let test_manager = TestManager::<V>::launch_with_default_activation_heights(
         validator,
         &BackendType::Fetch,
         network,

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -1086,7 +1086,7 @@ mod zebrad {
             .await;
             let mut chaintip_subscriber = state_service_subscriber.chaintip_update_subscriber();
             for _ in 0..5 {
-                test_manager.local_net.generate_blocks_with_delay(1).await;
+                let _ = test_manager.local_net.generate_blocks_with_delay(1).await;
                 assert_eq!(
                     chaintip_subscriber.next_tip_hash().await.unwrap().0,
                     <[u8; 32]>::try_from(

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -749,7 +749,10 @@ async fn state_service_z_get_subtrees_by_index_testnet() {
     test_manager.close().await;
 }
 
-async fn state_service_get_raw_transaction<V: Validator>(validator: &ValidatorKind) {
+use zcash_local_net::logs::LogsToStdoutAndStderr;
+async fn state_service_get_raw_transaction<V: Validator + LogsToStdoutAndStderr>(
+    validator: &ValidatorKind,
+) {
     let (
         mut test_manager,
         _fetch_service,
@@ -1057,7 +1060,7 @@ mod zebrad {
 
         use super::*;
         use zaino_testutils::ZEBRAD_CHAIN_CACHE_DIR;
-        use zcash_local_net::validator::Zebrad;
+        use zcash_local_net::validator::zebrad::Zebrad;
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn regtest_no_cache() {
@@ -1083,7 +1086,7 @@ mod zebrad {
             .await;
             let mut chaintip_subscriber = state_service_subscriber.chaintip_update_subscriber();
             for _ in 0..5 {
-                test_manager.generate_blocks_with_delay(1).await;
+                test_manager.local_net.generate_blocks_with_delay(1).await;
                 assert_eq!(
                     chaintip_subscriber.next_tip_hash().await.unwrap().0,
                     <[u8; 32]>::try_from(
@@ -1123,7 +1126,7 @@ mod zebrad {
 
     pub(crate) mod get {
 
-        use zcash_local_net::validator::Zebrad;
+        use zcash_local_net::validator::zebrad::Zebrad;
 
         use super::*;
 
@@ -1395,7 +1398,7 @@ mod zebrad {
         }
 
         mod z {
-            use zcash_local_net::validator::Zebrad;
+            use zcash_local_net::validator::zebrad::Zebrad;
 
             use super::*;
 

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -58,7 +58,7 @@ async fn create_test_manager_and_services<V: Validator>(
         ),
     };
 
-    test_manager.local_net.print_stdout();
+    // TODO: implement trait test_manager.local_net.print_stdout();
 
     let fetch_service = FetchService::spawn(FetchServiceConfig::new(
         test_manager.zebrad_rpc_listen_address,

--- a/integration-tests/tests/test_vectors.rs
+++ b/integration-tests/tests/test_vectors.rs
@@ -28,8 +28,9 @@ use zaino_state::{
 use zaino_testutils::from_inputs;
 use zaino_testutils::test_vectors::transactions::get_test_vectors;
 use zaino_testutils::{TestManager, ValidatorKind};
+use zcash_local_net::logs::LogsToStdoutAndStderr;
+use zcash_local_net::validator::zebrad::Zebrad;
 use zcash_local_net::validator::Validator;
-use zcash_local_net::validator::Zebrad;
 use zebra_chain::parameters::NetworkKind;
 use zebra_chain::serialization::{ZcashDeserialize, ZcashSerialize};
 use zebra_rpc::methods::GetAddressUtxos;
@@ -48,14 +49,14 @@ macro_rules! expected_read_response {
     };
 }
 
-async fn create_test_manager_and_services<V: Validator>(
+async fn create_test_manager_and_services<V: Validator + LogsToStdoutAndStderr>(
     validator: &ValidatorKind,
     chain_cache: Option<std::path::PathBuf>,
     enable_zaino: bool,
     enable_clients: bool,
     network: Option<NetworkKind>,
-) -> (TestManager, StateService, StateServiceSubscriber) {
-    let test_manager = TestManager::launch_with_default_activation_heights::<V>(
+) -> (TestManager<V>, StateService, StateServiceSubscriber) {
+    let test_manager = TestManager::<V>::launch_with_default_activation_heights(
         validator,
         &BackendType::Fetch,
         network,

--- a/integration-tests/tests/test_vectors.rs
+++ b/integration-tests/tests/test_vectors.rs
@@ -27,8 +27,9 @@ use zaino_state::{
 };
 use zaino_testutils::from_inputs;
 use zaino_testutils::test_vectors::transactions::get_test_vectors;
-use zaino_testutils::Validator as _;
 use zaino_testutils::{TestManager, ValidatorKind};
+use zcash_local_net::validator::Validator;
+use zcash_local_net::validator::Zebrad;
 use zebra_chain::parameters::NetworkKind;
 use zebra_chain::serialization::{ZcashDeserialize, ZcashSerialize};
 use zebra_rpc::methods::GetAddressUtxos;
@@ -47,14 +48,14 @@ macro_rules! expected_read_response {
     };
 }
 
-async fn create_test_manager_and_services(
+async fn create_test_manager_and_services<V: Validator>(
     validator: &ValidatorKind,
     chain_cache: Option<std::path::PathBuf>,
     enable_zaino: bool,
     enable_clients: bool,
     network: Option<NetworkKind>,
 ) -> (TestManager, StateService, StateServiceSubscriber) {
-    let test_manager = TestManager::launch_with_default_activation_heights(
+    let test_manager = TestManager::launch_with_default_activation_heights::<V>(
         validator,
         &BackendType::Fetch,
         network,
@@ -138,7 +139,8 @@ async fn create_test_manager_and_services(
 #[ignore = "Not a test! Used to build test vector data for zaino_state::chain_index unit tests."]
 async fn create_200_block_regtest_chain_vectors() {
     let (mut test_manager, _state_service, state_service_subscriber) =
-        create_test_manager_and_services(&ValidatorKind::Zebrad, None, true, true, None).await;
+        create_test_manager_and_services::<Zebrad>(&ValidatorKind::Zebrad, None, true, true, None)
+            .await;
 
     let mut clients = test_manager
         .clients

--- a/integration-tests/tests/wallet_to_validator.rs
+++ b/integration-tests/tests/wallet_to_validator.rs
@@ -154,10 +154,10 @@ async fn send_to_transparent<V: Validator>(validator: &ValidatorKind, backend: &
     clients.faucet.sync_and_await().await.unwrap();
 
     if matches!(validator, ValidatorKind::Zebrad) {
-        test_manager.local_net.generate_blocks_with_delay(100).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(100).await;
         clients.faucet.sync_and_await().await.unwrap();
         clients.faucet.quick_shield(AccountId::ZERO).await.unwrap();
-        test_manager.local_net.generate_blocks_with_delay(1).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(1).await;
         clients.faucet.sync_and_await().await.unwrap();
     };
 
@@ -166,7 +166,7 @@ async fn send_to_transparent<V: Validator>(validator: &ValidatorKind, backend: &
         .await
         .unwrap();
 
-    test_manager.local_net.generate_blocks_with_delay(1).await;
+    let _ = test_manager.local_net.generate_blocks_with_delay(1).await;
 
     let fetch_service = zaino_fetch::jsonrpsee::connector::JsonRpSeeConnector::new_with_basic_auth(
         test_node_and_return_url(
@@ -206,7 +206,7 @@ async fn send_to_transparent<V: Validator>(validator: &ValidatorKind, backend: &
     //       for this reason we generate blocks 1 at a time and sleep to let other tasks run.
     for height in 1..=99 {
         dbg!("Generating block at height: {}", height);
-        test_manager.local_net.generate_blocks_with_delay(1).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(1).await;
     }
 
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -255,21 +255,21 @@ async fn send_to_all<V: Validator>(validator: &ValidatorKind, backend: &BackendT
         .take()
         .expect("Clients are not initialized");
 
-    test_manager.local_net.generate_blocks_with_delay(2).await;
+    let _ = test_manager.local_net.generate_blocks_with_delay(2).await;
     clients.faucet.sync_and_await().await.unwrap();
 
     // "Create" 3 orchard notes in faucet.
     if matches!(validator, ValidatorKind::Zebrad) {
-        test_manager.local_net.generate_blocks_with_delay(100).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(100).await;
         clients.faucet.sync_and_await().await.unwrap();
         clients.faucet.quick_shield(AccountId::ZERO).await.unwrap();
-        test_manager.local_net.generate_blocks_with_delay(100).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(100).await;
         clients.faucet.sync_and_await().await.unwrap();
         clients.faucet.quick_shield(AccountId::ZERO).await.unwrap();
-        test_manager.local_net.generate_blocks_with_delay(100).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(100).await;
         clients.faucet.sync_and_await().await.unwrap();
         clients.faucet.quick_shield(AccountId::ZERO).await.unwrap();
-        test_manager.local_net.generate_blocks_with_delay(1).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(1).await;
         clients.faucet.sync_and_await().await.unwrap();
     };
 
@@ -292,7 +292,7 @@ async fn send_to_all<V: Validator>(validator: &ValidatorKind, backend: &BackendT
     //       for this reason we generate blocks 1 at a time and sleep to let other tasks run.
     for height in 1..=100 {
         dbg!("Generating block at height: {}", height);
-        test_manager.local_net.generate_blocks_with_delay(1).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(1).await;
     }
 
     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
@@ -349,10 +349,10 @@ async fn shield_for_validator<V: Validator>(validator: &ValidatorKind, backend: 
     clients.faucet.sync_and_await().await.unwrap();
 
     if matches!(validator, ValidatorKind::Zebrad) {
-        test_manager.local_net.generate_blocks_with_delay(100).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(100).await;
         clients.faucet.sync_and_await().await.unwrap();
         clients.faucet.quick_shield(AccountId::ZERO).await.unwrap();
-        test_manager.local_net.generate_blocks_with_delay(1).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(1).await;
         clients.faucet.sync_and_await().await.unwrap();
     };
 
@@ -367,7 +367,7 @@ async fn shield_for_validator<V: Validator>(validator: &ValidatorKind, backend: 
     //       for this reason we generate blocks 1 at a time and sleep to let other tasks run.
     for height in 1..=100 {
         dbg!("Generating block at height: {}", height);
-        test_manager.local_net.generate_blocks_with_delay(1).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(1).await;
     }
 
     tokio::time::sleep(std::time::Duration::from_secs(1)).await;
@@ -390,7 +390,7 @@ async fn shield_for_validator<V: Validator>(validator: &ValidatorKind, backend: 
         .quick_shield(AccountId::ZERO)
         .await
         .unwrap();
-    test_manager.local_net.generate_blocks_with_delay(1).await;
+    let _ = test_manager.local_net.generate_blocks_with_delay(1).await;
     clients.recipient.sync_and_await().await.unwrap();
 
     assert_eq!(
@@ -422,17 +422,17 @@ async fn monitor_unverified_mempool_for_validator<V: Validator>(
         .take()
         .expect("Clients are not initialized");
 
-    test_manager.local_net.generate_blocks_with_delay(1).await;
+    let _ = test_manager.local_net.generate_blocks_with_delay(1).await;
     clients.faucet.sync_and_await().await.unwrap();
 
     if matches!(validator, ValidatorKind::Zebrad) {
-        test_manager.local_net.generate_blocks_with_delay(100).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(100).await;
         clients.faucet.sync_and_await().await.unwrap();
         clients.faucet.quick_shield(AccountId::ZERO).await.unwrap();
-        test_manager.local_net.generate_blocks_with_delay(100).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(100).await;
         clients.faucet.sync_and_await().await.unwrap();
         clients.faucet.quick_shield(AccountId::ZERO).await.unwrap();
-        test_manager.local_net.generate_blocks_with_delay(1).await;
+        let _ = test_manager.local_net.generate_blocks_with_delay(1).await;
         clients.faucet.sync_and_await().await.unwrap();
     };
 
@@ -521,7 +521,7 @@ async fn monitor_unverified_mempool_for_validator<V: Validator>(
         250_000
     );
 
-    test_manager.local_net.generate_blocks_with_delay(1).await;
+    let _ = test_manager.local_net.generate_blocks_with_delay(1).await;
 
     println!("\n\nFetching Mined Tx 1!\n");
     let _transaction_1 = dbg!(

--- a/integration-tests/tests/wallet_to_validator.rs
+++ b/integration-tests/tests/wallet_to_validator.rs
@@ -6,15 +6,15 @@ use zaino_fetch::jsonrpsee::connector::test_node_and_return_url;
 use zaino_state::BackendType;
 use zaino_testutils::from_inputs;
 use zaino_testutils::TestManager;
-use zaino_testutils::Validator;
 use zaino_testutils::ValidatorKind;
+use zcash_local_net::validator::Validator;
 use zip32::AccountId;
 
 async fn connect_to_node_get_info_for_validator<T: Validator>(
     validator: &ValidatorKind,
     backend: &BackendType,
 ) {
-    let mut test_manager = TestManager::launch_with_default_activation_heights::<T>(
+    let mut test_manager = TestManager::<V>::launch_with_default_activation_heights(
         validator, backend, None, None, true, false, false, true, true, true,
     )
     .await
@@ -31,7 +31,7 @@ async fn connect_to_node_get_info_for_validator<T: Validator>(
 }
 
 async fn send_to_orchard<T: Validator>(validator: &ValidatorKind, backend: &BackendType) {
-    let mut test_manager = TestManager::launch_with_default_activation_heights::<T>(
+    let mut test_manager = TestManager::<V>::launch_with_default_activation_heights(
         validator, backend, None, None, true, false, false, true, true, true,
     )
     .await
@@ -51,7 +51,7 @@ async fn send_to_orchard<T: Validator>(validator: &ValidatorKind, backend: &Back
         clients.faucet.sync_and_await().await.unwrap();
     };
 
-    let recipient_ua = clients.get_recipient_address("unified").await;
+    let recipient_ua = clients.get_recipient_address("unified").await.to_string();
     from_inputs::quick_send(&mut clients.faucet, vec![(&recipient_ua, 250_000, None)])
         .await
         .unwrap();
@@ -74,7 +74,7 @@ async fn send_to_orchard<T: Validator>(validator: &ValidatorKind, backend: &Back
 }
 
 async fn send_to_sapling<V: Validator>(validator: &ValidatorKind, backend: &BackendType) {
-    let mut test_manager = TestManager::launch_with_default_activation_heights::<V>(
+    let mut test_manager = TestManager::<V>::launch_with_default_activation_heights(
         validator, backend, None, None, true, false, false, true, true, true,
     )
     .await
@@ -117,7 +117,7 @@ async fn send_to_sapling<V: Validator>(validator: &ValidatorKind, backend: &Back
 }
 
 async fn send_to_transparent<V: Validator>(validator: &ValidatorKind, backend: &BackendType) {
-    let mut test_manager = TestManager::launch_with_default_activation_heights::<V>(
+    let mut test_manager = TestManager::<V>::launch_with_default_activation_heights(
         validator, backend, None, None, true, false, false, true, true, true,
     )
     .await
@@ -221,7 +221,7 @@ async fn send_to_transparent<V: Validator>(validator: &ValidatorKind, backend: &
 }
 
 async fn send_to_all<V: Validator>(validator: &ValidatorKind, backend: &BackendType) {
-    let mut test_manager = TestManager::launch_with_default_activation_heights::<V>(
+    let mut test_manager = TestManager::<V>::launch_with_default_activation_heights(
         validator, backend, None, None, true, false, false, true, true, true,
     )
     .await
@@ -312,7 +312,7 @@ async fn send_to_all<V: Validator>(validator: &ValidatorKind, backend: &BackendT
 }
 
 async fn shield_for_validator<V: Validator>(validator: &ValidatorKind, backend: &BackendType) {
-    let mut test_manager = TestManager::launch_with_default_activation_heights::<V>(
+    let mut test_manager = TestManager::<V>::launch_with_default_activation_heights(
         validator, backend, None, None, true, false, false, true, true, true,
     )
     .await
@@ -388,7 +388,7 @@ async fn monitor_unverified_mempool_for_validator<V: Validator>(
     validator: &ValidatorKind,
     backend: &BackendType,
 ) {
-    let mut test_manager = TestManager::launch_with_default_activation_heights::<V>(
+    let mut test_manager = TestManager::<V>::launch_with_default_activation_heights(
         validator, backend, None, None, true, false, false, true, true, true,
     )
     .await

--- a/integration-tests/tests/wallet_to_validator.rs
+++ b/integration-tests/tests/wallet_to_validator.rs
@@ -6,11 +6,15 @@ use zaino_fetch::jsonrpsee::connector::test_node_and_return_url;
 use zaino_state::BackendType;
 use zaino_testutils::from_inputs;
 use zaino_testutils::TestManager;
+use zaino_testutils::Validator;
 use zaino_testutils::ValidatorKind;
 use zip32::AccountId;
 
-async fn connect_to_node_get_info_for_validator(validator: &ValidatorKind, backend: &BackendType) {
-    let mut test_manager = TestManager::launch_with_default_activation_heights(
+async fn connect_to_node_get_info_for_validator<T: Validator>(
+    validator: &ValidatorKind,
+    backend: &BackendType,
+) {
+    let mut test_manager = TestManager::launch_with_default_activation_heights::<T>(
         validator, backend, None, None, true, false, false, true, true, true,
     )
     .await
@@ -26,8 +30,8 @@ async fn connect_to_node_get_info_for_validator(validator: &ValidatorKind, backe
     test_manager.close().await;
 }
 
-async fn send_to_orchard(validator: &ValidatorKind, backend: &BackendType) {
-    let mut test_manager = TestManager::launch_with_default_activation_heights(
+async fn send_to_orchard<T: Validator>(validator: &ValidatorKind, backend: &BackendType) {
+    let mut test_manager = TestManager::launch_with_default_activation_heights::<T>(
         validator, backend, None, None, true, false, false, true, true, true,
     )
     .await
@@ -69,8 +73,8 @@ async fn send_to_orchard(validator: &ValidatorKind, backend: &BackendType) {
     test_manager.close().await;
 }
 
-async fn send_to_sapling(validator: &ValidatorKind, backend: &BackendType) {
-    let mut test_manager = TestManager::launch_with_default_activation_heights(
+async fn send_to_sapling<V: Validator>(validator: &ValidatorKind, backend: &BackendType) {
+    let mut test_manager = TestManager::launch_with_default_activation_heights::<V>(
         validator, backend, None, None, true, false, false, true, true, true,
     )
     .await
@@ -112,8 +116,8 @@ async fn send_to_sapling(validator: &ValidatorKind, backend: &BackendType) {
     test_manager.close().await;
 }
 
-async fn send_to_transparent(validator: &ValidatorKind, backend: &BackendType) {
-    let mut test_manager = TestManager::launch_with_default_activation_heights(
+async fn send_to_transparent<V: Validator>(validator: &ValidatorKind, backend: &BackendType) {
+    let mut test_manager = TestManager::launch_with_default_activation_heights::<V>(
         validator, backend, None, None, true, false, false, true, true, true,
     )
     .await
@@ -216,8 +220,8 @@ async fn send_to_transparent(validator: &ValidatorKind, backend: &BackendType) {
     test_manager.close().await;
 }
 
-async fn send_to_all(validator: &ValidatorKind, backend: &BackendType) {
-    let mut test_manager = TestManager::launch_with_default_activation_heights(
+async fn send_to_all<V: Validator>(validator: &ValidatorKind, backend: &BackendType) {
+    let mut test_manager = TestManager::launch_with_default_activation_heights::<V>(
         validator, backend, None, None, true, false, false, true, true, true,
     )
     .await
@@ -307,8 +311,8 @@ async fn send_to_all(validator: &ValidatorKind, backend: &BackendType) {
     test_manager.close().await;
 }
 
-async fn shield_for_validator(validator: &ValidatorKind, backend: &BackendType) {
-    let mut test_manager = TestManager::launch_with_default_activation_heights(
+async fn shield_for_validator<V: Validator>(validator: &ValidatorKind, backend: &BackendType) {
+    let mut test_manager = TestManager::launch_with_default_activation_heights::<V>(
         validator, backend, None, None, true, false, false, true, true, true,
     )
     .await
@@ -380,11 +384,11 @@ async fn shield_for_validator(validator: &ValidatorKind, backend: &BackendType) 
     test_manager.close().await;
 }
 
-async fn monitor_unverified_mempool_for_validator(
+async fn monitor_unverified_mempool_for_validator<V: Validator>(
     validator: &ValidatorKind,
     backend: &BackendType,
 ) {
-    let mut test_manager = TestManager::launch_with_default_activation_heights(
+    let mut test_manager = TestManager::launch_with_default_activation_heights::<V>(
         validator, backend, None, None, true, false, false, true, true, true,
     )
     .await
@@ -538,11 +542,17 @@ async fn monitor_unverified_mempool_for_validator(
 }
 
 mod zcashd {
+    use zcash_local_net::validator::Zcashd;
+
     use super::*;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn connect_to_node_get_info() {
-        connect_to_node_get_info_for_validator(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
+        connect_to_node_get_info_for_validator::<Zcashd>(
+            &ValidatorKind::Zcashd,
+            &BackendType::Fetch,
+        )
+        .await;
     }
 
     mod sent_to {
@@ -550,33 +560,37 @@ mod zcashd {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn orchard() {
-            send_to_orchard(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
+            send_to_orchard::<Zcashd>(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn sapling() {
-            send_to_sapling(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
+            send_to_sapling::<Zcashd>(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn transparent() {
-            send_to_transparent(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
+            send_to_transparent::<Zcashd>(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn all() {
-            send_to_all(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
+            send_to_all::<Zcashd>(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
         }
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn shield() {
-        shield_for_validator(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
+        shield_for_validator::<Zcashd>(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn monitor_unverified_mempool() {
-        monitor_unverified_mempool_for_validator(&ValidatorKind::Zcashd, &BackendType::Fetch).await;
+        monitor_unverified_mempool_for_validator::<Zcashd>(
+            &ValidatorKind::Zcashd,
+            &BackendType::Fetch,
+        )
+        .await;
     }
 }
 
@@ -584,90 +598,106 @@ mod zebrad {
     use super::*;
 
     mod fetch_service {
+        use zcash_local_net::validator::Zebrad;
+
         use super::*;
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn connect_to_node_get_info() {
-            connect_to_node_get_info_for_validator(&ValidatorKind::Zebrad, &BackendType::Fetch)
-                .await;
+            connect_to_node_get_info_for_validator::<Zebrad>(
+                &ValidatorKind::Zebrad,
+                &BackendType::Fetch,
+            )
+            .await;
         }
         mod send_to {
             use super::*;
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn sapling() {
-                send_to_sapling(&ValidatorKind::Zebrad, &BackendType::Fetch).await;
+                send_to_sapling::<Zebrad>(&ValidatorKind::Zebrad, &BackendType::Fetch).await;
             }
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn orchard() {
-                send_to_orchard(&ValidatorKind::Zebrad, &BackendType::Fetch).await;
+                send_to_orchard::<Zebrad>(&ValidatorKind::Zebrad, &BackendType::Fetch).await;
             }
 
             /// Bug documented in https://github.com/zingolabs/zaino/issues/145.
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn transparent() {
-                send_to_transparent(&ValidatorKind::Zebrad, &BackendType::Fetch).await;
+                send_to_transparent::<Zebrad>(&ValidatorKind::Zebrad, &BackendType::Fetch).await;
             }
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn all() {
-                send_to_all(&ValidatorKind::Zebrad, &BackendType::Fetch).await;
+                send_to_all::<Zebrad>(&ValidatorKind::Zebrad, &BackendType::Fetch).await;
             }
         }
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn shield() {
-            shield_for_validator(&ValidatorKind::Zebrad, &BackendType::Fetch).await;
+            shield_for_validator::<Zebrad>(&ValidatorKind::Zebrad, &BackendType::Fetch).await;
         }
         /// Bug documented in https://github.com/zingolabs/zaino/issues/144.
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn monitor_unverified_mempool() {
-            monitor_unverified_mempool_for_validator(&ValidatorKind::Zebrad, &BackendType::Fetch)
-                .await;
+            monitor_unverified_mempool_for_validator::<Zebrad>(
+                &ValidatorKind::Zebrad,
+                &BackendType::Fetch,
+            )
+            .await;
         }
     }
 
     mod state_service {
+        use zcash_local_net::validator::Zebrad;
+
         use super::*;
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn connect_to_node_get_info() {
-            connect_to_node_get_info_for_validator(&ValidatorKind::Zebrad, &BackendType::State)
-                .await;
+            connect_to_node_get_info_for_validator::<Zebrad>(
+                &ValidatorKind::Zebrad,
+                &BackendType::State,
+            )
+            .await;
         }
         mod send_to {
             use super::*;
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn sapling() {
-                send_to_sapling(&ValidatorKind::Zebrad, &BackendType::State).await;
+                send_to_sapling::<Zebrad>(&ValidatorKind::Zebrad, &BackendType::State).await;
             }
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn orchard() {
-                send_to_orchard(&ValidatorKind::Zebrad, &BackendType::State).await;
+                send_to_orchard::<Zebrad>(&ValidatorKind::Zebrad, &BackendType::State).await;
             }
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn transparent() {
-                send_to_transparent(&ValidatorKind::Zebrad, &BackendType::State).await;
+                send_to_transparent::<Zebrad>(&ValidatorKind::Zebrad, &BackendType::State).await;
             }
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn all() {
-                send_to_all(&ValidatorKind::Zebrad, &BackendType::State).await;
+                send_to_all::<Zebrad>(&ValidatorKind::Zebrad, &BackendType::State).await;
             }
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn shield() {
-            shield_for_validator(&ValidatorKind::Zebrad, &BackendType::State).await;
+            shield_for_validator::<Zebrad>(&ValidatorKind::Zebrad, &BackendType::State).await;
         }
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         async fn monitor_unverified_mempool() {
-            monitor_unverified_mempool_for_validator(&ValidatorKind::Zebrad, &BackendType::State)
-                .await;
+            monitor_unverified_mempool_for_validator::<Zebrad>(
+                &ValidatorKind::Zebrad,
+                &BackendType::State,
+            )
+            .await;
         }
     }
 }

--- a/zaino-state/Cargo.toml
+++ b/zaino-state/Cargo.toml
@@ -62,7 +62,7 @@ derive_more = { workspace = true, features = ["from"] }
 
 
 [dev-dependencies]
-zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", tag = "zcash_local_net_v0.1.0" }
+zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", tag = "zcash_local_net_v0.3.0" }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true }
 once_cell = { workspace = true }

--- a/zaino-testutils/Cargo.toml
+++ b/zaino-testutils/Cargo.toml
@@ -26,8 +26,8 @@ zcash_client_backend = { git = "https://github.com/zcash/librustzcash", rev = "d
 zebra-chain = { workspace = true }
 
 # Zingo-infra
-zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", tag = "zcash_local_net_v0.1.0" }
-zingo_test_vectors = { git = "https://github.com/zingolabs/infrastructure.git", tag = "zcash_local_net_v0.1.0"  }
+zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", tag = "zcash_local_net_v0.3.0" }
+zingo_test_vectors = { git = "https://github.com/zingolabs/infrastructure.git", tag = "zcash_local_net_v0.3.0"  }
 
 # Zingo-common
 zingo_common_components = { git = "https://github.com/zingolabs/zingo-common.git", tag = "zingo_common_components_v0.1.0", features = [ "for_test" ]}

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -384,7 +384,7 @@ impl TestManager {
     ///
     /// TODO: Add TestManagerConfig struct and constructor methods of common test setups.
     #[allow(clippy::too_many_arguments)]
-    pub async fn launch(
+    pub async fn launch<T: zcash_local_net::validator::Validator>(
         validator: &ValidatorKind,
         backend: &BackendType,
         network: Option<NetworkKind>,
@@ -570,7 +570,9 @@ impl TestManager {
 
     /// Helper function to support default test case.
     #[allow(clippy::too_many_arguments)]
-    pub async fn launch_with_default_activation_heights(
+    pub async fn launch_with_default_activation_heights<
+        T: zcash_local_net::validator::Validator,
+    >(
         validator: &ValidatorKind,
         backend: &BackendType,
         network: Option<NetworkKind>,
@@ -587,7 +589,7 @@ impl TestManager {
             ValidatorKind::Zcashd => ActivationHeights::default(),
         };
 
-        Self::launch(
+        Self::launch::<T>(
             validator,
             backend,
             network,
@@ -645,11 +647,13 @@ mod launch_testmanager {
 
     mod zcashd {
 
+        use zcash_local_net::validator::Zcashd;
+
         use super::*;
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn basic() {
-            let mut test_manager = TestManager::launch_with_default_activation_heights(
+            let mut test_manager = TestManager::launch_with_default_activation_heights::<Zcashd>(
                 &ValidatorKind::Zcashd,
                 &BackendType::Fetch,
                 None,
@@ -672,7 +676,7 @@ mod launch_testmanager {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn generate_blocks() {
-            let mut test_manager = TestManager::launch_with_default_activation_heights(
+            let mut test_manager = TestManager::launch_with_default_activation_heights::<Zcashd>(
                 &ValidatorKind::Zcashd,
                 &BackendType::Fetch,
                 None,
@@ -701,7 +705,7 @@ mod launch_testmanager {
         #[ignore = "chain cache needs development"]
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn with_chain() {
-            let mut test_manager = TestManager::launch_with_default_activation_heights(
+            let mut test_manager = TestManager::launch_with_default_activation_heights::<Zcashd>(
                 &ValidatorKind::Zcashd,
                 &BackendType::Fetch,
                 None,
@@ -724,7 +728,7 @@ mod launch_testmanager {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn zaino() {
-            let mut test_manager = TestManager::launch_with_default_activation_heights(
+            let mut test_manager = TestManager::launch_with_default_activation_heights::<Zcashd>(
                 &ValidatorKind::Zcashd,
                 &BackendType::Fetch,
                 None,
@@ -751,7 +755,7 @@ mod launch_testmanager {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn zaino_clients() {
-            let mut test_manager = TestManager::launch_with_default_activation_heights(
+            let mut test_manager = TestManager::launch_with_default_activation_heights::<Zcashd>(
                 &ValidatorKind::Zcashd,
                 &BackendType::Fetch,
                 None,
@@ -779,7 +783,7 @@ mod launch_testmanager {
         /// Even if rewards need 100 confirmations these blocks should not have to be mined at the same time.
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn zaino_clients_receive_mining_reward() {
-            let mut test_manager = TestManager::launch_with_default_activation_heights(
+            let mut test_manager = TestManager::launch_with_default_activation_heights::<Zcashd>(
                 &ValidatorKind::Zcashd,
                 &BackendType::Fetch,
                 None,
@@ -823,26 +827,28 @@ mod launch_testmanager {
 
         mod fetch_service {
 
+            use zcash_local_net::validator::Zebrad;
             use zip32::AccountId;
 
             use super::*;
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn basic() {
-                let mut test_manager = TestManager::launch_with_default_activation_heights(
-                    &ValidatorKind::Zebrad,
-                    &BackendType::Fetch,
-                    None,
-                    None,
-                    false,
-                    false,
-                    false,
-                    true,
-                    true,
-                    false,
-                )
-                .await
-                .unwrap();
+                let mut test_manager =
+                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                        &ValidatorKind::Zebrad,
+                        &BackendType::Fetch,
+                        None,
+                        None,
+                        false,
+                        false,
+                        false,
+                        true,
+                        true,
+                        false,
+                    )
+                    .await
+                    .unwrap();
                 assert_eq!(
                     2,
                     u32::from(test_manager.local_net.get_chain_height().await)
@@ -852,20 +858,21 @@ mod launch_testmanager {
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn generate_blocks() {
-                let mut test_manager = TestManager::launch_with_default_activation_heights(
-                    &ValidatorKind::Zebrad,
-                    &BackendType::Fetch,
-                    None,
-                    None,
-                    false,
-                    false,
-                    false,
-                    true,
-                    true,
-                    false,
-                )
-                .await
-                .unwrap();
+                let mut test_manager =
+                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                        &ValidatorKind::Zebrad,
+                        &BackendType::Fetch,
+                        None,
+                        None,
+                        false,
+                        false,
+                        false,
+                        true,
+                        true,
+                        false,
+                    )
+                    .await
+                    .unwrap();
                 assert_eq!(
                     2,
                     u32::from(test_manager.local_net.get_chain_height().await)
@@ -881,20 +888,21 @@ mod launch_testmanager {
             #[ignore = "chain cache needs development"]
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn with_chain() {
-                let mut test_manager = TestManager::launch_with_default_activation_heights(
-                    &ValidatorKind::Zebrad,
-                    &BackendType::Fetch,
-                    None,
-                    ZEBRAD_CHAIN_CACHE_DIR.clone(),
-                    false,
-                    false,
-                    false,
-                    true,
-                    true,
-                    false,
-                )
-                .await
-                .unwrap();
+                let mut test_manager =
+                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                        &ValidatorKind::Zebrad,
+                        &BackendType::Fetch,
+                        None,
+                        ZEBRAD_CHAIN_CACHE_DIR.clone(),
+                        false,
+                        false,
+                        false,
+                        true,
+                        true,
+                        false,
+                    )
+                    .await
+                    .unwrap();
                 assert_eq!(
                     52,
                     u32::from(test_manager.local_net.get_chain_height().await)
@@ -904,20 +912,21 @@ mod launch_testmanager {
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino() {
-                let mut test_manager = TestManager::launch_with_default_activation_heights(
-                    &ValidatorKind::Zebrad,
-                    &BackendType::Fetch,
-                    None,
-                    None,
-                    true,
-                    false,
-                    false,
-                    true,
-                    true,
-                    false,
-                )
-                .await
-                .unwrap();
+                let mut test_manager =
+                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                        &ValidatorKind::Zebrad,
+                        &BackendType::Fetch,
+                        None,
+                        None,
+                        true,
+                        false,
+                        false,
+                        true,
+                        true,
+                        false,
+                    )
+                    .await
+                    .unwrap();
                 let _grpc_client = build_client(services::network::localhost_uri(
                     test_manager
                         .zaino_grpc_listen_address
@@ -931,20 +940,21 @@ mod launch_testmanager {
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients() {
-                let mut test_manager = TestManager::launch_with_default_activation_heights(
-                    &ValidatorKind::Zebrad,
-                    &BackendType::Fetch,
-                    None,
-                    None,
-                    true,
-                    false,
-                    false,
-                    true,
-                    true,
-                    true,
-                )
-                .await
-                .unwrap();
+                let mut test_manager =
+                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                        &ValidatorKind::Zebrad,
+                        &BackendType::Fetch,
+                        None,
+                        None,
+                        true,
+                        false,
+                        false,
+                        true,
+                        true,
+                        true,
+                    )
+                    .await
+                    .unwrap();
                 let clients = test_manager
                     .clients
                     .as_ref()
@@ -959,20 +969,21 @@ mod launch_testmanager {
             /// Even if rewards need 100 confirmations these blocks should not have to be mined at the same time.
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients_receive_mining_reward() {
-                let mut test_manager = TestManager::launch_with_default_activation_heights(
-                    &ValidatorKind::Zebrad,
-                    &BackendType::Fetch,
-                    None,
-                    None,
-                    true,
-                    false,
-                    false,
-                    true,
-                    true,
-                    true,
-                )
-                .await
-                .unwrap();
+                let mut test_manager =
+                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                        &ValidatorKind::Zebrad,
+                        &BackendType::Fetch,
+                        None,
+                        None,
+                        true,
+                        false,
+                        false,
+                        true,
+                        true,
+                        true,
+                    )
+                    .await
+                    .unwrap();
                 let mut clients = test_manager
                     .clients
                     .take()
@@ -1006,20 +1017,21 @@ mod launch_testmanager {
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients_receive_mining_reward_and_send() {
-                let mut test_manager = TestManager::launch_with_default_activation_heights(
-                    &ValidatorKind::Zebrad,
-                    &BackendType::Fetch,
-                    None,
-                    None,
-                    true,
-                    false,
-                    false,
-                    true,
-                    true,
-                    true,
-                )
-                .await
-                .unwrap();
+                let mut test_manager =
+                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                        &ValidatorKind::Zebrad,
+                        &BackendType::Fetch,
+                        None,
+                        None,
+                        true,
+                        false,
+                        false,
+                        true,
+                        true,
+                        true,
+                    )
+                    .await
+                    .unwrap();
                 let mut clients = test_manager
                     .clients
                     .take()
@@ -1108,20 +1120,21 @@ mod launch_testmanager {
             #[ignore = "requires fully synced testnet."]
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_testnet() {
-                let mut test_manager = TestManager::launch_with_default_activation_heights(
-                    &ValidatorKind::Zebrad,
-                    &BackendType::Fetch,
-                    Some(NetworkKind::Testnet),
-                    ZEBRAD_TESTNET_CACHE_DIR.clone(),
-                    true,
-                    false,
-                    false,
-                    true,
-                    true,
-                    true,
-                )
-                .await
-                .unwrap();
+                let mut test_manager =
+                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                        &ValidatorKind::Zebrad,
+                        &BackendType::Fetch,
+                        Some(NetworkKind::Testnet),
+                        ZEBRAD_TESTNET_CACHE_DIR.clone(),
+                        true,
+                        false,
+                        false,
+                        true,
+                        true,
+                        true,
+                    )
+                    .await
+                    .unwrap();
                 let clients = test_manager
                     .clients
                     .as_ref()
@@ -1134,26 +1147,28 @@ mod launch_testmanager {
 
         mod state_service {
 
+            use zcash_local_net::validator::Zebrad;
             use zip32::AccountId;
 
             use super::*;
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn basic() {
-                let mut test_manager = TestManager::launch_with_default_activation_heights(
-                    &ValidatorKind::Zebrad,
-                    &BackendType::State,
-                    None,
-                    None,
-                    false,
-                    false,
-                    false,
-                    true,
-                    true,
-                    false,
-                )
-                .await
-                .unwrap();
+                let mut test_manager =
+                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                        &ValidatorKind::Zebrad,
+                        &BackendType::State,
+                        None,
+                        None,
+                        false,
+                        false,
+                        false,
+                        true,
+                        true,
+                        false,
+                    )
+                    .await
+                    .unwrap();
                 assert_eq!(
                     2,
                     u32::from(test_manager.local_net.get_chain_height().await)
@@ -1163,20 +1178,21 @@ mod launch_testmanager {
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn generate_blocks() {
-                let mut test_manager = TestManager::launch_with_default_activation_heights(
-                    &ValidatorKind::Zebrad,
-                    &BackendType::State,
-                    None,
-                    None,
-                    false,
-                    false,
-                    false,
-                    true,
-                    true,
-                    false,
-                )
-                .await
-                .unwrap();
+                let mut test_manager =
+                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                        &ValidatorKind::Zebrad,
+                        &BackendType::State,
+                        None,
+                        None,
+                        false,
+                        false,
+                        false,
+                        true,
+                        true,
+                        false,
+                    )
+                    .await
+                    .unwrap();
                 assert_eq!(
                     2,
                     u32::from(test_manager.local_net.get_chain_height().await)
@@ -1192,20 +1208,21 @@ mod launch_testmanager {
             #[ignore = "chain cache needs development"]
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn with_chain() {
-                let mut test_manager = TestManager::launch_with_default_activation_heights(
-                    &ValidatorKind::Zebrad,
-                    &BackendType::State,
-                    None,
-                    ZEBRAD_CHAIN_CACHE_DIR.clone(),
-                    false,
-                    false,
-                    false,
-                    true,
-                    true,
-                    false,
-                )
-                .await
-                .unwrap();
+                let mut test_manager =
+                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                        &ValidatorKind::Zebrad,
+                        &BackendType::State,
+                        None,
+                        ZEBRAD_CHAIN_CACHE_DIR.clone(),
+                        false,
+                        false,
+                        false,
+                        true,
+                        true,
+                        false,
+                    )
+                    .await
+                    .unwrap();
                 assert_eq!(
                     52,
                     u32::from(test_manager.local_net.get_chain_height().await)
@@ -1215,20 +1232,21 @@ mod launch_testmanager {
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino() {
-                let mut test_manager = TestManager::launch_with_default_activation_heights(
-                    &ValidatorKind::Zebrad,
-                    &BackendType::State,
-                    None,
-                    None,
-                    true,
-                    false,
-                    false,
-                    true,
-                    true,
-                    false,
-                )
-                .await
-                .unwrap();
+                let mut test_manager =
+                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                        &ValidatorKind::Zebrad,
+                        &BackendType::State,
+                        None,
+                        None,
+                        true,
+                        false,
+                        false,
+                        true,
+                        true,
+                        false,
+                    )
+                    .await
+                    .unwrap();
                 let _grpc_client = build_client(services::network::localhost_uri(
                     test_manager
                         .zaino_grpc_listen_address
@@ -1242,20 +1260,21 @@ mod launch_testmanager {
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients() {
-                let mut test_manager = TestManager::launch_with_default_activation_heights(
-                    &ValidatorKind::Zebrad,
-                    &BackendType::State,
-                    None,
-                    None,
-                    true,
-                    false,
-                    false,
-                    true,
-                    true,
-                    true,
-                )
-                .await
-                .unwrap();
+                let mut test_manager =
+                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                        &ValidatorKind::Zebrad,
+                        &BackendType::State,
+                        None,
+                        None,
+                        true,
+                        false,
+                        false,
+                        true,
+                        true,
+                        true,
+                    )
+                    .await
+                    .unwrap();
                 let clients = test_manager
                     .clients
                     .as_ref()
@@ -1270,20 +1289,21 @@ mod launch_testmanager {
             /// Even if rewards need 100 confirmations these blocks should not have to be mined at the same time.
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients_receive_mining_reward() {
-                let mut test_manager = TestManager::launch_with_default_activation_heights(
-                    &ValidatorKind::Zebrad,
-                    &BackendType::State,
-                    None,
-                    None,
-                    true,
-                    false,
-                    false,
-                    true,
-                    true,
-                    true,
-                )
-                .await
-                .unwrap();
+                let mut test_manager =
+                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                        &ValidatorKind::Zebrad,
+                        &BackendType::State,
+                        None,
+                        None,
+                        true,
+                        false,
+                        false,
+                        true,
+                        true,
+                        true,
+                    )
+                    .await
+                    .unwrap();
 
                 let mut clients = test_manager
                     .clients
@@ -1318,20 +1338,21 @@ mod launch_testmanager {
 
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients_receive_mining_reward_and_send() {
-                let mut test_manager = TestManager::launch_with_default_activation_heights(
-                    &ValidatorKind::Zebrad,
-                    &BackendType::State,
-                    None,
-                    None,
-                    true,
-                    false,
-                    false,
-                    true,
-                    true,
-                    true,
-                )
-                .await
-                .unwrap();
+                let mut test_manager =
+                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                        &ValidatorKind::Zebrad,
+                        &BackendType::State,
+                        None,
+                        None,
+                        true,
+                        false,
+                        false,
+                        true,
+                        true,
+                        true,
+                    )
+                    .await
+                    .unwrap();
 
                 let mut clients = test_manager
                     .clients
@@ -1418,20 +1439,21 @@ mod launch_testmanager {
             #[ignore = "requires fully synced testnet."]
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_testnet() {
-                let mut test_manager = TestManager::launch_with_default_activation_heights(
-                    &ValidatorKind::Zebrad,
-                    &BackendType::State,
-                    Some(NetworkKind::Testnet),
-                    ZEBRAD_TESTNET_CACHE_DIR.clone(),
-                    true,
-                    false,
-                    false,
-                    true,
-                    true,
-                    true,
-                )
-                .await
-                .unwrap();
+                let mut test_manager =
+                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                        &ValidatorKind::Zebrad,
+                        &BackendType::State,
+                        Some(NetworkKind::Testnet),
+                        ZEBRAD_TESTNET_CACHE_DIR.clone(),
+                        true,
+                        false,
+                        false,
+                        true,
+                        true,
+                        true,
+                    )
+                    .await
+                    .unwrap();
                 let clients = test_manager
                     .clients
                     .as_ref()

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -142,12 +142,6 @@ pub enum ValidatorConfig {
     ZebradConfig(ZebradConfig),
 }
 
-/// Available zcash-local-net configurations.
-#[allow(
-    clippy::large_enum_variant,
-    reason = "Maybe this issue: https://github.com/rust-lang/rust-clippy/issues/9798"
-)]
-
 /// Holds zingo lightclients along with the lightclient builder for wallet-2-validator tests.
 pub struct Clients {
     /// Lightclient builder.
@@ -627,7 +621,7 @@ mod launch_testmanager {
 
         mod fetch_service {
 
-            use zcash_local_net::validator::Zebrad;
+            use zcash_local_net::validator::zebrad::Zebrad;
             use zip32::AccountId;
 
             use super::*;

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -20,7 +20,7 @@ use zaino_common::{
 use zaino_state::BackendType;
 use zainodlib::config::default_ephemeral_cookie_path;
 pub use zcash_local_net as services;
-use zcash_local_net::validator::{zcashd::ZcashdConfig, zebrad::ZebradConfig, ControlChain};
+use zcash_local_net::validator::{zcashd::ZcashdConfig, zebrad::ZebradConfig, Validator};
 use zebra_chain::parameters::NetworkKind;
 use zingo_test_vectors::seeds;
 pub use zingolib::get_base_address_macro;
@@ -204,7 +204,7 @@ impl TestManager {
     ///
     /// TODO: Add TestManagerConfig struct and constructor methods of common test setups.
     #[allow(clippy::too_many_arguments)]
-    pub async fn launch<C: ControlChain>(
+    pub async fn launch<C: Validator>(
         validator: &ValidatorKind,
         backend: &BackendType,
         network: Option<NetworkKind>,
@@ -376,7 +376,7 @@ impl TestManager {
     }
     /// Helper function to support default test case.
     #[allow(clippy::too_many_arguments)]
-    pub async fn launch_with_default_activation_heights<C: ControlChain>(
+    pub async fn launch_with_default_activation_heights<C: Validator>(
         validator: &ValidatorKind,
         backend: &BackendType,
         network: Option<NetworkKind>,
@@ -880,7 +880,7 @@ mod launch_testmanager {
                 clients.faucet.account_balance(zip32::AccountId::ZERO).await.unwrap().confirmed_transparent_balance.unwrap().into_u64()
             );
 
-                let recipient_zaddr = clients.get_recipient_address("sapling").await;
+                let recipient_zaddr = clients.get_recipient_address("sapling").await.to_string();
                 zingolib::testutils::lightclient::from_inputs::quick_send(
                     &mut clients.faucet,
                     vec![(&recipient_zaddr, 250_000, None)],

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -221,15 +221,16 @@ impl<C: Validator> TestManager<C> {
         }
 
         // Launch LocalNet:
-        let rpc_listen_port = portpicker::pick_unused_port().expect("No ports free");
         let grpc_listen_port = portpicker::pick_unused_port().expect("No ports free");
-        let full_node_rpc_listen_address =
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), rpc_listen_port);
         let full_node_grpc_listen_address =
             SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), grpc_listen_port);
         let local_net = C::launch_default()
             .await
             .expect("to launch a default validator");
+        let rpc_listen_port = local_net.get_port();
+        let full_node_rpc_listen_address =
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), rpc_listen_port);
+
         let data_dir = local_net.data_dir().path().to_path_buf();
         let zaino_db_path = data_dir.join("zaino");
 
@@ -506,7 +507,7 @@ mod launch_testmanager {
             test_manager.close().await;
         }
 
-        /// This test shows currently we do not receive mining rewards from Zebra unless we mine 100 blocks at a time.
+        /// This test shows nothing about zebrad.
         /// This is not the case with Zcashd and should not be the case here.
         /// Even if rewards need 100 confirmations these blocks should not have to be mined at the same time.
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -461,10 +461,7 @@ mod launch_testmanager {
             )
             .await
             .unwrap();
-            assert_eq!(
-                2,
-                (test_manager.local_net.get_chain_height().await)
-            );
+            assert_eq!(2, (test_manager.local_net.get_chain_height().await));
             test_manager.close().await;
         }
 
@@ -484,15 +481,9 @@ mod launch_testmanager {
             )
             .await
             .unwrap();
-            assert_eq!(
-                2,
-                (test_manager.local_net.get_chain_height().await)
-            );
+            assert_eq!(2, (test_manager.local_net.get_chain_height().await));
             test_manager.local_net.generate_blocks(1).await.unwrap();
-            assert_eq!(
-                3,
-                (test_manager.local_net.get_chain_height().await)
-            );
+            assert_eq!(3, (test_manager.local_net.get_chain_height().await));
             test_manager.close().await;
         }
 
@@ -513,10 +504,7 @@ mod launch_testmanager {
             )
             .await
             .unwrap();
-            assert_eq!(
-                10,
-                (test_manager.local_net.get_chain_height().await)
-            );
+            assert_eq!(10, (test_manager.local_net.get_chain_height().await));
             test_manager.close().await;
         }
 
@@ -643,10 +631,7 @@ mod launch_testmanager {
                     )
                     .await
                     .unwrap();
-                assert_eq!(
-                    2,
-                    (test_manager.local_net.get_chain_height().await)
-                );
+                assert_eq!(2, (test_manager.local_net.get_chain_height().await));
                 test_manager.close().await;
             }
 
@@ -667,15 +652,9 @@ mod launch_testmanager {
                     )
                     .await
                     .unwrap();
-                assert_eq!(
-                    2,
-                    (test_manager.local_net.get_chain_height().await)
-                );
+                assert_eq!(2, (test_manager.local_net.get_chain_height().await));
                 test_manager.local_net.generate_blocks(1).await.unwrap();
-                assert_eq!(
-                    3,
-                    (test_manager.local_net.get_chain_height().await)
-                );
+                assert_eq!(3, (test_manager.local_net.get_chain_height().await));
                 test_manager.close().await;
             }
 
@@ -697,10 +676,7 @@ mod launch_testmanager {
                     )
                     .await
                     .unwrap();
-                assert_eq!(
-                    52,
-                    (test_manager.local_net.get_chain_height().await)
-                );
+                assert_eq!(52, (test_manager.local_net.get_chain_height().await));
                 test_manager.close().await;
             }
 
@@ -963,10 +939,7 @@ mod launch_testmanager {
                     )
                     .await
                     .unwrap();
-                assert_eq!(
-                    2,
-                    (test_manager.local_net.get_chain_height().await)
-                );
+                assert_eq!(2, (test_manager.local_net.get_chain_height().await));
                 test_manager.close().await;
             }
 
@@ -987,15 +960,9 @@ mod launch_testmanager {
                     )
                     .await
                     .unwrap();
-                assert_eq!(
-                    2,
-                    (test_manager.local_net.get_chain_height().await)
-                );
-                test_manager.local_net.generate_blocks_with_delay(1).await;
-                assert_eq!(
-                    3,
-                    (test_manager.local_net.get_chain_height().await)
-                );
+                assert_eq!(2, (test_manager.local_net.get_chain_height().await));
+                let _ = test_manager.local_net.generate_blocks_with_delay(1).await;
+                assert_eq!(3, (test_manager.local_net.get_chain_height().await));
                 test_manager.close().await;
             }
 
@@ -1017,10 +984,7 @@ mod launch_testmanager {
                     )
                     .await
                     .unwrap();
-                assert_eq!(
-                    52,
-                    (test_manager.local_net.get_chain_height().await)
-                );
+                assert_eq!(52, (test_manager.local_net.get_chain_height().await));
                 test_manager.close().await;
             }
 
@@ -1111,7 +1075,7 @@ mod launch_testmanager {
                     .await
                     .unwrap());
 
-                test_manager.local_net.generate_blocks_with_delay(100).await;
+                let _ = test_manager.local_net.generate_blocks_with_delay(100).await;
                 clients.faucet.sync_and_await().await.unwrap();
                 dbg!(clients
                     .faucet
@@ -1153,7 +1117,7 @@ mod launch_testmanager {
                     .take()
                     .expect("Clients are not initialized");
 
-                test_manager.local_net.generate_blocks_with_delay(100).await;
+                let _ = test_manager.local_net.generate_blocks_with_delay(100).await;
                 clients.faucet.sync_and_await().await.unwrap();
                 dbg!(clients
                     .faucet
@@ -1184,7 +1148,7 @@ mod launch_testmanager {
 
                 // *Send all transparent funds to own orchard address.
                 clients.faucet.quick_shield(AccountId::ZERO).await.unwrap();
-                test_manager.local_net.generate_blocks_with_delay(1).await;
+                let _ = test_manager.local_net.generate_blocks_with_delay(1).await;
                 clients.faucet.sync_and_await().await.unwrap();
                 dbg!(clients
                     .faucet
@@ -1207,7 +1171,7 @@ mod launch_testmanager {
                 .await
                 .unwrap();
 
-                test_manager.local_net.generate_blocks_with_delay(1).await;
+                let _ = test_manager.local_net.generate_blocks_with_delay(1).await;
                 clients.recipient.sync_and_await().await.unwrap();
                 dbg!(clients
                     .recipient

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -997,7 +997,7 @@ mod launch_testmanager {
                     2,
                     u32::from(test_manager.local_net.get_chain_height().await)
                 );
-                test_manager.generate_blocks_with_delay(1).await;
+                test_manager.local_net.generate_blocks_with_delay(1).await;
                 assert_eq!(
                     3,
                     u32::from(test_manager.local_net.get_chain_height().await)
@@ -1117,7 +1117,7 @@ mod launch_testmanager {
                     .await
                     .unwrap());
 
-                test_manager.generate_blocks_with_delay(100).await;
+                test_manager.local_net.generate_blocks_with_delay(100).await;
                 clients.faucet.sync_and_await().await.unwrap();
                 dbg!(clients
                     .faucet
@@ -1159,7 +1159,7 @@ mod launch_testmanager {
                     .take()
                     .expect("Clients are not initialized");
 
-                test_manager.generate_blocks_with_delay(100).await;
+                test_manager.local_net.generate_blocks_with_delay(100).await;
                 clients.faucet.sync_and_await().await.unwrap();
                 dbg!(clients
                     .faucet
@@ -1190,7 +1190,7 @@ mod launch_testmanager {
 
                 // *Send all transparent funds to own orchard address.
                 clients.faucet.quick_shield(AccountId::ZERO).await.unwrap();
-                test_manager.generate_blocks_with_delay(1).await;
+                test_manager.local_net.generate_blocks_with_delay(1).await;
                 clients.faucet.sync_and_await().await.unwrap();
                 dbg!(clients
                     .faucet
@@ -1213,7 +1213,7 @@ mod launch_testmanager {
                 .await
                 .unwrap();
 
-                test_manager.generate_blocks_with_delay(1).await;
+                test_manager.local_net.generate_blocks_with_delay(1).await;
                 clients.recipient.sync_and_await().await.unwrap();
                 dbg!(clients
                     .recipient

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -193,13 +193,6 @@ pub struct TestManager {
     pub clients: Option<Clients>,
 }
 
-/// Adds a delay between blocks to allow zaino / zebra to catch up with test.
-pub(crate) async fn generate_blocks_with_delay<C: ControlChain>(controller: C, blocks: u32) {
-    for _ in 0..blocks {
-        controller.generate_blocks(1).await.unwrap();
-        tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
-    }
-}
 impl TestManager {
     /// Launches zcash-local-net<Empty, Validator>.
     ///
@@ -373,7 +366,10 @@ impl TestManager {
         // Generate an extra block to turn on NU5 and NU6,
         // as they currently must be turned on at block height = 2.
         // Generates `blocks` regtest blocks.
-        generate_blocks_with_delay(local_net, 1).await;
+        local_net
+            .generate_blocks_with_delay(1)
+            .await
+            .expect("indexer to match validator");
         tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
 
         Ok(test_manager)

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -635,7 +635,7 @@ mod launch_testmanager {
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn basic() {
                 let mut test_manager =
-                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                    TestManager::<Zebrad>::launch_with_default_activation_heights(
                         &ValidatorKind::Zebrad,
                         &BackendType::Fetch,
                         None,
@@ -659,7 +659,7 @@ mod launch_testmanager {
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn generate_blocks() {
                 let mut test_manager =
-                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                    TestManager::<Zebrad>::launch_with_default_activation_heights(
                         &ValidatorKind::Zebrad,
                         &BackendType::Fetch,
                         None,
@@ -689,7 +689,7 @@ mod launch_testmanager {
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn with_chain() {
                 let mut test_manager =
-                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                    TestManager::<Zebrad>::launch_with_default_activation_heights(
                         &ValidatorKind::Zebrad,
                         &BackendType::Fetch,
                         None,
@@ -713,7 +713,7 @@ mod launch_testmanager {
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino() {
                 let mut test_manager =
-                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                    TestManager::<Zebrad>::launch_with_default_activation_heights(
                         &ValidatorKind::Zebrad,
                         &BackendType::Fetch,
                         None,
@@ -741,7 +741,7 @@ mod launch_testmanager {
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients() {
                 let mut test_manager =
-                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                    TestManager::<Zebrad>::launch_with_default_activation_heights(
                         &ValidatorKind::Zebrad,
                         &BackendType::Fetch,
                         None,
@@ -770,7 +770,7 @@ mod launch_testmanager {
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients_receive_mining_reward() {
                 let mut test_manager =
-                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                    TestManager::<Zebrad>::launch_with_default_activation_heights(
                         &ValidatorKind::Zebrad,
                         &BackendType::Fetch,
                         None,
@@ -818,7 +818,7 @@ mod launch_testmanager {
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients_receive_mining_reward_and_send() {
                 let mut test_manager =
-                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                    TestManager::<Zebrad>::launch_with_default_activation_heights(
                         &ValidatorKind::Zebrad,
                         &BackendType::Fetch,
                         None,
@@ -921,7 +921,7 @@ mod launch_testmanager {
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_testnet() {
                 let mut test_manager =
-                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                    TestManager::<Zebrad>::launch_with_default_activation_heights(
                         &ValidatorKind::Zebrad,
                         &BackendType::Fetch,
                         Some(NetworkKind::Testnet),
@@ -955,7 +955,7 @@ mod launch_testmanager {
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn basic() {
                 let mut test_manager =
-                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                    TestManager::<Zebrad>::launch_with_default_activation_heights(
                         &ValidatorKind::Zebrad,
                         &BackendType::State,
                         None,
@@ -979,7 +979,7 @@ mod launch_testmanager {
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn generate_blocks() {
                 let mut test_manager =
-                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                    TestManager::<Zebrad>::launch_with_default_activation_heights(
                         &ValidatorKind::Zebrad,
                         &BackendType::State,
                         None,
@@ -1009,7 +1009,7 @@ mod launch_testmanager {
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn with_chain() {
                 let mut test_manager =
-                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                    TestManager::<Zebrad>::launch_with_default_activation_heights(
                         &ValidatorKind::Zebrad,
                         &BackendType::State,
                         None,
@@ -1033,7 +1033,7 @@ mod launch_testmanager {
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino() {
                 let mut test_manager =
-                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                    TestManager::<Zebrad>::launch_with_default_activation_heights(
                         &ValidatorKind::Zebrad,
                         &BackendType::State,
                         None,
@@ -1061,7 +1061,7 @@ mod launch_testmanager {
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients() {
                 let mut test_manager =
-                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                    TestManager::<Zebrad>::launch_with_default_activation_heights(
                         &ValidatorKind::Zebrad,
                         &BackendType::State,
                         None,
@@ -1090,7 +1090,7 @@ mod launch_testmanager {
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients_receive_mining_reward() {
                 let mut test_manager =
-                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                    TestManager::<Zebrad>::launch_with_default_activation_heights(
                         &ValidatorKind::Zebrad,
                         &BackendType::State,
                         None,
@@ -1139,7 +1139,7 @@ mod launch_testmanager {
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_clients_receive_mining_reward_and_send() {
                 let mut test_manager =
-                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                    TestManager::<Zebrad>::launch_with_default_activation_heights(
                         &ValidatorKind::Zebrad,
                         &BackendType::State,
                         None,
@@ -1240,7 +1240,7 @@ mod launch_testmanager {
             #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
             pub(crate) async fn zaino_testnet() {
                 let mut test_manager =
-                    TestManager::launch_with_default_activation_heights::<Zebrad>(
+                    TestManager::<Zebrad>::launch_with_default_activation_heights(
                         &ValidatorKind::Zebrad,
                         &BackendType::State,
                         Some(NetworkKind::Testnet),

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -21,8 +21,8 @@ use zaino_common::{
 use zaino_serve::server::config::{GrpcServerConfig, JsonRpcServerConfig};
 use zaino_state::BackendType;
 pub use zcash_local_net as services;
+use zcash_local_net::validator::zcashd::ZcashdConfig;
 use zcash_local_net::validator::Validator;
-use zcash_local_net::validator::{zcashd::ZcashdConfig, zebrad::ZebradConfig};
 use zebra_chain::parameters::NetworkKind;
 use zingo_test_vectors::seeds;
 pub use zingolib::get_base_address_macro;
@@ -186,7 +186,6 @@ impl<C: Validator> TestManager<C> {
     /// If clients is set to active zingolib lightclients will be created for test use.
     ///
     /// TODO: Add TestManagerConfig struct and constructor methods of common test setups.
-    #[allow(clippy::too_many_arguments)]
     pub async fn launch(
         validator: &ValidatorKind,
         backend: &BackendType,

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -463,7 +463,7 @@ mod launch_testmanager {
             .unwrap();
             assert_eq!(
                 2,
-                u32::from(test_manager.local_net.get_chain_height().await)
+                (test_manager.local_net.get_chain_height().await)
             );
             test_manager.close().await;
         }
@@ -486,12 +486,12 @@ mod launch_testmanager {
             .unwrap();
             assert_eq!(
                 2,
-                u32::from(test_manager.local_net.get_chain_height().await)
+                (test_manager.local_net.get_chain_height().await)
             );
             test_manager.local_net.generate_blocks(1).await.unwrap();
             assert_eq!(
                 3,
-                u32::from(test_manager.local_net.get_chain_height().await)
+                (test_manager.local_net.get_chain_height().await)
             );
             test_manager.close().await;
         }
@@ -515,7 +515,7 @@ mod launch_testmanager {
             .unwrap();
             assert_eq!(
                 10,
-                u32::from(test_manager.local_net.get_chain_height().await)
+                (test_manager.local_net.get_chain_height().await)
             );
             test_manager.close().await;
         }
@@ -645,7 +645,7 @@ mod launch_testmanager {
                     .unwrap();
                 assert_eq!(
                     2,
-                    u32::from(test_manager.local_net.get_chain_height().await)
+                    (test_manager.local_net.get_chain_height().await)
                 );
                 test_manager.close().await;
             }
@@ -669,12 +669,12 @@ mod launch_testmanager {
                     .unwrap();
                 assert_eq!(
                     2,
-                    u32::from(test_manager.local_net.get_chain_height().await)
+                    (test_manager.local_net.get_chain_height().await)
                 );
                 test_manager.local_net.generate_blocks(1).await.unwrap();
                 assert_eq!(
                     3,
-                    u32::from(test_manager.local_net.get_chain_height().await)
+                    (test_manager.local_net.get_chain_height().await)
                 );
                 test_manager.close().await;
             }
@@ -699,7 +699,7 @@ mod launch_testmanager {
                     .unwrap();
                 assert_eq!(
                     52,
-                    u32::from(test_manager.local_net.get_chain_height().await)
+                    (test_manager.local_net.get_chain_height().await)
                 );
                 test_manager.close().await;
             }
@@ -965,7 +965,7 @@ mod launch_testmanager {
                     .unwrap();
                 assert_eq!(
                     2,
-                    u32::from(test_manager.local_net.get_chain_height().await)
+                    (test_manager.local_net.get_chain_height().await)
                 );
                 test_manager.close().await;
             }
@@ -989,12 +989,12 @@ mod launch_testmanager {
                     .unwrap();
                 assert_eq!(
                     2,
-                    u32::from(test_manager.local_net.get_chain_height().await)
+                    (test_manager.local_net.get_chain_height().await)
                 );
                 test_manager.local_net.generate_blocks_with_delay(1).await;
                 assert_eq!(
                     3,
-                    u32::from(test_manager.local_net.get_chain_height().await)
+                    (test_manager.local_net.get_chain_height().await)
                 );
                 test_manager.close().await;
             }
@@ -1019,7 +1019,7 @@ mod launch_testmanager {
                     .unwrap();
                 assert_eq!(
                     52,
-                    u32::from(test_manager.local_net.get_chain_height().await)
+                    (test_manager.local_net.get_chain_height().await)
                 );
                 test_manager.close().await;
             }

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -453,7 +453,7 @@ mod launch_testmanager {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn basic() {
-            let mut test_manager = TestManager::launch_with_default_activation_heights::<Zcashd>(
+            let mut test_manager = TestManager::<Zcashd>::launch_with_default_activation_heights(
                 &ValidatorKind::Zcashd,
                 &BackendType::Fetch,
                 None,
@@ -476,7 +476,7 @@ mod launch_testmanager {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn generate_blocks() {
-            let mut test_manager = TestManager::launch_with_default_activation_heights::<Zcashd>(
+            let mut test_manager = TestManager::<Zcashd>::launch_with_default_activation_heights(
                 &ValidatorKind::Zcashd,
                 &BackendType::Fetch,
                 None,
@@ -505,7 +505,7 @@ mod launch_testmanager {
         #[ignore = "chain cache needs development"]
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn with_chain() {
-            let mut test_manager = TestManager::launch_with_default_activation_heights::<Zcashd>(
+            let mut test_manager = TestManager::<Zcashd>::launch_with_default_activation_heights(
                 &ValidatorKind::Zcashd,
                 &BackendType::Fetch,
                 None,
@@ -528,7 +528,7 @@ mod launch_testmanager {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn zaino() {
-            let mut test_manager = TestManager::launch_with_default_activation_heights::<Zcashd>(
+            let mut test_manager = TestManager::<Zcashd>::launch_with_default_activation_heights(
                 &ValidatorKind::Zcashd,
                 &BackendType::Fetch,
                 None,
@@ -555,7 +555,7 @@ mod launch_testmanager {
 
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn zaino_clients() {
-            let mut test_manager = TestManager::launch_with_default_activation_heights::<Zcashd>(
+            let mut test_manager = TestManager::<Zcashd>::launch_with_default_activation_heights(
                 &ValidatorKind::Zcashd,
                 &BackendType::Fetch,
                 None,
@@ -583,7 +583,7 @@ mod launch_testmanager {
         /// Even if rewards need 100 confirmations these blocks should not have to be mined at the same time.
         #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
         pub(crate) async fn zaino_clients_receive_mining_reward() {
-            let mut test_manager = TestManager::launch_with_default_activation_heights::<Zcashd>(
+            let mut test_manager = TestManager::<Zcashd>::launch_with_default_activation_heights(
                 &ValidatorKind::Zcashd,
                 &BackendType::Fetch,
                 None,


### PR DESCRIPTION
## Motivation

The test code needs to be DRYed.  By leveraging the modern traits provided in infrastructure significant boilerplate can be removed from the test code, including at least some 

## Solution
Use infra traits in the new version of infrastructure.  This code will need to land before this solution will work:  https://github.com/zingolabs/infrastructure/pull/152

### Tests

All extant tests

### Follow-up Work

More test code (that was originally copied and pasted) should be deletable.

### PR Checklist

<!-- Check as many boxes as possible. -->

- [ ] The PR name is suitable for the release notes.
- [ ] The solution is tested.
- [ ] The documentation is up to date.
