### PR TITLE
fix: version bump, startup logging, and entrypoint location

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/zingolabs"
 homepage = "https://www.zingolabs.org/"
 edition = "2021"
 license = "Apache-2.0"
-version = "0.1.2"
+version = "0.2.0"
 
 
 [workspace.dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,8 +76,8 @@ RUN mkdir -p /app/config /app/data && \
 
 # Copy binary and entrypoint
 COPY --from=builder /out/bin/zainod /usr/local/bin/zainod
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 # Default ports
 ARG ZAINO_GRPC_PORT=8137
@@ -88,5 +88,5 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD /usr/local/bin/zainod --version >/dev/null 2>&1 || exit 1
 
 # Start as root; entrypoint drops privileges after setting up directories
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["start"]

--- a/zainod/src/lib.rs
+++ b/zainod/src/lib.rs
@@ -24,6 +24,8 @@ pub mod indexer;
 pub async fn run(config_path: PathBuf) -> Result<(), IndexerError> {
     init_logging();
 
+    info!("zainod v{}", env!("CARGO_PKG_VERSION"));
+
     let config = load_config(&config_path)?;
 
     loop {


### PR DESCRIPTION
### Changes

- Bump workspace version in `Cargo.toml` from `0.1.2` to `0.2.0`
- Print version to logs on startup for easier debugging
- Move `entrypoint.sh` from `/usr/local/bin/` to `/` per Docker convention

### Fixes

- Fixes #879
- Fixes #880