### PR TITLE
add sound notification makers task

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,4 +1,7 @@
-extend = "makefiles/lints.toml"
+extend = [
+    { path = "makefiles/lints.toml" },
+    { path = "makefiles/notify.toml" },
+]
 env_files = [".env.testing-artifacts"]
 
 [config]
@@ -271,6 +274,7 @@ DOCKER_PID=$!
 # Wait for the docker process
 wait $DOCKER_PID
 '''
+script.post = "makers notify"
 
 # -------------------------------------------------------------------
 

--- a/makefiles/notify.toml
+++ b/makefiles/notify.toml
@@ -1,0 +1,17 @@
+[tasks.notify]
+description = "Play a sound notification (used after long-running tasks)"
+script_runner = "bash"
+script = '''
+SOUNDS="/usr/share/sounds/freedesktop/stereo/complete.oga /usr/share/sounds/freedesktop/stereo/bell.oga"
+
+for player in paplay pw-play aplay; do
+    if command -v "$player" &>/dev/null; then
+        for sound in $SOUNDS; do
+            [[ -f "$sound" ]] && "$player" "$sound" 2>/dev/null && exit 0
+        done
+    fi
+done
+
+# Terminal bell as last resort
+printf '\a'
+'''


### PR DESCRIPTION
Plays a notification sound when long-running test tasks finish.
Uses paplay/pw-play/aplay with fallback to terminal bell.
