### PR TITLE
Update dockerignore to ignore testing dirs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,7 @@ target/
 
 # Misc
 **/*.log
+
+docker_cargo/
+container-target/
+


### PR DESCRIPTION
Without this, the docker build passes those massive dirs as context and they aren't really needed.

The dirs are:

```
/docker_cargo/
/container-target/
```

these are for `makers` container testing to persist a cache in between runs, we don't need them passed around in zainod docker builds