### PR TITLE
Support Zebra 4.3.0

### DIFF
--- a/.env.testing-artifacts
+++ b/.env.testing-artifacts
@@ -5,4 +5,4 @@ RUST_VERSION=1.92
 ZCASH_VERSION=6.11.0
 
 # zebrad version tag for pulling zfnd/zebra:<version>
-ZEBRA_VERSION=4.2.0
+ZEBRA_VERSION=4.3.0

--- a/.env.testing-artifacts
+++ b/.env.testing-artifacts
@@ -2,7 +2,7 @@
 RUST_VERSION=1.92
 
 # zcashd Git tag (https://github.com/zcash/zcash/releases)
-ZCASH_VERSION=6.11.0
+ZCASH_VERSION=6.12.0
 
 # zebrad version tag for pulling zfnd/zebra:<version>
 ZEBRA_VERSION=4.3.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8800,7 +8800,6 @@ dependencies = [
  "tracing-tree",
  "zebra-chain",
  "zingo_common_components",
- "zingolib",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9761,7 +9761,8 @@ dependencies = [
 [[package]]
 name = "zingo_common_components"
 version = "0.3.0"
-source = "git+https://github.com/zingolabs/zingo-common?tag=zingo-netutils-v4.0.0#196ec7b57393ea63a3b51fb1eca143b865024523"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ed7ebc771980a59ec5f208d5dcf40c010dce2b5d493164c9d2f7baa73e9284"
 
 [[package]]
 name = "zingo_test_vectors"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,9 +2766,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
- "log",
  "rustls 0.23.37",
- "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -3077,11 +3075,11 @@ dependencies = [
  "zaino-state",
  "zaino-testutils",
  "zainod",
- "zcash_local_net",
+ "zcash_local_net 0.4.0 (git+https://github.com/zingolabs/infrastructure.git?rev=1a75152f4744b9e130a7d7f249a5b7691a6bf2fe)",
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",
- "zingo_test_vectors",
+ "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?rev=1a75152f4744b9e130a7d7f249a5b7691a6bf2fe)",
  "zip32",
 ]
 
@@ -3414,7 +3412,6 @@ version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -3441,6 +3438,17 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "zcash_script",
+]
+
+[[package]]
+name = "lightwallet-protocol"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d72a1e80c511125c79cf54cc35fe263fed710abe88d6291f64e6e1ca4b909ec"
+dependencies = [
+ "prost",
+ "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
@@ -4149,7 +4157,7 @@ dependencies = [
 [[package]]
 name = "pepper-sync"
 version = "0.2.0"
-source = "git+https://github.com/zingolabs/zingolib.git?rev=14a69853a8bd2e473dee8a433004c4c06aaf5308#14a69853a8bd2e473dee8a433004c4c06aaf5308"
+source = "git+https://github.com/zingolabs/zingolib.git?rev=823a8f77b85592064ecd8daaa584a027766ee1ab#823a8f77b85592064ecd8daaa584a027766ee1ab"
 dependencies = [
  "bip32",
  "byteorder",
@@ -4178,7 +4186,6 @@ dependencies = [
  "zcash_protocol",
  "zcash_transparent",
  "zingo-memo",
- "zingo-netutils",
  "zingo-status",
  "zip32",
 ]
@@ -8793,6 +8800,7 @@ dependencies = [
  "tracing-tree",
  "zebra-chain",
  "zingo_common_components",
+ "zingolib",
 ]
 
 [[package]]
@@ -8933,13 +8941,13 @@ dependencies = [
  "zaino-testvectors",
  "zainod",
  "zcash_client_backend",
- "zcash_local_net",
+ "zcash_local_net 0.4.0 (git+https://github.com/zingolabs/infrastructure.git?rev=1a75152f4744b9e130a7d7f249a5b7691a6bf2fe)",
  "zcash_protocol",
  "zebra-chain",
  "zebra-state",
- "zingo-netutils",
+ "zingo-netutils 4.0.0 (git+https://github.com/zingolabs/zingo-common?tag=zingo-netutils-v4.0.0)",
  "zingo_common_components",
- "zingo_test_vectors",
+ "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?rev=1a75152f4744b9e130a7d7f249a5b7691a6bf2fe)",
  "zingolib",
  "zingolib_testutils",
  "zip32",
@@ -9109,6 +9117,28 @@ dependencies = [
 [[package]]
 name = "zcash_local_net"
 version = "0.4.0"
+source = "git+https://github.com/zingolabs/infrastructure.git?rev=1a75152f4744b9e130a7d7f249a5b7691a6bf2fe#1a75152f4744b9e130a7d7f249a5b7691a6bf2fe"
+dependencies = [
+ "getset",
+ "hex",
+ "json",
+ "portpicker",
+ "serde_json",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+ "zcash_protocol",
+ "zebra-chain",
+ "zebra-node-services",
+ "zebra-rpc",
+ "zingo_common_components",
+ "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?rev=1a75152f4744b9e130a7d7f249a5b7691a6bf2fe)",
+]
+
+[[package]]
+name = "zcash_local_net"
+version = "0.4.0"
 source = "git+https://github.com/zingolabs/infrastructure.git?rev=69d7a4b72ebe871d2c6bc6f18d93d5b4c9dbec9f#69d7a4b72ebe871d2c6bc6f18d93d5b4c9dbec9f"
 dependencies = [
  "getset",
@@ -9125,7 +9155,7 @@ dependencies = [
  "zebra-node-services",
  "zebra-rpc",
  "zingo_common_components",
- "zingo_test_vectors",
+ "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?rev=69d7a4b72ebe871d2c6bc6f18d93d5b4c9dbec9f)",
 ]
 
 [[package]]
@@ -9678,14 +9708,25 @@ dependencies = [
 
 [[package]]
 name = "zingo-netutils"
-version = "2.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2ca11c717feb94a0032da1e6cffb2928ce2c34aca3b430e85cac02fd0ab425"
+checksum = "b6a5967ccc7ca23d0afd438c60ba9b5e32e0ca63c86d2fba584f9d8bfb97bc07"
 dependencies = [
  "http",
- "hyper",
- "hyper-rustls",
- "hyper-util",
+ "lightwallet-protocol",
+ "thiserror 1.0.69",
+ "tokio-rustls",
+ "tonic",
+ "zcash_client_backend",
+]
+
+[[package]]
+name = "zingo-netutils"
+version = "4.0.0"
+source = "git+https://github.com/zingolabs/zingo-common?tag=zingo-netutils-v4.0.0#196ec7b57393ea63a3b51fb1eca143b865024523"
+dependencies = [
+ "http",
+ "lightwallet-protocol",
  "thiserror 1.0.69",
  "tokio-rustls",
  "tonic",
@@ -9695,7 +9736,7 @@ dependencies = [
 [[package]]
 name = "zingo-price"
 version = "0.0.1"
-source = "git+https://github.com/zingolabs/zingolib.git?rev=14a69853a8bd2e473dee8a433004c4c06aaf5308#14a69853a8bd2e473dee8a433004c4c06aaf5308"
+source = "git+https://github.com/zingolabs/zingolib.git?rev=823a8f77b85592064ecd8daaa584a027766ee1ab#823a8f77b85592064ecd8daaa584a027766ee1ab"
 dependencies = [
  "byteorder",
  "reqwest",
@@ -9721,8 +9762,15 @@ dependencies = [
 [[package]]
 name = "zingo_common_components"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ed7ebc771980a59ec5f208d5dcf40c010dce2b5d493164c9d2f7baa73e9284"
+source = "git+https://github.com/zingolabs/zingo-common?tag=zingo-netutils-v4.0.0#196ec7b57393ea63a3b51fb1eca143b865024523"
+
+[[package]]
+name = "zingo_test_vectors"
+version = "0.0.1"
+source = "git+https://github.com/zingolabs/infrastructure.git?rev=1a75152f4744b9e130a7d7f249a5b7691a6bf2fe#1a75152f4744b9e130a7d7f249a5b7691a6bf2fe"
+dependencies = [
+ "bip0039 0.12.0",
+]
 
 [[package]]
 name = "zingo_test_vectors"
@@ -9735,7 +9783,7 @@ dependencies = [
 [[package]]
 name = "zingolib"
 version = "3.0.0"
-source = "git+https://github.com/zingolabs/zingolib.git?rev=14a69853a8bd2e473dee8a433004c4c06aaf5308#14a69853a8bd2e473dee8a433004c4c06aaf5308"
+source = "git+https://github.com/zingolabs/zingolib.git?rev=823a8f77b85592064ecd8daaa584a027766ee1ab#823a8f77b85592064ecd8daaa584a027766ee1ab"
 dependencies = [
  "append-only-vec",
  "bech32",
@@ -9749,8 +9797,6 @@ dependencies = [
  "futures",
  "hex",
  "http",
- "hyper-rustls",
- "hyper-util",
  "incrementalmerkletree",
  "json",
  "jubjub",
@@ -9762,24 +9808,18 @@ dependencies = [
  "prost",
  "rand 0.8.5",
  "ring",
- "rusqlite",
  "rust-embed",
  "rustls 0.23.37",
  "sapling-crypto",
  "secp256k1 0.31.1",
  "secrecy",
  "serde",
- "serde_json",
  "shardtree",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-rustls",
- "tonic",
- "tower 0.5.3",
  "tracing",
  "tracing-subscriber",
- "webpki-roots 1.0.6",
  "zcash_address",
  "zcash_client_backend",
  "zcash_encoding",
@@ -9789,28 +9829,28 @@ dependencies = [
  "zcash_protocol",
  "zcash_transparent",
  "zingo-memo",
- "zingo-netutils",
+ "zingo-netutils 4.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "zingo-price",
  "zingo-status",
  "zingo_common_components",
- "zingo_test_vectors",
+ "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?rev=69d7a4b72ebe871d2c6bc6f18d93d5b4c9dbec9f)",
  "zip32",
 ]
 
 [[package]]
 name = "zingolib_testutils"
 version = "0.1.0"
-source = "git+https://github.com/zingolabs/zingolib.git?rev=14a69853a8bd2e473dee8a433004c4c06aaf5308#14a69853a8bd2e473dee8a433004c4c06aaf5308"
+source = "git+https://github.com/zingolabs/zingolib.git?rev=823a8f77b85592064ecd8daaa584a027766ee1ab#823a8f77b85592064ecd8daaa584a027766ee1ab"
 dependencies = [
  "bip0039 0.14.0",
  "http",
  "pepper-sync",
  "portpicker",
  "tempfile",
- "zcash_local_net",
+ "zcash_local_net 0.4.0 (git+https://github.com/zingolabs/infrastructure.git?rev=69d7a4b72ebe871d2c6bc6f18d93d5b4c9dbec9f)",
  "zcash_protocol",
  "zingo_common_components",
- "zingo_test_vectors",
+ "zingo_test_vectors 0.0.1 (git+https://github.com/zingolabs/infrastructure.git?rev=69d7a4b72ebe871d2c6bc6f18d93d5b4c9dbec9f)",
  "zingolib",
  "zip32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ version = "0.2.0"
 
 # Zingo 
 
-zingo_common_components =  { git = "https://github.com/zingolabs/zingo-common", tag = "zingo-netutils-v4.0.0" }
+zingo_common_components =  "0.3.0"
 zingo-netutils = { git = "https://github.com/zingolabs/zingo-common", tag = "zingo-netutils-v4.0.0", features = ["back_compatible"] }
 zingolib = { git = "https://github.com/zingolabs/zingolib.git", rev = "823a8f77b85592064ecd8daaa584a027766ee1ab", features = [
     "testutils",
@@ -154,7 +154,6 @@ lazy_static = "1.5.0"
 #zcash_primitives = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
 #zcash_protocol = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
 #zcash_transparent = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
-zingo_common_components =  { git = "https://github.com/zingolabs/zingo-common", tag = "zingo-netutils-v4.0.0" }
 
 [profile.test]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,14 +28,14 @@ version = "0.2.0"
 
 # Zingo 
 
-zingo_common_components = "0.3.0"
-zingo-netutils = "2.0.2"
-zingolib = { git = "https://github.com/zingolabs/zingolib.git", rev = "14a69853a8bd2e473dee8a433004c4c06aaf5308", features = [
+zingo_common_components =  { git = "https://github.com/zingolabs/zingo-common", tag = "zingo-netutils-v4.0.0" }
+zingo-netutils = { git = "https://github.com/zingolabs/zingo-common", tag = "zingo-netutils-v4.0.0", features = ["back_compatible"] }
+zingolib = { git = "https://github.com/zingolabs/zingolib.git", rev = "823a8f77b85592064ecd8daaa584a027766ee1ab", features = [
     "testutils",
 ] }
-zingolib_testutils = { git = "https://github.com/zingolabs/zingolib.git", rev = "14a69853a8bd2e473dee8a433004c4c06aaf5308" }
-zingo_test_vectors = { git = "https://github.com/zingolabs/infrastructure.git", rev = "69d7a4b72ebe871d2c6bc6f18d93d5b4c9dbec9f" }
-zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", rev = "69d7a4b72ebe871d2c6bc6f18d93d5b4c9dbec9f" }
+zingolib_testutils = { git = "https://github.com/zingolabs/zingolib.git", rev = "823a8f77b85592064ecd8daaa584a027766ee1ab" }
+zingo_test_vectors = { git = "https://github.com/zingolabs/infrastructure.git", rev = "1a75152f4744b9e130a7d7f249a5b7691a6bf2fe" }
+zcash_local_net = { git = "https://github.com/zingolabs/infrastructure.git", rev = "1a75152f4744b9e130a7d7f249a5b7691a6bf2fe" }
 
 
 # Librustzcash
@@ -47,9 +47,9 @@ zcash_transparent = "0.6.3"
 zcash_client_backend = "0.21.0"
 
 # Zebra
-zebra-chain = "6.0.0"
+zebra-chain = "6.0.1"
 zebra-state = "5.0.0"
-zebra-rpc = "6.0.0"
+zebra-rpc = "6.0.1"
 
 # Runtime
 tokio = { version = "1.38", features = ["full"] }
@@ -154,6 +154,7 @@ lazy_static = "1.5.0"
 #zcash_primitives = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
 #zcash_protocol = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
 #zcash_transparent = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
+zingo_common_components =  { git = "https://github.com/zingolabs/zingo-common", tag = "zingo-netutils-v4.0.0" }
 
 [profile.test]
 opt-level = 3

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -1506,7 +1506,7 @@ async fn state_service_get_address_transactions_regtest<V: ValidatorExt>(
 
     if matches!(validator, ValidatorKind::Zebrad) {
         test_manager.local_net.generate_blocks(100).await.unwrap();
-        tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(3000)).await;
         clients.faucet.sync_and_await().await.unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
         clients.faucet.quick_shield(AccountId::ZERO).await.unwrap();

--- a/integration-tests/tests/wallet_to_validator.rs
+++ b/integration-tests/tests/wallet_to_validator.rs
@@ -436,7 +436,7 @@ where
     .unwrap();
 
     println!("\n\nStarting Mempool!\n");
-    clients.recipient.wallet.write().await.clear_all();
+    clients.recipient.wallet().write().await.clear_all();
     clients.recipient.sync_and_await().await.unwrap();
 
     // test_manager.local_net.print_stdout();

--- a/zaino-common/Cargo.toml
+++ b/zaino-common/Cargo.toml
@@ -29,4 +29,3 @@ time = { workspace = true }
 
 # Zingo 
 zingo_common_components = { workspace = true }
-zingolib = { workspace = true }

--- a/zaino-common/Cargo.toml
+++ b/zaino-common/Cargo.toml
@@ -29,3 +29,4 @@ time = { workspace = true }
 
 # Zingo 
 zingo_common_components = { workspace = true }
+zingolib = { workspace = true }

--- a/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -2,8 +2,6 @@
 
 use std::path::PathBuf;
 use tempfile::TempDir;
-
-use hex::ToHex;
 use zaino_common::network::ActivationHeights;
 use zaino_common::{DatabaseConfig, Network, StorageConfig};
 use zaino_proto::proto::utils::{compact_block_with_pool_types, PoolTypeFilter};

--- a/zaino-testutils/Cargo.toml
+++ b/zaino-testutils/Cargo.toml
@@ -33,7 +33,7 @@ zaino-common.workspace = true
 zainod = { workspace = true }
 
 # Librustzcash
-zcash_protocol = { version = "0.7.0", features = [
+zcash_protocol = { workspace = true, features = [
   "local-consensus",
 ] }
 zcash_client_backend = { workspace = true, features = ["lightwalletd-tonic"] }

--- a/zaino-testutils/src/lib.rs
+++ b/zaino-testutils/src/lib.rs
@@ -10,11 +10,9 @@ pub mod test_vectors {
 
 use once_cell::sync::Lazy;
 use tonic::transport::Channel;
-// use zingo_common_components::protocol::{ActivationHeights, ActivationHeightsBuilder};
+use zingolib::{config::WalletConfig, wallet::SyncConfig};
 use std::{
-    future::Future,
-    net::{IpAddr, Ipv4Addr, SocketAddr},
-    path::PathBuf,
+    future::Future, net::{IpAddr, Ipv4Addr, SocketAddr}, num::{NonZero, NonZeroU32}, path::PathBuf
 };
 use tracing::{debug, info, instrument};
 use zaino_common::{
@@ -41,7 +39,7 @@ use zcash_local_net::{
 use zcash_local_net::{logs::LogsToStdoutAndStderr, process::Process};
 use zcash_protocol::PoolType;
 use zebra_chain::parameters::NetworkKind;
-use zingo_netutils::{GetClientError, get_client};
+use zingo_netutils::{GetClientError, GrpcIndexer};
 use zingo_test_vectors::seeds;
 pub use zingolib::get_base_address_macro;
 pub use zingolib::lightclient::LightClient;
@@ -457,16 +455,15 @@ where
                         .port(),
                 ),
                 tempfile::tempdir().unwrap(),
-            );
-            
+            ); 
 
-            let faucet = client_builder.build_faucet(true, activation_heights.into());
+            let config = WalletConfig::MnemonicPhrase { mnemonic_phrase: seeds::HOSPITAL_MUSEUM_SEED.to_string(), no_of_accounts: NonZeroU32::new(1).expect("this should not fail"), birthday: 1, wallet_settings: zingolib::wallet::WalletSettings { sync_config:SyncConfig::default(), min_confirmations: NonZero::<u32>::new(1).expect("this should not fail") } };
+            let faucet = client_builder.build_faucet(true, activation_heights.into()).await;
             let recipient = client_builder.build_client(
-                seeds::HOSPITAL_MUSEUM_SEED.to_string(),
-                1,
+                config,
                 true,
                 activation_heights.into(),
-            );
+            ).await;
             Some(Clients {
                 client_builder,
                 faucet,
@@ -715,7 +712,7 @@ impl<C: Validator, Service: LightWalletService + Send + Sync + 'static> Drop
 async fn build_client(
     uri: http::Uri,
 ) -> Result<CompactTxStreamerClient<Channel>, GetClientError> {
-    get_client(uri).await
+    GrpcIndexer::new(uri)?.get_zcb_client().await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`zingo_common_components` points to tag `zingo-netutils-v4.0.0` `zingo_netutils` points to tag `zingo-netutils-v4.0.0`

Zingolib points to commit `823a8f77b85592064ecd8daaa584a027766ee1ab` which needs to be merged and released.

zingo_test_vectors and zcash_local_net point to infrastructure branch `support-zebra-4-3-0` PR https://github.com/zingolabs/infrastructure/pull/238

Fixes:
