### PR TITLE
ZainoVersionedSerde and BlockHeaderData serde fix

### DIFF
--- a/packages/zaino-state/src/chain_index/encoding.rs
+++ b/packages/zaino-state/src/chain_index/encoding.rs
@@ -1,4 +1,60 @@
-//! Holds traits and primitive functions for Zaino's Serialisation schema.
+/* ────────────────────────── Zaino Serialiser Traits ─────────────────────────── */
+
+/*!
+Provides **backward-compatible** encoding and decoding for versioned structs that implement
+`ZainoVersionedSerde`.
+
+Design goals
+- Allow code to **read**  and **write** older on-disk versions.
+- Enable implementers to supply compact, explicit encoders/decoders for historical versions
+  without duplicating decode logic in multiple places.
+- Provide a small set of *version-agnostic* APIs that consumers can call without caring
+  about which concrete wire-format was used on-disk.
+
+Wire-format overview
+- Every record begins with a single **version tag byte** followed by a version-specific body.
+- `Self::VERSION` is the newest implemented version this build **writes**; on read we dispatch
+  using the tag.
+- Implementations *must* expose encoders/decoders for the versions they support so that
+  callers can reliably regenerate exact historical bytes (necessary for checksums,
+  backward-compatible verification and database version migration logic).
+
+Developer guidance (how to implement a versioned type)
+1. When introducing a type, select the initial wire version:
+   - `const VERSION = version::V1;` for first release.
+   - Implement `encode_v1` and `decode_v1` (body-only helpers), and make `encode_latest`
+     / `decode_latest` wrap v1 behaviour.
+2. When bumping to a new wire-format (V2, V3, …):
+   - Introduce `encode_vN` and `decode_vN` for the new layout.
+   - Update `const VERSION` to the new tag (this build will now write the new tag by default).
+   - Make `encode_latest` / `decode_latest` delegate to the new vN helpers.
+   - Preserve `decode_v(M)` helpers for earlier M so older on-disk values remain readable.
+3. For types that *contain* inner fields that themselves implement `ZainoVersionedSerde`
+   (for example `BlockHeaderData` contains `BlockIndex`), **explicitly** control the inner
+   field’s encoded version when producing historical top-level encodings:
+   - Use `serialize_with_version` (or `to_bytes_with_version`) on the inner field to request
+     the exact nested version you need.  This guarantees that `to_bytes_with_version(Some(v))`
+     reproduces exact bytes that historical writers produced (critical for checksum equality).
+   - Do *not* rely on the inner field’s current `serialize()` when producing historical
+     top-level encodings — doing so will change nested bytes and break checksum verification.
+4. Keep encode helpers narrow and faithful:
+   - Implement only the `encode_vN` helpers that are required to reproduce historical
+     bytes; default implementations return an error. This keeps implementations explicit
+     and easy to review.
+
+Consumer (version-agnostic) APIs
+- `serialize()` / `to_bytes()` — writes the current version tag + body.
+- `serialize_with_version(&mut w, version)` / `to_bytes_with_version(version)` — write a
+  chosen version tag and body (useful when reproducing historical bytes).
+- `deserialize()` / `from_bytes()` / `decode_body()` — read and dispatch by version tag.
+
+Safety note
+- `StoredEntry*` wrappers compute and verify checksums over the exact bytes written to disk:
+  `blake2b256(encoded_key || encoded_item_bytes)`. For verification to succeed against older
+  on-disk rows, an implementation MUST be able to reproduce the exact historical `encoded_item_bytes`
+  (including nested fields’ tags/bodies). Use `serialize_with_version` for nested fields to
+  guarantee this behaviour.
+*/
 #![allow(dead_code)]
 
 use core::iter::FromIterator;
@@ -16,7 +72,7 @@ pub mod version {
     // pub const V3: u8 = 3;
 }
 
-/* ────────────────────────── Zaino Serialiser Traits ─────────────────────────── */
+/* ────────────────────────── ZainoVersionedSerde ─────────────────────────── */
 /// # Zaino wire-format: one-byte version tag
 ///
 /// ## Quick summary
@@ -25,56 +81,68 @@ pub mod version {
 /// │ version  │              (little-endian by default)          │
 /// └──────────┴──────────────────────────────────────────────────┘
 ///
-/// * `Self::VERSION` = the tag **this build *writes***.
+/// * `Self::VERSION` is the highest (newest) version implemented in this build.
 /// * On **read**, we peek at the tag:
 ///   * if it equals `Self::VERSION` call `decode_latest`;
 ///   * otherwise fall back to the relevant `decode_vN` helper
 ///     (defaults to “unsupported” unless overwritten).
 ///
-/// ## Update guide.
+/// ## Developer behaviour (implementer guidance)
 ///
-/// ### Initial release (`VERSION = 1`)
-/// 1. `pub struct TxV1 { … }`   // layout frozen forever
-/// 2. `impl ZainoVersionedSerde for TxV1`
-///    * `const VERSION = 1`
-///    * `encode_body` – **v1** layout
-///    * `decode_v1` – parses **v1** bytes
-///    * `decode_latest` - wrapper for `Self::decode_v1`
+/// When you implement a new versioned type:
+/// - Provide *both* encoders and decoders for concrete versions you need to support:
+///   - `encode_vN` and `decode_vN` are the *body-only* helpers for version `N`.
+///   - `encode_latest` should emit the body for the current `Self::VERSION`.
+///   - `decode_latest` must parse the body for the current `Self::VERSION`.
+/// - On a version bump (v1 → v2):
+///   1. Implement `encode_v2` and `decode_v2` for the v2 layout.
+///   2. Update `const VERSION = version::V2;`.
+///   3. Make `encode_latest` forward to `encode_v2` and `decode_latest` forward to `decode_v2`.
+///   4. Keep `decode_v1` and `encode_v1`so existing on-disk v1 values remain readable and
+///      constructable.
+/// - On version bumps >v2:
+///   1. Create `pub const Vn: u8 = n` struct in version mod for new version.
+///   2. Add optional `encode_vn` and `decode_vn` methods to `ZainoVersionedSerde`.
+///   3. Implement new `encode_vn` and `decode_vn` for the new vn layout.
+///   2. Update `const VERSION = version::Vn;`.
+///   3. Make `encode_latest` forward to `encode_vn` and `decode_latest` forward to `decode_vn`.
+///   4. Keep existing encodes / decodes so existing on-disk v1 values remain readable and
+///      constructable.
 ///
-/// ### Bump to v2
-/// 1. `pub struct TxV2 { … }`   // new “current” layout
-/// 2. `impl From<TxV1> for TxV2` // loss-less upgrade path
-/// 3. `impl ZainoVersionedSerde for TxV2`
-///    * `const VERSION = 2`
-///    * `encode_body` – **v2** layout
-///    * `decode_v1` – `TxV1::decode_latest(r).map(Self::from)`
-///    * `decode_v2` – parses **v2** bytes
-///    * `decode_latest` - wrapper for `Self::decode_v2`
+/// Important: **nested versioned fields.**
+/// - If your type contains fields that also implement `ZainoVersionedSerde` (for example
+///   `BlockHeaderData` contains `BlockIndex`), you **must** control the concrete nested
+///   version when producing historical top-level encodings.
+/// - Use `serialize_with_version(..., version)` or `to_bytes_with_version(version)` on the
+///   nested field inside `encode_vN` to force the inner field to be encoded with a specific
+///   tag/body. This guarantees that `to_bytes_with_version(Some(v))` reproduces *exactly* the
+///   bytes historical writers produced (critical for checksum equality and verification).
 ///
-/// ### Next bumps (v3, v4, …, vN)
-/// * Create struct for new version.
-/// * Set `const VERSION = N`.
-/// * Add the `decode_vN` trait method and extend the `match` table inside **this trait** when a brand-new tag first appears.
-/// * Implement `decode_vN` for N’s layout.
-/// * Update `decode_latest` to wrap `decode_vN`.
-/// * Implement `decode_v(N-1)`, `decode_v(N-2)`, ..., `decode_v(N-K)` for all previous versions.
+/// ## Version-agnostic consumer helpers
+///
+/// Implementers expose the low-level `encode_vN`/`decode_vN` helpers; consumers should use
+/// the version-agnostic APIs below:
+/// - `serialize()` / `to_bytes()` — write the current version (latest) tag + body.
+/// - `serialize_with_version(&mut w, version)` / `to_bytes_with_version(version)` — write the
+///   chosen version tag and body (use when reproducing historical bytes).
+/// - `deserialize()` / `from_bytes()` — read version tag and dispatch to the correct decode.
 ///
 /// ## Mandatory items per implementation
 /// * `const VERSION`
-/// * `encode_body`
-/// * `decode_vN` — **must** parse bytes for version N, where N = [`Self::VERSION`].
-/// * `decode_latest` — **must** parse `Self::VERSION` bytes.
-///
-/// Historical helpers (`decode_v1`, `decode_v2`, …) must be implemented
-/// for compatibility with historical versions
+/// * `encode_latest`
+/// * `encode_vN`
+/// * `decode_latest`
+/// * `decode_vN`
 pub trait ZainoVersionedSerde: Sized {
     /// Tag this build writes.
     const VERSION: u8;
 
     /*──────────── encoding ────────────*/
 
-    /// Encode **only** the body (no tag).
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()>;
+    /// Endodes a body whose tag equals `Self::VERSION`.
+    ///
+    /// The trait implementation must wrap `decode_vN` where N = [`Self::VERSION`]
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()>;
 
     /*──────────── mandatory decoder for *this* version ────────────*/
 
@@ -83,23 +151,64 @@ pub trait ZainoVersionedSerde: Sized {
     /// The trait implementation must wrap `decode_vN` where N = [`Self::VERSION`]
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self>;
 
-    /*──────────── version decoders ────────────*/
+    /*──────────── version encoders / decoders ────────────*/
     // Add more versions here when required.
+
+    /// Encode the body in the *v1* layout (tag-less body only).
+    #[inline(always)]
+    #[allow(unused)]
+    fn encode_v1<W: Write>(&self, _w: &mut W) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "v1 encode unsupported",
+        ))
+    }
+
+    /// Encode the body in the *v2* layout (tag-less body only).
+    #[inline(always)]
+    #[allow(unused)]
+    fn encode_v2<W: Write>(&self, _w: &mut W) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "v2 encode unsupported",
+        ))
+    }
 
     #[inline(always)]
     #[allow(unused)]
-    /// Decode an older v1 version
+    /// Decode the body in the *v1* layout (tag-less body only).
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
         Err(io::Error::new(io::ErrorKind::InvalidData, "v1 unsupported"))
     }
     #[inline(always)]
     #[allow(unused)]
-    /// Decode an older v2 version
+    /// Decode the body in the *v2* layout (tag-less body only).
     fn decode_v2<R: Read>(r: &mut R) -> io::Result<Self> {
         Err(io::Error::new(io::ErrorKind::InvalidData, "v2 unsupported"))
     }
 
     /*──────────── router ────────────*/
+
+    /// Encode a body for the requested `version_tag`.
+    ///
+    /// This mirrors `decode_body` but for encoding. Types that only support latest
+    /// may rely on the default behaviour where attempts to encode an older version
+    /// return an error.
+    #[inline]
+    fn encode_body<W: Write>(&self, w: &mut W, version_tag: u8) -> io::Result<()> {
+        if version_tag == Self::VERSION {
+            self.encode_latest(w)
+        } else {
+            match version_tag {
+                version::V1 => self.encode_v1(w),
+                version::V2 => self.encode_v2(w),
+                _ => Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unsupported encode version {version_tag}"),
+                )),
+            }
+        }
+    }
 
     #[inline]
     /// Decode the body, dispatcing to the appropriate decode_vx function
@@ -123,8 +232,15 @@ pub trait ZainoVersionedSerde: Sized {
     #[inline]
     /// The expected start point. Read the version tag, then decode the rest
     fn serialize<W: Write>(&self, mut w: W) -> io::Result<()> {
-        w.write_all(&[Self::VERSION])?;
-        self.encode_body(&mut w)
+        self.serialize_with_version(&mut w, Self::VERSION)
+    }
+
+    /// Serialise specifying a `version` (None -> latest). This writes the
+    /// version tag byte and then the body encoded *for that version*.
+    #[inline]
+    fn serialize_with_version<W: Write>(&self, mut w: W, version: u8) -> io::Result<()> {
+        w.write_all(&[version])?;
+        self.encode_body(&mut w, version)
     }
 
     #[inline]
@@ -138,8 +254,14 @@ pub trait ZainoVersionedSerde: Sized {
     /// Serialize into a `Vec<u8>` (tag + body).
     #[inline]
     fn to_bytes(&self) -> io::Result<Vec<u8>> {
+        self.to_bytes_with_version(Self::VERSION)
+    }
+
+    /// to_bytes with explicit version selection (None -> latest).
+    #[inline]
+    fn to_bytes_with_version(&self, version: u8) -> io::Result<Vec<u8>> {
         let mut buf = Vec::new();
-        self.serialize(&mut buf)?;
+        self.serialize_with_version(&mut buf, version)?;
         Ok(buf)
     }
 
@@ -498,4 +620,390 @@ where
 {
     let len = CompactSize::read(&mut r)? as usize;
     (0..len).map(|_| f(&mut r)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core2::io::Cursor;
+
+    #[test]
+    fn compactsize_roundtrip_various() {
+        let values: &[usize] = &[
+            0usize,
+            1,
+            10,
+            252,
+            253,
+            254,
+            1024,
+            0xFFFFusize,
+            0x1_0000usize,
+            MAX_COMPACT_SIZE as usize,
+        ];
+
+        for &v in values {
+            let mut buf = Vec::new();
+            CompactSize::write(&mut buf, v).expect("write compactsize");
+            let mut cur = Cursor::new(&buf);
+            let r = CompactSize::read(&mut cur).expect("read compactsize");
+            assert_eq!(r as usize, v, "compactsize roundtrip mismatch for {}", v);
+
+            // serialized_size should match produced length
+            assert_eq!(CompactSize::serialized_size(v), buf.len());
+        }
+    }
+
+    #[test]
+    fn compactsize_too_large_errors() {
+        let too_big = (MAX_COMPACT_SIZE as usize) + 1;
+        let mut buf = Vec::new();
+        CompactSize::write(&mut buf, too_big).expect("write oversized");
+        // Reading should return an error because the value exceeds MAX_COMPACT_SIZE.
+        assert!(
+            CompactSize::read(Cursor::new(&buf)).is_err(),
+            "reading compactsize > MAX_COMPAC T_SIZE should error"
+        );
+    }
+
+    #[test]
+    fn compactsize_read_t_roundtrip() {
+        let mut buf = Vec::new();
+        CompactSize::write(&mut buf, 1000).expect("write 1000");
+        let mut cur = Cursor::new(&buf);
+        let v: u32 = CompactSize::read_t(&mut cur).expect("read_t to u32");
+        assert_eq!(v, 1000u32);
+    }
+
+    #[test]
+    fn u8_roundtrip() {
+        let mut buf = Vec::new();
+        write_u8(&mut buf, 0xAB).expect("write_u8");
+        let v = read_u8(Cursor::new(&buf)).expect("read_u8");
+        assert_eq!(v, 0xAB);
+    }
+
+    #[test]
+    fn u16_le_roundtrip() {
+        let mut buf = Vec::new();
+        write_u16_le(&mut buf, 0x1234).expect("write_u16_le");
+        let v = read_u16_le(Cursor::new(&buf)).expect("read_u16_le");
+        assert_eq!(v, 0x1234);
+    }
+
+    #[test]
+    fn u16_be_roundtrip() {
+        let mut buf = Vec::new();
+        write_u16_be(&mut buf, 0x1234).expect("write_u16_be");
+        let v = read_u16_be(Cursor::new(&buf)).expect("read_u16_be");
+        assert_eq!(v, 0x1234);
+    }
+
+    #[test]
+    fn u32_le_roundtrip() {
+        let mut buf = Vec::new();
+        write_u32_le(&mut buf, 0x1122_3344).expect("write_u32_le");
+        let v = read_u32_le(Cursor::new(&buf)).expect("read_u32_le");
+        assert_eq!(v, 0x1122_3344);
+    }
+
+    #[test]
+    fn u32_be_roundtrip() {
+        let mut buf = Vec::new();
+        write_u32_be(&mut buf, 0x1122_3344).expect("write_u32_be");
+        let v = read_u32_be(Cursor::new(&buf)).expect("read_u32_be");
+        assert_eq!(v, 0x1122_3344);
+    }
+
+    #[test]
+    fn u64_le_roundtrip() {
+        let mut buf = Vec::new();
+        write_u64_le(&mut buf, 0x0102_0304_0506_0708).expect("write_u64_le");
+        let v = read_u64_le(Cursor::new(&buf)).expect("read_u64_le");
+        assert_eq!(v, 0x0102_0304_0506_0708u64);
+    }
+
+    #[test]
+    fn u64_be_roundtrip() {
+        let mut buf = Vec::new();
+        write_u64_be(&mut buf, 0x0102_0304_0506_0708).expect("write_u64_be");
+        let v = read_u64_be(Cursor::new(&buf)).expect("read_u64_be");
+        assert_eq!(v, 0x0102_0304_0506_0708u64);
+    }
+
+    #[test]
+    fn i64_le_roundtrip() {
+        let mut buf = Vec::new();
+        let val: i64 = -9_001_234_567_890i64;
+        write_i64_le(&mut buf, val).expect("write_i64_le");
+        let r = read_i64_le(Cursor::new(&buf)).expect("read_i64_le");
+        assert_eq!(r, val);
+    }
+
+    #[test]
+    fn i64_be_roundtrip() {
+        let mut buf = Vec::new();
+        let val: i64 = -9_001_234_567_890i64;
+        write_i64_be(&mut buf, val).expect("write_i64_be");
+        let r = read_i64_be(Cursor::new(&buf)).expect("read_i64_be");
+        assert_eq!(r, val);
+    }
+
+    #[test]
+    fn fixed_le_roundtrip() {
+        let arr: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+        let mut buf = Vec::new();
+        write_fixed_le::<8, _>(&mut buf, &arr).expect("write_fixed_le");
+        let got: [u8; 8] = read_fixed_le::<8, _>(Cursor::new(&buf)).expect("read_fixed_le");
+        assert_eq!(got, arr);
+    }
+
+    #[test]
+    fn fixed_be_roundtrip() {
+        let arr: [u8; 8] = [10, 11, 12, 13, 14, 15, 16, 17];
+        let mut buf = Vec::new();
+        write_fixed_be::<8, _>(&mut buf, &arr).expect("write_fixed_be");
+        let got: [u8; 8] = read_fixed_be::<8, _>(Cursor::new(&buf)).expect("read_fixed_be");
+        // read_fixed_be reverses the wire bytes back into internal order, so we expect equality
+        assert_eq!(got, arr);
+    }
+
+    #[test]
+    fn option_none_roundtrip() {
+        let mut buf = Vec::new();
+        write_option(&mut buf, &None::<u32>, |_w, _v| Ok(())).expect("write_option none");
+        let mut cur = Cursor::new(&buf);
+        let r: Option<u32> = read_option(&mut cur, |_r| unreachable!()).expect("read_option none");
+        assert!(r.is_none());
+    }
+
+    #[test]
+    fn option_some_roundtrip() {
+        let mut buf = Vec::new();
+        write_option(&mut buf, &Some(0xDEADBEEFu32), |w, v| write_u32_le(w, *v))
+            .expect("write_option some");
+        let mut cur = Cursor::new(&buf);
+        let r: Option<u32> = read_option(&mut cur, |r| read_u32_le(r)).expect("read_option some");
+        assert_eq!(r, Some(0xDEADBEEF));
+    }
+
+    #[test]
+    fn write_vec_read_vec_roundtrip() {
+        let items = vec![1u16, 2u16, 3u16, 0xABCDu16];
+        let mut buf = Vec::new();
+        write_vec(&mut buf, &items, |w, v| write_u16_le(w, *v)).expect("write_vec");
+        let mut cur = Cursor::new(&buf);
+        let r: Vec<u16> = read_vec(&mut cur, |r| read_u16_le(r)).expect("read_vec");
+        assert_eq!(r, items);
+    }
+
+    #[test]
+    fn read_vec_into_roundtrip() {
+        let items = vec![10u32, 11u32, 12u32];
+        let mut buf = Vec::new();
+        write_vec(&mut buf, &items, |w, v| write_u32_le(w, *v)).expect("write_vec u32");
+        let mut cur = Cursor::new(&buf);
+        let out: Vec<u32> = read_vec_into(&mut cur, |r| read_u32_le(r)).expect("read_vec_into");
+        assert_eq!(out, items);
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct Inner {
+        pub x: u32,
+    }
+
+    // Inner: versioned: v1 writes little-endian, v2 writes big-endian for demonstration.
+    impl ZainoVersionedSerde for Inner {
+        // current build writes v2
+        const VERSION: u8 = version::V2;
+
+        fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+            // latest = v2
+            self.encode_v2(w)
+        }
+
+        fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
+            Self::decode_v2(r)
+        }
+
+        fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+            // v1 body: x as little-endian
+            write_u32_le(w, self.x)
+        }
+
+        fn encode_v2<W: Write>(&self, w: &mut W) -> io::Result<()> {
+            // v2 body: x as big-endian
+            write_u32_be(w, self.x)
+        }
+
+        fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
+            let x = read_u32_le(r)?;
+            Ok(Inner { x })
+        }
+
+        fn decode_v2<R: Read>(r: &mut R) -> io::Result<Self> {
+            let x = read_u32_be(r)?;
+            Ok(Inner { x })
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct Outer {
+        pub inner: Inner,
+        pub y: u8,
+    }
+
+    // Outer: top-level is versioned. Top-level v1 must include nested Inner encoded as v1.
+    impl ZainoVersionedSerde for Outer {
+        // this build writes v2 by default
+        const VERSION: u8 = version::V2;
+
+        fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+            self.encode_v2(w)
+        }
+
+        fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
+            Self::decode_v2(r)
+        }
+
+        // Top-level v1: explicitly request inner as v1 (writes inner tag+body for v1)
+        fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+            // write nested Inner as a versioned record with tag+body
+            self.inner.serialize_with_version(&mut *w, version::V1)?;
+            // then write y
+            w.write_all(&[self.y])?;
+            Ok(())
+        }
+
+        // Top-level v2: explicitly request inner as v2
+        fn encode_v2<W: Write>(&self, w: &mut W) -> io::Result<()> {
+            self.inner.serialize_with_version(&mut *w, version::V2)?;
+            w.write_all(&[self.y])?;
+            Ok(())
+        }
+
+        fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
+            // inner is stored with its own tag, so use Inner::deserialize
+            let inner = Inner::deserialize(&mut *r)?;
+            let mut buf = [0u8; 1];
+            r.read_exact(&mut buf)?;
+            Ok(Outer { inner, y: buf[0] })
+        }
+
+        fn decode_v2<R: Read>(r: &mut R) -> io::Result<Self> {
+            // same decoding behavior: nested inner may include its tag
+            let inner = Inner::deserialize(&mut *r)?;
+            let mut buf = [0u8; 1];
+            r.read_exact(&mut buf)?;
+            Ok(Outer { inner, y: buf[0] })
+        }
+    }
+
+    #[test]
+    fn inner_v1_v2_roundtrip_and_difference() {
+        let i = Inner { x: 0x1122_3344 };
+
+        // v1 and v2 bytes should differ
+        let b_v1 = i.to_bytes_with_version(version::V1).expect("v1 bytes");
+        let b_v2 = i.to_bytes_with_version(version::V2).expect("v2 bytes");
+        assert_ne!(b_v1, b_v2, "v1 and v2 encodings must differ for the test");
+
+        // decoding roundtrip for both
+        let decoded_v1 = Inner::from_bytes(&b_v1).expect("decode v1");
+        let decoded_v2 = Inner::from_bytes(&b_v2).expect("decode v2");
+        assert_eq!(decoded_v1, i);
+        assert_eq!(decoded_v2, i);
+
+        // check tags: first byte is version tag
+        assert_eq!(b_v1[0], version::V1);
+        assert_eq!(b_v2[0], version::V2);
+
+        // Inspect body bytes to ensure endianness was used differently
+        // body starts at index 1 (after tag)
+        let body_v1 = &b_v1[1..];
+        let body_v2 = &b_v2[1..];
+        // v1 is little-endian -> first body byte should be low-order byte 0x44
+        assert_eq!(body_v1[0], 0x44);
+        // v2 is big-endian -> first body byte should be high-order byte 0x11
+        assert_eq!(body_v2[0], 0x11);
+    }
+
+    #[test]
+    fn outer_nested_v1_v2_roundtrip_and_nested_tag_behavior() {
+        let o = Outer {
+            inner: Inner { x: 0xAABBCCDD },
+            y: 0x7f,
+        };
+
+        // produce top-level v1 and v2 bytes
+        let top_v1 = o.to_bytes_with_version(version::V1).expect("outer v1");
+        let top_v2 = o.to_bytes_with_version(version::V2).expect("outer v2");
+
+        // top-level tags:
+        assert_eq!(top_v1[0], version::V1);
+        assert_eq!(top_v2[0], version::V2);
+
+        // nested inner tag should appear immediately after top-level tag
+        // (we wrote inner with serialize_with_version in encode_vN)
+        assert!(top_v1.len() >= 2 && top_v2.len() >= 2);
+        let nested_tag_v1 = top_v1[1];
+        let nested_tag_v2 = top_v2[1];
+
+        // For top-level v1 we explicitly asked inner to be v1
+        assert_eq!(nested_tag_v1, version::V1);
+        // For top-level v2 we explicitly asked inner to be v2
+        assert_eq!(nested_tag_v2, version::V2);
+
+        // decode both and ensure roundtrip equality
+        let decoded_v1 = Outer::from_bytes(&top_v1).expect("decode outer v1");
+        let decoded_v2 = Outer::from_bytes(&top_v2).expect("decode outer v2");
+        assert_eq!(decoded_v1, o);
+        assert_eq!(decoded_v2, o);
+    }
+
+    #[test]
+    fn serialize_and_deserialize_helpers_consistency() {
+        let i = Inner { x: 0x0102_0304 };
+
+        // serialize() should use latest = v2
+        let latest_bytes = i.to_bytes().expect("latest bytes");
+        assert_eq!(latest_bytes[0], version::V2);
+
+        // serialize_with_version should produce requested tag
+        let v1_bytes = i.to_bytes_with_version(version::V1).expect("v1 bytes");
+        let v2_bytes = i.to_bytes_with_version(version::V2).expect("v2 bytes");
+        assert_eq!(v1_bytes[0], version::V1);
+        assert_eq!(v2_bytes[0], version::V2);
+
+        // to_bytes/from_bytes roundtrip across versions
+        assert_eq!(Inner::from_bytes(&v1_bytes).expect("from v1"), i);
+        assert_eq!(Inner::from_bytes(&v2_bytes).expect("from v2"), i);
+        // latest roundtrip
+        assert_eq!(Inner::from_bytes(&latest_bytes).expect("from latest"), i);
+    }
+
+    // Additional test: ensure nested explicit encoding is necessary
+    #[test]
+    fn nested_encoding_must_use_serialize_with_version() {
+        let o = Outer {
+            inner: Inner { x: 0xDEAD_BEEF },
+            y: 0x42,
+        };
+
+        // If we had implemented encode_v1 for Outer *without* calling inner.serialize_with_version(..., V1)
+        // the nested tag would be the inner's current tag (V2), and roundtrip of top-level v1
+        // produced by such a broken implementation would not match historical bytes.
+        //
+        // The test below asserts that our encode_v1 produces nested tag == V1.
+        let top_v1 = o.to_bytes_with_version(version::V1).expect("outer v1");
+        assert_eq!(
+            top_v1[1],
+            version::V1,
+            "nested inner tag must be v1 for top-level v1"
+        );
+
+        // Confirm the outer decoding still works
+        let decoded = Outer::from_bytes(&top_v1).expect("decode outer v1");
+        assert_eq!(decoded, o);
+    }
 }

--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -186,7 +186,10 @@ use tracing::{info, instrument};
 use zebra_chain::parameters::NetworkKind;
 
 use crate::{
-    chain_index::{source::BlockchainSourceError, types::GENESIS_HEIGHT},
+    chain_index::{
+        finalised_state::db::v1::DB_VERSION_V1, source::BlockchainSourceError,
+        types::GENESIS_HEIGHT,
+    },
     config::BlockCacheConfig,
     error::FinalisedStateError,
     BlockHash, BlockMetadata, BlockWithMetadata, ChainWork, Height, IndexedBlock, StatusType,
@@ -260,7 +263,7 @@ impl ZainoDB {
     ///
     /// ## Version selection rules
     /// - `cfg.db_version == 0` targets `DbVersion { 0, 0, 0 }` (legacy layout).
-    /// - `cfg.db_version == 1` targets `DbVersion { 1, 0, 0 }` (current layout).
+    /// - `cfg.db_version == 1` targets the latest v1 DB version (`DB_VERSION_V1`)..
     /// - Any other value returns an error.
     ///
     /// ## Migrations
@@ -292,11 +295,7 @@ impl ZainoDB {
                 minor: 0,
                 patch: 0,
             },
-            1 => DbVersion {
-                major: 1,
-                minor: 0,
-                patch: 0,
-            },
+            1 => DB_VERSION_V1,
             x => {
                 return Err(FinalisedStateError::Custom(format!(
                     "unsupported database version: DbV{x}"

--- a/packages/zaino-state/src/chain_index/finalised_state/CHANGELOG.md
+++ b/packages/zaino-state/src/chain_index/finalised_state/CHANGELOG.md
@@ -144,6 +144,31 @@ Bug Fixes / Optimisations
 - Added safety check for idempotent DB writes
 - Updated 'fix_addr_hist_records_by_addr_and_index_blocking' to take and reuse an lmdb ro transaction, improving initial sync performance.
 
+--------------------------------------------------------------------------------
+DB VERSION v1.0.0 (from v1.1.0)
+Date: 2026-01-27
+--------------------------------------------------------------------------------
+
+Summary
+- BlockHeaderData v2 introduced (internally using new BlockIndex::V2 format); because relevant tables (notably `headers` / `BlockHeaderData`) use
+   variable-length encodings existing tables are updated in-place: DB values may contain either v1 or v2 `BlockHeaderData` entries.
+- Recorded on-disk schema text was clarified; migration refreshes persisted `DbMetadata.schema_hash`
+   so the metadata matches the repository's schema contract.
+
+On-disk schema
+- Layout:
+  - Updated [`BlockHeaderData`] table by introducing [`BlockHeaderData::V2`] (and internally [`BlockIndex::V2`]), this table may now hold either V1 or V2
+     [`BlockHeaderData`] structs, with serde handled internally.
+- Tables:
+  - Added: None.
+  - Removed: None.
+  - Renamed: None.
+- Encoding:
+  - Keys: No changes.
+  - Values: Introduced `[BlockHeaderData::V2]`.
+  - Checksums / validation: No changes.
+- Invariants:
+  - No changes.
 
 --------------------------------------------------------------------------------
 (append new entries below)

--- a/packages/zaino-state/src/chain_index/finalised_state/capability.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/capability.rs
@@ -351,14 +351,18 @@ impl DbMetadata {
 impl ZainoVersionedSerde for DbMetadata {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        self.version.serialize(&mut *w)?;
-        write_fixed_le::<32, _>(&mut *w, &self.schema_hash)?;
-        self.migration_status.serialize(&mut *w)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        self.version.serialize_with_version(&mut *w, 1)?;
+        write_fixed_le::<32, _>(&mut *w, &self.schema_hash)?;
+        self.migration_status.serialize_with_version(&mut *w, 1)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -499,14 +503,18 @@ impl DbVersion {
 impl ZainoVersionedSerde for DbVersion {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        write_u32_le(&mut *w, self.major)?;
-        write_u32_le(&mut *w, self.minor)?;
-        write_u32_le(&mut *w, self.patch)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        write_u32_le(&mut *w, self.major)?;
+        write_u32_le(&mut *w, self.minor)?;
+        write_u32_le(&mut *w, self.patch)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -588,7 +596,15 @@ impl fmt::Display for MigrationStatus {
 impl ZainoVersionedSerde for MigrationStatus {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
+    }
+
+    fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
+        Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
         let tag = match self {
             MigrationStatus::Empty => 0,
             MigrationStatus::PartialBuidInProgress => 1,
@@ -597,10 +613,6 @@ impl ZainoVersionedSerde for MigrationStatus {
             MigrationStatus::Complete => 4,
         };
         write_u8(w, tag)
-    }
-
-    fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
-        Self::decode_v1(r)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {

--- a/packages/zaino-state/src/chain_index/finalised_state/db/db_schema_v1.txt
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/db_schema_v1.txt
@@ -30,17 +30,21 @@
 #
 # 1. headers  ―  H  ->  StoredEntryVar<BlockHeaderData>
 #    Key : BE height
-#    Val : 0x01 + BlockHeaderData
+#    Val : 0x01/0x02 + BlockHeaderData
 #           BlockHeaderData V1 body  =
-#              BlockIndex  +  BlockData
-#              BlockIndex  =  B hash  B parent_hash  U256 chain_work
-#                             Option<H> height
+#              BlockIndex V1  +  BlockData
+#
+#           BlockHeaderData V2 body  =
+#              BlockIndex V2  +  BlockData
+#
+#              BlockIndex V2 body =  B hash  B parent_hash  U256 chain_work  H height
+#              BlockIndex V1 body =  B hash  B parent_hash  U256 chain_work  Option<H> height
+#
 #              BlockData   =  LE(u32) version
 #                             LE(i64) unix_time
-#                             B merkle_root
-#                             B block_commitments
 #                             LE(u32) bits
 #                             [32] nonce
+#
 #
 # 2. txids  ―  H  ->  StoredEntryVar<TxidList>
 #    Val : 0x01 + CS count + count × B txid
@@ -91,11 +95,14 @@
 #    Val : 0x01 + CS len + raw event bytes  (multiple entries may share the key)
 #
 # 10. metadata  ―  "metadata" (ASCII)  ->  StoredEntryFixed<DbMetadata>  (singleton)
-#     DbMetadata V1 body =
-#         [32] schema_hash
-#         LE(i64) created_unix_ts
-#         LE(u32) pruned_tip
-#         LE(u32) network (Zcash main = 0, test = 1, regtest = 2)
+#    Val : 0x01 + DbMetadata V1 body + [32] checksum
+#    DbMetadata V1 body =
+#        DbVersion version
+#        32-byte schema_hash
+#        MigrationStatus migration_status
+#
+#    DbVersion = LE(u32) major  LE(u32) minor  LE(u32) patch
+#    MigrationStatus = u8 enum (0 = Empty, 1 = InProgress, 2 = Completed, 3 = Failed)
 #
 # ─────────────────────────── Environment settings ─────────────────────────────
 #   LMDB page-size:         platform default

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -99,14 +99,14 @@ pub(crate) mod transparent_address_history;
 /// compile-time. The path is relative to this source file.
 ///
 /// 1. Bring the *exact* ASCII description of the on-disk layout into the binary at compile-time.
-pub(crate) const DB_SCHEMA_V1_TEXT: &str = include_str!("db_schema_v1_0.txt");
+pub(crate) const DB_SCHEMA_V1_TEXT: &str = include_str!("db_schema_v1.txt");
 
 /*
 2. Compute the checksum once, outside the code:
 
-       $ cd zaino-state/src/chain_index/finalised_state/db
-       $ b2sum -l 256 db_schema_v1_0.txt
-       bc135247b46bb46a4a971e4c2707826f8095e662b6919d28872c71b6bd676593  db_schema_v1_0.txt
+       $ cd packages/zaino-state/src/chain_index/finalised_state/db
+       $ b2sum -l 256 db_schema_v1.txt
+       => [HASH]  db_schema_v1.txt
 
    Optional helper if you don’t have `b2sum`:
 
@@ -118,8 +118,7 @@ pub(crate) const DB_SCHEMA_V1_TEXT: &str = include_str!("db_schema_v1_0.txt");
 
 3. Turn those 64 hex digits into a Rust `[u8; 32]` literal:
 
-       echo bc135247b46bb46a4a971e4c2707826f8095e662b6919d28872c71b6bd676593 \
-       | sed 's/../0x&, /g' | fold -s -w48
+       $ echo [HASH] | sed 's/../0x&, /g' | fold -s -w48
 
 */
 
@@ -128,14 +127,14 @@ pub(crate) const DB_SCHEMA_V1_TEXT: &str = include_str!("db_schema_v1_0.txt");
 /// This value is compared against the schema hash stored in the metadata record to detect schema
 /// drift without a corresponding version bump.
 pub(crate) const DB_SCHEMA_V1_HASH: [u8; 32] = [
-    0xbc, 0x13, 0x52, 0x47, 0xb4, 0x6b, 0xb4, 0x6a, 0x4a, 0x97, 0x1e, 0x4c, 0x27, 0x07, 0x82, 0x6f,
-    0x80, 0x95, 0xe6, 0x62, 0xb6, 0x91, 0x9d, 0x28, 0x87, 0x2c, 0x71, 0xb6, 0xbd, 0x67, 0x65, 0x93,
+    0xa8, 0x19, 0x61, 0x50, 0xff, 0xb6, 0x9e, 0xf8, 0xb2, 0xb5, 0x31, 0x80, 0xdd, 0x90, 0xd0, 0x67,
+    0x41, 0x57, 0xfc, 0x51, 0x39, 0xa1, 0x3a, 0xbe, 0xce, 0x70, 0x4e, 0x51, 0x55, 0xc3, 0x3a, 0x0a,
 ];
 
 /// *Current* database V1 version.
 pub(crate) const DB_VERSION_V1: DbVersion = DbVersion {
     major: 1,
-    minor: 0,
+    minor: 1,
     patch: 0,
 };
 

--- a/packages/zaino-state/src/chain_index/finalised_state/entry.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/entry.rs
@@ -138,13 +138,30 @@ impl<T: ZainoVersionedSerde + FixedEncodedLen> StoredEntryFixed<T> {
     /// Callers should treat a checksum mismatch as a corruption or incompatibility signal and
     /// return a hard error (or trigger a rebuild path), depending on context.
     pub(crate) fn verify<K: AsRef<[u8]>>(&self, key: K) -> bool {
-        let body = {
-            let mut v = Vec::with_capacity(T::VERSIONED_LEN);
-            self.item.serialize(&mut v).unwrap();
-            v
-        };
-        let candidate = Self::blake2b256(&[key.as_ref(), &body].concat());
-        candidate == self.checksum
+        // Iterate from latest (T::VERSION) down to 1 (inclusive).
+        let mut v = T::VERSION;
+        loop {
+            // Try to obtain the encoded bytes for this candidate version (tag + body).
+            match self.item.to_bytes_with_version(v) {
+                Ok(item_bytes) => {
+                    // Compute the candidate checksum over (encoded_key || item_bytes).
+                    let candidate = Self::blake2b256(&[key.as_ref(), &item_bytes].concat());
+                    if candidate == self.checksum {
+                        return true;
+                    }
+                }
+                Err(_) => {
+                    // This version not supported by the type's encoder; try older version.
+                }
+            }
+
+            if v == 1 {
+                break;
+            }
+            v = v.saturating_sub(1);
+        }
+
+        false
     }
 
     /// Returns a reference to the inner record.
@@ -176,13 +193,17 @@ impl<T: ZainoVersionedSerde + FixedEncodedLen> StoredEntryFixed<T> {
 impl<T: ZainoVersionedSerde + FixedEncodedLen> ZainoVersionedSerde for StoredEntryFixed<T> {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        self.item.serialize(&mut *w)?;
-        write_fixed_le::<32, _>(&mut *w, &self.checksum)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        self.item.serialize(&mut *w)?;
+        write_fixed_le::<32, _>(&mut *w, &self.checksum)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -253,10 +274,30 @@ impl<T: ZainoVersionedSerde> StoredEntryVar<T> {
     /// # Key requirements
     /// `key` must be the exact byte encoding used as the LMDB key for this record.
     pub(crate) fn verify<K: AsRef<[u8]>>(&self, key: K) -> bool {
-        let mut body = Vec::new();
-        self.item.serialize(&mut body).unwrap();
-        let candidate = Self::blake2b256(&[key.as_ref(), &body].concat());
-        candidate == self.checksum
+        // Iterate from latest (T::VERSION) down to 1 (inclusive).
+        let mut v = T::VERSION;
+        loop {
+            // Try to obtain the encoded bytes for this candidate version (tag + body).
+            match self.item.to_bytes_with_version(v) {
+                Ok(item_bytes) => {
+                    // Compute the candidate checksum over (encoded_key || item_bytes).
+                    let candidate = Self::blake2b256(&[key.as_ref(), &item_bytes].concat());
+                    if candidate == self.checksum {
+                        return true;
+                    }
+                }
+                Err(_) => {
+                    // This version not supported by the type's encoder; try older version.
+                }
+            }
+
+            if v == 1 {
+                break;
+            }
+            v = v.saturating_sub(1);
+        }
+
+        false
     }
 
     /// Returns a reference to the inner record.
@@ -288,17 +329,21 @@ impl<T: ZainoVersionedSerde> StoredEntryVar<T> {
 impl<T: ZainoVersionedSerde> ZainoVersionedSerde for StoredEntryVar<T> {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
+    }
+
+    fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
+        Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
         let mut body = Vec::new();
         self.item.serialize(&mut body)?;
 
         CompactSize::write(&mut *w, body.len())?;
         w.write_all(&body)?;
         write_fixed_le::<32, _>(&mut *w, &self.checksum)
-    }
-
-    fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
-        Self::decode_v1(r)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -310,5 +355,212 @@ impl<T: ZainoVersionedSerde> ZainoVersionedSerde for StoredEntryVar<T> {
 
         let checksum = read_fixed_le::<32, _>(r)?;
         Ok(Self { item, checksum })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{read_u32_be, read_u32_le, write_u32_be, write_u32_le};
+
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct TestInner {
+        pub x: u32,
+    }
+
+    // TestInner: versioned type with two encodings:
+    // - v1: x as little-endian (body only)
+    // - v2: x as big-endian (body only) and v2 is the current version
+    impl ZainoVersionedSerde for TestInner {
+        const VERSION: u8 = version::V2;
+
+        fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+            self.encode_v2(w)
+        }
+        fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
+            Self::decode_v2(r)
+        }
+
+        fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+            write_u32_le(w, self.x)
+        }
+        fn encode_v2<W: Write>(&self, w: &mut W) -> io::Result<()> {
+            write_u32_be(w, self.x)
+        }
+
+        fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
+            let x = read_u32_le(r)?;
+            Ok(TestInner { x })
+        }
+        fn decode_v2<R: Read>(r: &mut R) -> io::Result<Self> {
+            let x = read_u32_be(r)?;
+            Ok(TestInner { x })
+        }
+    }
+
+    // Make TestInner fixed-length for StoredEntryFixed tests.
+    impl FixedEncodedLen for TestInner {
+        // body length (no version tag): 4 bytes (u32)
+        const ENCODED_LEN: usize = 4;
+    }
+
+    // Helper: simple key bytes for tests
+    fn key_bytes() -> Vec<u8> {
+        b"test-key".to_vec()
+    }
+
+    // StoredEntryFixed: latest roundtrip (new -> to_bytes -> from_bytes -> verify)
+    #[test]
+    fn stored_entry_fixed_roundtrip_latest() {
+        let inner = TestInner { x: 0x1122_3344 };
+        let key = key_bytes();
+
+        // Construct wrapper using current serializer (StoredEntryFixed::new uses latest encoding)
+        let wrapper = StoredEntryFixed::new(&key, inner.clone());
+
+        // Verify should succeed for the same key
+        assert!(
+            wrapper.verify(&key),
+            "wrapper verify (latest) should succeed"
+        );
+
+        // Encode wrapper to bytes and decode back
+        let bytes = wrapper.to_bytes().expect("wrapper to_bytes");
+        let parsed = StoredEntryFixed::<TestInner>::from_bytes(&bytes).expect("from_bytes");
+        assert_eq!(parsed.item, inner);
+        assert_eq!(parsed.checksum, wrapper.checksum);
+
+        // parsed wrapper should verify with same key
+        assert!(parsed.verify(&key));
+    }
+
+    #[test]
+    // StoredEntryFixed: historical v1 body present on disk -> from_bytes + verify must succeed
+    fn stored_entry_fixed_verify_old_v1() {
+        let inner = TestInner { x: 0xAABB_CCDD };
+        let key = key_bytes();
+
+        // Produce item bytes according to historical v1 (tag + body)
+        let item_bytes_v1 = inner
+            .to_bytes_with_version(version::V1)
+            .expect("inner v1 bytes");
+
+        // Compute checksum over (key || item_bytes_v1)
+        let mut digest_input = Vec::with_capacity(key.len() + item_bytes_v1.len());
+        digest_input.extend_from_slice(&key);
+        digest_input.extend_from_slice(&item_bytes_v1);
+        let checksum = StoredEntryFixed::<TestInner>::blake2b256(&digest_input);
+
+        // Manually build on-disk raw bytes for StoredEntryFixed:
+        // [StoredEntryFixed::VERSION] + item_bytes_v1 (should have length T::VERSIONED_LEN) + checksum
+        let mut raw = Vec::new();
+        raw.push(StoredEntryFixed::<TestInner>::VERSION);
+        raw.extend_from_slice(&item_bytes_v1);
+        raw.extend_from_slice(&checksum);
+
+        // Parse using from_bytes (which will call decode_v1 and reconstruct wrapper)
+        let parsed = StoredEntryFixed::<TestInner>::from_bytes(&raw).expect("from_bytes v1");
+        // parsed.item should equal the decoded inner
+        assert_eq!(parsed.item, inner);
+        // verify should succeed using the same key (it will try v2 then v1 candidate encodings)
+        assert!(parsed.verify(&key));
+    }
+
+    // StoredEntryFixed: verify fails on tampered checksum or key
+    #[test]
+    fn stored_entry_fixed_verify_tamper() {
+        let inner = TestInner { x: 0x0102_0304 };
+        let key = key_bytes();
+
+        let mut wrapper = StoredEntryFixed::new(&key, inner.clone());
+        assert!(wrapper.verify(&key));
+
+        // Tamper checksum (flip a byte) and ensure verify fails
+        wrapper.checksum[0] ^= 0xff;
+        assert!(
+            !wrapper.verify(&key),
+            "verify should fail with tampered checksum"
+        );
+
+        // Restore checksum and verify ok, then check wrong key fails
+        wrapper = StoredEntryFixed::new(&key, inner.clone());
+        assert!(wrapper.verify(&key));
+        let wrong_key = b"other-key".to_vec();
+        assert!(
+            !wrapper.verify(&wrong_key),
+            "verify should fail with wrong key"
+        );
+    }
+
+    // -------------------- StoredEntryVar tests --------------------
+
+    #[test]
+    fn stored_entry_var_roundtrip_latest() {
+        let inner = TestInner { x: 0x5566_7788 };
+        let key = key_bytes();
+
+        let wrapper = StoredEntryVar::new(&key, inner.clone());
+        assert!(
+            wrapper.verify(&key),
+            "var wrapper verify (latest) should succeed"
+        );
+
+        // Encode wrapper to bytes and decode back via From/To bytes
+        let bytes = wrapper.to_bytes().expect("var to_bytes");
+        let parsed = StoredEntryVar::<TestInner>::from_bytes(&bytes).expect("var from_bytes");
+        assert_eq!(parsed.item, inner);
+        assert_eq!(parsed.checksum, wrapper.checksum);
+        assert!(parsed.verify(&key));
+    }
+
+    #[test]
+    fn stored_entry_var_verify_old_v1() {
+        let inner = TestInner { x: 0xDEAD_BEEF };
+        let key = key_bytes();
+
+        // item serialized as v1 (tag + body)
+        let item_bytes_v1 = inner
+            .to_bytes_with_version(version::V1)
+            .expect("inner v1 bytes");
+
+        // checksum computed over (key || item_bytes_v1)
+        let mut digest_input = Vec::with_capacity(key.len() + item_bytes_v1.len());
+        digest_input.extend_from_slice(&key);
+        digest_input.extend_from_slice(&item_bytes_v1);
+        let checksum = StoredEntryVar::<TestInner>::blake2b256(&digest_input);
+
+        // Build raw stored value for StoredEntryVar:
+        // [StoredEntryVar::VERSION] + CompactSize(len) + item_bytes_v1 + checksum
+        let mut raw = Vec::new();
+        raw.push(StoredEntryVar::<TestInner>::VERSION);
+        CompactSize::write(&mut raw, item_bytes_v1.len()).expect("write compactsize");
+        raw.extend_from_slice(&item_bytes_v1);
+        // write checksum as fixed 32 bytes
+        write_fixed_le::<32, _>(&mut raw, &checksum).expect("write checksum");
+
+        // from_bytes should parse the body and return wrapper
+        let parsed = StoredEntryVar::<TestInner>::from_bytes(&raw).expect("var from_bytes v1");
+        assert_eq!(parsed.item, inner);
+        // verify must succeed using same key (it will try v2 then v1)
+        assert!(parsed.verify(&key));
+    }
+
+    #[test]
+    fn stored_entry_var_verify_tamper() {
+        let inner = TestInner { x: 0xCAFEBABE };
+        let key = key_bytes();
+
+        let mut wrapper = StoredEntryVar::new(&key, inner);
+        assert!(wrapper.verify(&key));
+
+        // tamper checksum
+        wrapper.checksum[31] ^= 0xff;
+        assert!(!wrapper.verify(&key));
+
+        // restore and test wrong key fails
+        let wrapper = StoredEntryVar::new(&key, TestInner { x: 0xCAFEBABE });
+        let wrong_key = b"bad-key".to_vec();
+        assert!(!wrapper.verify(&wrong_key));
     }
 }

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -111,6 +111,28 @@
 //! - Mark `migration_status = Complete` in shadow metadata.
 //! - Promote shadow to primary via `router.promote_shadow()`.
 //! - Delete the old v0 directory asynchronously once all strong references are dropped.
+//!
+//! ## v1.0.0 → v1.1.0
+//!
+//! `Migration1_0_0To1_1_0` is a **minor version bump** with **on disk schema changes**, but does
+//! not include changes to the external ZainoDB API.
+//!
+//! Important changes in v1.1.0:
+//! - ZainoVersionedSerde had a bug which stopped varifying the checksum of older serde formats,
+//!   this meant that is was not possible to safely update database formats without a full DB
+//!   rebuild. This bug has been fixed and all serde updated to follow the new contract (Note this
+//!   change is 100% compaitible with the old sschema, only extending functionality as required).
+//! - BlockHeaderData v2 added: the Height field in BlockHeaderData.BlockIndex is no longer
+//!   optional. (Note, as heights are required for the finalised portion of the chain this does not
+//!   change db logic, as height was already gruenteed, with a error returned if a block with no
+//!   height is every written to the db).
+//!
+//! Important note: `BlockHeaderData` now has a V2 on-disk layout which uses the V2
+//! `BlockIndex` wire format. Because the `headers` table stores `BlockHeaderData` as a
+//! `StoredEntryVar` (no fixed-length optimisations), the table may contain both V1 and V2
+//! `BlockHeaderData` records concurrently. This migration is metadata-only: it advances
+//! `DbMetadata::version` and refreshes the recorded schema checksum so persisted metadata
+//! matches the repository's updated schema text.
 
 use super::{
     capability::{
@@ -121,7 +143,9 @@ use super::{
 };
 
 use crate::{
-    chain_index::{source::BlockchainSource, types::GENESIS_HEIGHT},
+    chain_index::{
+        finalised_state::capability::DbMetadata, source::BlockchainSource, types::GENESIS_HEIGHT,
+    },
     config::BlockCacheConfig,
     error::FinalisedStateError,
     BlockHash, BlockMetadata, BlockWithMetadata, ChainWork, Height, IndexedBlock,
@@ -269,6 +293,7 @@ impl<T: BlockchainSource> MigrationManager<T> {
             self.current_version.patch,
         ) {
             (0, 0, 0) => Ok(MigrationStep::Migration0_0_0To1_0_0(Migration0_0_0To1_0_0)),
+            (1, 0, 0) => Ok(MigrationStep::Migration1_0_0To1_1_0(Migration1_0_0To1_1_0)),
             (_, _, _) => Err(FinalisedStateError::Custom(format!(
                 "Missing migration from version {}",
                 self.current_version
@@ -284,6 +309,7 @@ impl<T: BlockchainSource> MigrationManager<T> {
 /// to select a step and call `migrate(...)`, and to read the step’s `TO_VERSION`.
 enum MigrationStep {
     Migration0_0_0To1_0_0(Migration0_0_0To1_0_0),
+    Migration1_0_0To1_1_0(Migration1_0_0To1_1_0),
 }
 
 impl MigrationStep {
@@ -291,6 +317,9 @@ impl MigrationStep {
         match self {
             MigrationStep::Migration0_0_0To1_0_0(_step) => {
                 <Migration0_0_0To1_0_0 as Migration<T>>::TO_VERSION
+            }
+            MigrationStep::Migration1_0_0To1_1_0(_step) => {
+                <Migration1_0_0To1_1_0 as Migration<T>>::TO_VERSION
             }
         }
     }
@@ -303,6 +332,7 @@ impl MigrationStep {
     ) -> Result<(), FinalisedStateError> {
         match self {
             MigrationStep::Migration0_0_0To1_0_0(step) => step.migrate(router, cfg, source).await,
+            MigrationStep::Migration1_0_0To1_1_0(step) => step.migrate(router, cfg, source).await,
         }
     }
 }
@@ -502,6 +532,63 @@ impl<T: BlockchainSource> Migration<T> for Migration0_0_0To1_0_0 {
 
         info!("v0.0.0 to v1.0.0 migration complete.");
 
+        Ok(())
+    }
+}
+
+/// Minor migration: v1.0.0 → v1.1.0.
+///
+/// Important note: `BlockHeaderData` now has a V2 on-disk layout which uses the V2
+/// `BlockIndex` wire format. Because the `headers` table stores `BlockHeaderData` as a
+/// `StoredEntryVar` (no fixed-length optimisations), the table may contain both V1 and V2
+/// `BlockHeaderData` records concurrently. This migration is metadata-only: it advances
+/// `DbMetadata::version` and refreshes the recorded schema checksum so persisted metadata
+/// matches the repository's updated schema text.
+///
+/// Safety and resumability:
+/// - Idempotent: if run more than once, it will re-write the same metadata.
+/// - No shadow database and no table rebuild.
+/// - Clears any stale in-progress migration status.
+struct Migration1_0_0To1_1_0;
+
+#[async_trait]
+impl<T: BlockchainSource> Migration<T> for Migration1_0_0To1_1_0 {
+    const CURRENT_VERSION: DbVersion = DbVersion {
+        major: 1,
+        minor: 0,
+        patch: 0,
+    };
+
+    const TO_VERSION: DbVersion = DbVersion {
+        major: 1,
+        minor: 1,
+        patch: 0,
+    };
+
+    async fn migrate(
+        &self,
+        router: Arc<Router>,
+        _cfg: BlockCacheConfig,
+        _source: T,
+    ) -> Result<(), FinalisedStateError> {
+        info!("Starting v1.0.0 → v1.1.0 migration (metadata-only).");
+
+        let mut metadata: DbMetadata = router.get_metadata().await?;
+
+        // Advance the version marker to reflect the new API contract (v1.1.0), and refresh the
+        // persisted schema hash to match the repository's recorded schema contract.
+        // There are no on-disk layout changes; BlockIndex V2 is supported in-place because the
+        // headers table stores a variable-length BlockHeaderData which nests a versioned BlockIndex.
+        metadata.version = <Self as Migration<T>>::TO_VERSION;
+        metadata.schema_hash = crate::chain_index::finalised_state::db::v1::DB_SCHEMA_V1_HASH;
+
+        // Outside of migrations this should be `Empty`. This step performs no build phases, so we
+        // ensure we do not leave a stale in-progress status behind.
+        metadata.migration_status = MigrationStatus::Empty;
+
+        router.update_metadata(metadata).await?;
+
+        info!("v1.0.0 to v1.1.0 migration complete.");
         Ok(())
     }
 }

--- a/packages/zaino-state/src/chain_index/tests.rs
+++ b/packages/zaino-state/src/chain_index/tests.rs
@@ -3,6 +3,7 @@
 pub(crate) mod finalised_state;
 pub(crate) mod mempool;
 mod proptest_blockgen;
+pub(crate) mod types;
 pub(crate) mod vectors;
 
 pub(crate) fn init_tracing() {

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/migrations.rs
@@ -1,21 +1,25 @@
 //! Holds database migration tests.
 
 use std::path::PathBuf;
+use std::sync::Arc;
 use tempfile::TempDir;
 use zaino_common::network::ActivationHeights;
 use zaino_common::{DatabaseConfig, Network, StorageConfig};
 
 use crate::chain_index::finalised_state::capability::{
-    DbCore as _, DbVersion, DbWrite as _, MigrationStatus,
+    BlockCoreExt as _, DbCore as _, DbRead as _, DbVersion, DbWrite as _, MigrationStatus,
 };
 use crate::chain_index::finalised_state::db::v1::DB_SCHEMA_V1_HASH;
 use crate::chain_index::finalised_state::db::DbBackend;
+use crate::chain_index::finalised_state::entry::StoredEntryVar;
 use crate::chain_index::finalised_state::ZainoDB;
 use crate::chain_index::tests::init_tracing;
 use crate::chain_index::tests::vectors::{
     build_mockchain_source, load_test_vectors, TestVectorData,
 };
-use crate::BlockCacheConfig;
+use crate::{
+    version, BlockCacheConfig, BlockHeaderData, CompactSize, Height, ZainoVersionedSerde as _,
+};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn v0_to_v1_full() {
@@ -289,6 +293,235 @@ async fn v1_0_to_v1_1_metadata_migration() {
     );
     assert_eq!(post_meta.migration_status, MigrationStatus::Empty);
     assert_eq!(post_meta.schema_hash, DB_SCHEMA_V1_HASH);
+
+    zaino_db.shutdown().await.unwrap();
+}
+
+/// Tests that a database containing a mix of V1-encoded and V2-encoded
+/// `BlockHeaderData` entries — which arises when a v1.0.0 deployment is upgraded
+/// to v1.1.0 mid-chain — deserialises every header correctly and returns the right
+/// height for every block.
+///
+/// Scenario:
+///   Phase 1 – write first half of the chain using the normal V2 path, then
+///              backpatch those header entries in LMDB to use the V1 wire format
+///              (simulating a v1.0.0 on-disk state) and downgrade the stored
+///              metadata to 1.0.0.
+///   Phase 2 – reopen with ZainoDB (target 1.1.0); the metadata-only migration
+///              runs, bumping the version without touching the headers table.
+///   Phase 3 – write the second half using the current V2 path.
+///   Phase 4 – assert that every header (V1 or V2 on-disk) deserialises to the
+///              correct height.
+#[tokio::test(flavor = "multi_thread")]
+async fn v1_0_to_v1_1_mixed_blockheaderdata_formats() {
+    init_tracing();
+
+    let TestVectorData { blocks, .. } = load_test_vectors().unwrap();
+
+    // Split at the midpoint so the DB will eventually hold both encoding formats.
+    let split = blocks.len() / 2;
+    let first_half = blocks[..split].to_vec();
+    let second_half = blocks[split..].to_vec();
+
+    let temp_dir: TempDir = tempfile::tempdir().unwrap();
+    let db_path: PathBuf = temp_dir.path().to_path_buf();
+
+    let v1_config = BlockCacheConfig {
+        storage: StorageConfig {
+            database: DatabaseConfig {
+                path: db_path.clone(),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        db_version: 1,
+        network: Network::Regtest(ActivationHeights::default()),
+    };
+
+    let source = build_mockchain_source(blocks.clone());
+
+    // ── Phase 1: build first half (V2 write path), collect headers, downgrade metadata ──
+
+    // Spawn the v1 backend directly so we can call `get_block_header` without
+    // going through ZainoDB's migration logic.
+    let db = DbBackend::spawn_v1(&v1_config).await.unwrap();
+    crate::chain_index::tests::vectors::sync_db_with_blockdata(&db, first_half.clone(), None).await;
+
+    // Wait for the background validator to mark all first-half blocks as known-good
+    // so that `get_block_header` can take the fast path.
+    db.wait_until_ready().await;
+
+    // Read back the decoded headers; we will re-encode them as V1 below.
+    let mut first_half_headers: Vec<(Height, BlockHeaderData)> = Vec::new();
+    for block_data in &first_half {
+        let h = Height(block_data.height);
+        let header = db.get_block_header(h).await.unwrap();
+        first_half_headers.push((h, header));
+    }
+
+    // Downgrade stored metadata to 1.0.0 so ZainoDB::spawn will trigger the
+    // minor migration when we reopen.
+    let mut meta = db.get_metadata().await.unwrap();
+    meta.version = DbVersion {
+        major: 1,
+        minor: 0,
+        patch: 0,
+    };
+    meta.schema_hash = [0u8; 32]; // stale hash; migration will refresh it
+    db.update_metadata(meta).await.unwrap();
+
+    db.shutdown().await.unwrap();
+    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+    // ── Phase 2: overwrite first-half headers with correctly-checksummed V1 bytes ──
+    //
+    // We open the LMDB environment directly (the ZainoDB is shut down, so there is
+    // no active writer) and replace each header entry with bytes that carry a V1-
+    // encoded BlockHeaderData (BlockIndex with *optional* height) and a checksum
+    // computed over those V1 bytes.  After this the `headers_1_0_0` table holds:
+    //
+    //   heights  0 .. split-1  → StoredEntryVar with V1-encoded BlockHeaderData
+    //   heights  split .. N-1  → (not yet written)
+    {
+        use lmdb::{Environment, EnvironmentFlags, Transaction as _, WriteFlags};
+
+        let lmdb_path = db_path.join("regtest").join("v1");
+        let env = Environment::new()
+            .set_max_dbs(12)
+            .set_map_size(128 * 1024 * 1024) // 128 MiB – plenty for the test DB
+            .set_flags(EnvironmentFlags::NO_TLS)
+            .open(&lmdb_path)
+            .unwrap();
+
+        let headers_db = env.open_db(Some("headers_1_0_0")).unwrap();
+        let mut txn = env.begin_rw_txn().unwrap();
+
+        for (height, header) in &first_half_headers {
+            // Key = Height::to_bytes() = [V1 tag][big-endian u32]
+            let height_key = height.to_bytes().unwrap();
+
+            // Re-encode this header using the V1 wire format:
+            //   [V1 tag = 1][BlockIndex V1 body (optional height)][BlockData V1 body]
+            let v1_item_bytes = header.to_bytes_with_version(version::V1).unwrap();
+
+            // Checksum must be computed over the *exact* bytes that will be stored so
+            // that StoredEntryVar::verify() finds a match on its V1 iteration.
+            // checksum = blake2b256(height_key || v1_item_bytes)
+            let checksum = StoredEntryVar::<BlockHeaderData>::blake2b256(
+                &[height_key.as_slice(), v1_item_bytes.as_slice()].concat(),
+            );
+
+            // Build the full LMDB value for a StoredEntryVar<BlockHeaderData>:
+            //   [StoredEntry V1 outer tag][CompactSize(item_len)][item_bytes][32-byte checksum]
+            //
+            // The StoredEntry outer tag is always V1 here because StoredEntryVar::VERSION = V1.
+            // The "V1/V2" distinction lives *inside* item_bytes (the first byte of item_bytes
+            // is the BlockHeaderData version tag).
+            let mut stored_bytes: Vec<u8> = Vec::new();
+            stored_bytes.push(version::V1); // StoredEntryVar outer version tag
+            CompactSize::write(&mut stored_bytes, v1_item_bytes.len()).unwrap();
+            stored_bytes.extend_from_slice(&v1_item_bytes);
+            stored_bytes.extend_from_slice(&checksum);
+
+            // Overwrite the existing V2 entry with the V1 one.
+            txn.put(headers_db, &height_key, &stored_bytes, WriteFlags::empty())
+                .unwrap();
+        }
+
+        txn.commit().unwrap();
+        env.sync(true).unwrap();
+    }
+
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // ── Phase 3: reopen at v1.1.0 – migration runs; write second half (V2) ──
+    //
+    // ZainoDB detects current_version 1.0.0 < target 1.1.0 and runs
+    // Migration1_0_0To1_1_0, which is metadata-only and leaves the headers table
+    // (including our freshly-written V1 entries) untouched.
+    let zaino_db = ZainoDB::spawn(v1_config.clone(), source.clone())
+        .await
+        .unwrap();
+    zaino_db.wait_until_ready().await;
+
+    // Confirm the metadata migration completed correctly.
+    let post_meta = zaino_db.get_metadata().await.unwrap();
+    assert_eq!(
+        post_meta.version,
+        DbVersion {
+            major: 1,
+            minor: 1,
+            patch: 0,
+        },
+        "DB version should be 1.1.0 after migration"
+    );
+    assert_eq!(
+        post_meta.migration_status,
+        MigrationStatus::Empty,
+        "Migration status should be Empty after the metadata-only migration"
+    );
+    assert_eq!(
+        post_meta.schema_hash, DB_SCHEMA_V1_HASH,
+        "Schema hash should be refreshed to the current value"
+    );
+
+    // Write the second half; these use the current (V2) BlockHeaderData format,
+    // so the DB now holds V1 headers at 0..split-1 and V2 headers at split..N-1.
+    crate::chain_index::tests::vectors::sync_db_with_blockdata(
+        zaino_db.router(),
+        second_half.clone(),
+        None,
+    )
+    .await;
+    zaino_db.wait_until_ready().await;
+
+    // ── Phase 4: verify every header decodes correctly with the right height ──
+    //
+    // The initial block scan in the background task has already called
+    // validate_block_blocking() for every height, which internally invokes
+    // StoredEntryVar::verify().  For V1-encoded entries that method tries V2 first
+    // (no match), then V1 (match).  Reaching Ready status here means all blocks
+    // passed validation.
+    let zaino_db = Arc::new(zaino_db);
+    let reader = zaino_db.to_reader();
+
+    // V1-format headers (first half) – these were written before the format bump.
+    for block_data in &first_half {
+        let h = Height(block_data.height);
+        let header = reader
+            .get_block_header(h)
+            .await
+            .unwrap_or_else(|e| panic!("failed to read V1-format header at height {}: {e}", h.0));
+        assert_eq!(
+            header.index().height(),
+            h,
+            "V1-format header at height {} returned wrong height",
+            h.0
+        );
+    }
+
+    // V2-format headers (second half) – written after the migration.
+    for block_data in &second_half {
+        let h = Height(block_data.height);
+        let header = reader
+            .get_block_header(h)
+            .await
+            .unwrap_or_else(|e| panic!("failed to read V2-format header at height {}: {e}", h.0));
+        assert_eq!(
+            header.index().height(),
+            h,
+            "V2-format header at height {} returned wrong height",
+            h.0
+        );
+    }
+
+    // The overall DB tip should cover the full chain.
+    let db_height = zaino_db.db_height().await.unwrap().unwrap();
+    let expected_tip = Height((blocks.len() - 1) as u32);
+    assert_eq!(
+        db_height, expected_tip,
+        "DB tip should be the last block's height after building the full chain"
+    );
 
     zaino_db.shutdown().await.unwrap();
 }

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/migrations.rs
@@ -5,7 +5,10 @@ use tempfile::TempDir;
 use zaino_common::network::ActivationHeights;
 use zaino_common::{DatabaseConfig, Network, StorageConfig};
 
-use crate::chain_index::finalised_state::capability::DbCore as _;
+use crate::chain_index::finalised_state::capability::{
+    DbCore as _, DbVersion, DbWrite as _, MigrationStatus,
+};
+use crate::chain_index::finalised_state::db::v1::DB_SCHEMA_V1_HASH;
 use crate::chain_index::finalised_state::db::DbBackend;
 use crate::chain_index::finalised_state::ZainoDB;
 use crate::chain_index::tests::init_tracing;
@@ -206,4 +209,86 @@ async fn v0_to_v1_partial() {
     let db_height = dbg!(zaino_db_2.db_height().await.unwrap()).unwrap();
     assert_eq!(db_height.0, 200);
     dbg!(zaino_db_2.shutdown().await.unwrap());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn v1_0_to_v1_1_metadata_migration() {
+    init_tracing();
+
+    // Prepare test blocks/source (we won't rely on heavy rebuild in this metadata-only migration)
+    let TestVectorData { blocks, .. } = load_test_vectors().unwrap();
+
+    let temp_dir: TempDir = tempfile::tempdir().unwrap();
+    let db_path: PathBuf = temp_dir.path().to_path_buf();
+
+    // BlockCacheConfig: use v1 target like other tests
+    let v1_config = BlockCacheConfig {
+        storage: StorageConfig {
+            database: DatabaseConfig {
+                path: db_path.clone(),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        db_version: 1,
+        network: Network::Regtest(ActivationHeights::default()),
+    };
+
+    let source = build_mockchain_source(blocks.clone());
+
+    // Build v1 database.
+    let zaino_db = ZainoDB::spawn(v1_config.clone(), source.clone())
+        .await
+        .unwrap();
+    crate::chain_index::tests::vectors::sync_db_with_blockdata(
+        zaino_db.router(),
+        blocks.clone(),
+        None,
+    )
+    .await;
+
+    zaino_db.wait_until_ready().await;
+    dbg!(zaino_db.status());
+    dbg!(zaino_db.db_height().await.unwrap());
+
+    // 2) Coerce the metadata to look like an older 1.0.0 DB with a stale schema hash and an
+    //    in-progress migration status so the migration has work to do.
+    let mut metadata = zaino_db.get_metadata().await.unwrap();
+    metadata.version = DbVersion {
+        major: 1,
+        minor: 0,
+        patch: 0,
+    };
+    // An obviously different schema hash (any non-matching 32 bytes will do)
+    metadata.schema_hash = [0u8; 32];
+    // Set a non-empty migration status to ensure migration clears it
+    metadata.migration_status = MigrationStatus::PartialBuidInProgress;
+
+    zaino_db.router().update_metadata(metadata).await.unwrap();
+
+    // shutdown this backend so ZainoDB::spawn will open the same DB and perform migration
+    dbg!(zaino_db.shutdown().await.unwrap());
+
+    // Let the filesystem settle (tests elsewhere do a brief sleep)
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // 3) Spawn ZainoDB which should detect current_version == 1.0.0 < target 1.1.0 and run the metadata
+    //    migration. We await until ready so migration completes.
+    let zaino_db = ZainoDB::spawn(v1_config, source).await.unwrap();
+    zaino_db.wait_until_ready().await;
+
+    // 4) Read persisted metadata and assert migration effects.
+    let post_meta = zaino_db.get_metadata().await.unwrap();
+    assert_eq!(
+        post_meta.version,
+        DbVersion {
+            major: 1,
+            minor: 1,
+            patch: 0
+        }
+    );
+    assert_eq!(post_meta.migration_status, MigrationStatus::Empty);
+    assert_eq!(post_meta.schema_hash, DB_SCHEMA_V1_HASH);
+
+    zaino_db.shutdown().await.unwrap();
 }

--- a/packages/zaino-state/src/chain_index/tests/types.rs
+++ b/packages/zaino-state/src/chain_index/tests/types.rs
@@ -1,0 +1,34 @@
+//! Unit tests for Zaino-state::ChainIndex::types and encoding.
+
+use crate::{chain_index::tests::init_tracing, version, BlockIndex, ZainoVersionedSerde as _};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn blockindex_v1_v2_serde() {
+    init_tracing();
+
+    // Build canonical components
+    let hash = crate::BlockHash::from([1u8; 32]);
+    let parent_hash = crate::BlockHash::from([2u8; 32]);
+    let chainwork = crate::ChainWork::from_u256(0.into());
+    let height = crate::Height(42);
+
+    // Create a BlockIndex value
+    let bidx = BlockIndex::new(hash, parent_hash, chainwork, height);
+
+    // Produce v1 bytes using the new versioned encode API (tag + body)
+    let v1_bytes = bidx
+        .to_bytes_with_version(version::V1)
+        .expect("v1 to_bytes_with_version");
+
+    // Parse v1 bytes using the new BlockIndex deserialiser — should succeed and produce same height.
+    let parsed_v1 = BlockIndex::from_bytes(&v1_bytes).expect("decode v1 BlockIndex");
+    assert_eq!(parsed_v1, bidx);
+
+    // Now round-trip a v2 BlockIndex (current writer). BlockIndex::to_bytes() writes V2.
+    let v2_bytes = bidx.to_bytes().expect("v2 to_bytes");
+    let parsed_v2 = BlockIndex::from_bytes(&v2_bytes).expect("decode v2 BlockIndex");
+    assert_eq!(parsed_v2, bidx);
+
+    // sanity: v1 and v2 encodings must differ
+    assert_ne!(v1_bytes, v2_bytes, "v1 and v2 encodings should differ");
+}

--- a/packages/zaino-state/src/chain_index/tests/types.rs
+++ b/packages/zaino-state/src/chain_index/tests/types.rs
@@ -1,6 +1,9 @@
 //! Unit tests for Zaino-state::ChainIndex::types and encoding.
 
-use crate::{chain_index::tests::init_tracing, version, BlockIndex, ZainoVersionedSerde as _};
+use crate::{
+    chain_index::{tests::init_tracing, types::EquihashSolution},
+    version, BlockData, BlockHeaderData, BlockIndex, ZainoVersionedSerde as _,
+};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn blockindex_v1_v2_serde() {
@@ -28,6 +31,44 @@ async fn blockindex_v1_v2_serde() {
     let v2_bytes = bidx.to_bytes().expect("v2 to_bytes");
     let parsed_v2 = BlockIndex::from_bytes(&v2_bytes).expect("decode v2 BlockIndex");
     assert_eq!(parsed_v2, bidx);
+
+    // sanity: v1 and v2 encodings must differ
+    assert_ne!(v1_bytes, v2_bytes, "v1 and v2 encodings should differ");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn blockheaderdata_v1_v2_serde() {
+    init_tracing();
+
+    // Build canonical components
+    let hash = crate::BlockHash::from([1u8; 32]);
+    let parent_hash = crate::BlockHash::from([2u8; 32]);
+    let chainwork = crate::ChainWork::from_u256(0.into());
+    let height = crate::Height(42);
+    let solution = EquihashSolution::Standard([6u8; 1344]);
+
+    // Create a BlockIndex value
+    let bidx = BlockIndex::new(hash, parent_hash, chainwork, height);
+
+    // create BlockData value
+    let bdata = BlockData::new(1, 2, [3u8; 32], [4u8; 32], 3, [5u8; 32], solution);
+
+    // Create BlockHeader value:
+    let bheader = BlockHeaderData::new(bidx, bdata);
+
+    // Produce v1 bytes using the new versioned encode API (tag + body):w
+    let v1_bytes = bheader
+        .to_bytes_with_version(version::V1)
+        .expect("v1 to_bytes_with_version");
+
+    // Parse v1 bytes using the new BlockIndex deserialiser — should succeed and produce same height.
+    let parsed_v1 = BlockHeaderData::from_bytes(&v1_bytes).expect("decode v1 BlockHeaderData");
+    assert_eq!(parsed_v1, bheader);
+
+    // Now round-trip a v2 BlockIndex (current writer). BlockIndex::to_bytes() writes V2.
+    let v2_bytes = bheader.to_bytes().expect("v2 to_bytes");
+    let parsed_v2 = BlockHeaderData::from_bytes(&v2_bytes).expect("decode v2 BlockHeaderData");
+    assert_eq!(parsed_v2, bheader);
 
     // sanity: v1 and v2 encodings must differ
     assert_ne!(v1_bytes, v2_bytes, "v1 and v2 encodings should differ");

--- a/packages/zaino-state/src/chain_index/types/db/commitment.rs
+++ b/packages/zaino-state/src/chain_index/types/db/commitment.rs
@@ -41,14 +41,18 @@ impl CommitmentTreeData {
 impl ZainoVersionedSerde for CommitmentTreeData {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        let mut w = w;
-        self.roots.serialize(&mut w)?; // carries its own tag
-        self.sizes.serialize(&mut w)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        let mut w = w;
+        self.roots.serialize(&mut w)?; // carries its own tag
+        self.sizes.serialize(&mut w)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -97,14 +101,18 @@ impl CommitmentTreeRoots {
 impl ZainoVersionedSerde for CommitmentTreeRoots {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        let mut w = w;
-        write_fixed_le::<32, _>(&mut w, &self.sapling)?;
-        write_fixed_le::<32, _>(&mut w, &self.orchard)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        let mut w = w;
+        write_fixed_le::<32, _>(&mut w, &self.sapling)?;
+        write_fixed_le::<32, _>(&mut w, &self.orchard)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -151,14 +159,18 @@ impl CommitmentTreeSizes {
 impl ZainoVersionedSerde for CommitmentTreeSizes {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        let mut w = w;
-        write_u32_le(&mut w, self.sapling)?;
-        write_u32_le(&mut w, self.orchard)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        let mut w = w;
+        write_u32_le(&mut w, self.sapling)?;
+        write_u32_le(&mut w, self.orchard)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {

--- a/packages/zaino-state/src/chain_index/types/db/legacy.rs
+++ b/packages/zaino-state/src/chain_index/types/db/legacy.rs
@@ -181,12 +181,16 @@ impl From<zcash_primitives::block::BlockHash> for BlockHash {
 impl ZainoVersionedSerde for BlockHash {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        write_fixed_le::<32, _>(w, &self.0)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        write_fixed_le::<32, _>(w, &self.0)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -315,12 +319,16 @@ impl From<zcash_primitives::transaction::TxId> for TransactionHash {
 impl ZainoVersionedSerde for TransactionHash {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        write_fixed_le::<32, _>(w, &self.0)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        write_fixed_le::<32, _>(w, &self.0)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -452,13 +460,17 @@ impl TryFrom<zcash_protocol::consensus::BlockHeight> for Height {
 impl ZainoVersionedSerde for Height {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        // Height must sort lexicographically - write **big-endian**
-        write_u32_be(w, self.0)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        // Height must sort lexicographically - write **big-endian**
+        write_u32_be(w, self.0)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -484,13 +496,17 @@ pub struct ShardIndex(pub u32);
 impl ZainoVersionedSerde for ShardIndex {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        // Index must sort lexicographically - write **big-endian**
-        write_u32_be(w, self.0)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        // Index must sort lexicographically - write **big-endian**
+        write_u32_be(w, self.0)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -604,13 +620,17 @@ impl From<AddrScript> for [u8; 21] {
 impl ZainoVersionedSerde for AddrScript {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        write_fixed_le::<20, _>(&mut *w, &self.hash)?;
-        w.write_all(&[self.script_type])
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        write_fixed_le::<20, _>(&mut *w, &self.hash)?;
+        w.write_all(&[self.script_type])
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -669,14 +689,18 @@ impl Outpoint {
 impl ZainoVersionedSerde for Outpoint {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        let mut w = w;
-        write_fixed_le::<32, _>(&mut w, &self.prev_txid)?;
-        write_u32_le(&mut w, self.prev_index)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        let mut w = w;
+        write_fixed_le::<32, _>(&mut w, &self.prev_txid)?;
+        write_u32_le(&mut w, self.prev_index)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -749,17 +773,32 @@ impl BlockIndex {
 impl ZainoVersionedSerde for BlockIndex {
     const VERSION: u8 = version::V2;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        let mut w = w;
-
-        self.hash.serialize(&mut w)?;
-        self.parent_hash.serialize(&mut w)?;
-        self.chainwork.serialize(&mut w)?;
-        self.height.serialize(&mut *w)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v2(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v2(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        let mut w = w;
+
+        self.hash.serialize_with_version(&mut w, 1)?;
+        self.parent_hash.serialize_with_version(&mut w, 1)?;
+        self.chainwork.serialize_with_version(&mut w, 1)?;
+        write_option(&mut w, &Some(self.height), |w, h| {
+            h.serialize_with_version(w, 1)
+        })
+    }
+
+    fn encode_v2<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        let mut w = w;
+
+        self.hash.serialize_with_version(&mut w, 1)?;
+        self.parent_hash.serialize_with_version(&mut w, 1)?;
+        self.chainwork.serialize_with_version(&mut w, 1)?;
+        self.height.serialize_with_version(&mut w, 1)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -838,12 +877,16 @@ impl fmt::Display for ChainWork {
 impl ZainoVersionedSerde for ChainWork {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        write_fixed_le::<32, _>(w, &self.0)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        write_fixed_le::<32, _>(w, &self.0)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -1004,7 +1047,15 @@ impl BlockData {
 impl ZainoVersionedSerde for BlockData {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
+    }
+
+    fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
+        Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
         let mut w = w; // re-borrow
 
         write_u32_le(&mut w, self.version)?;
@@ -1016,11 +1067,7 @@ impl ZainoVersionedSerde for BlockData {
         write_u32_le(&mut w, self.bits)?;
         write_fixed_le::<32, _>(&mut w, &self.nonce)?;
 
-        self.solution.serialize(&mut w)
-    }
-
-    fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
-        Self::decode_v1(r)
+        self.solution.serialize_with_version(&mut w, 1)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -1113,7 +1160,15 @@ impl<'a> TryFrom<&'a [u8]> for EquihashSolution {
 impl ZainoVersionedSerde for EquihashSolution {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
+    }
+
+    fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
+        Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
         let mut w = w;
 
         match self {
@@ -1126,10 +1181,6 @@ impl ZainoVersionedSerde for EquihashSolution {
                 write_fixed_le::<36, _>(&mut w, bytes)
             }
         }
-    }
-
-    fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
-        Self::decode_v1(r)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -1268,15 +1319,21 @@ impl IndexedBlock {
 impl ZainoVersionedSerde for IndexedBlock {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, mut w: &mut W) -> io::Result<()> {
-        self.index.serialize(&mut w)?;
-        self.data.serialize(&mut w)?;
-        write_vec(&mut w, &self.transactions, |w, tx| tx.serialize(w))?;
-        self.commitment_tree_data.serialize(&mut w)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, mut w: &mut W) -> io::Result<()> {
+        self.index.serialize_with_version(&mut w, 1)?;
+        self.data.serialize_with_version(&mut w, 1)?;
+        write_vec(&mut w, &self.transactions, |w, tx| {
+            tx.serialize_with_version(w, 1)
+        })?;
+        self.commitment_tree_data.serialize_with_version(&mut w, 1)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -1675,17 +1732,21 @@ impl TryFrom<(u64, zaino_fetch::chain::transaction::FullTransaction)> for Compac
 impl ZainoVersionedSerde for CompactTxData {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, mut w: &mut W) -> io::Result<()> {
-        write_u64_le(&mut w, self.index)?;
-
-        self.txid.serialize(&mut w)?;
-        self.transparent.serialize(&mut w)?;
-        self.sapling.serialize(&mut w)?;
-        self.orchard.serialize(&mut w)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, mut w: &mut W) -> io::Result<()> {
+        write_u64_le(&mut w, self.index)?;
+
+        self.txid.serialize_with_version(&mut w, 1)?;
+        self.transparent.serialize_with_version(&mut w, 1)?;
+        self.sapling.serialize_with_version(&mut w, 1)?;
+        self.orchard.serialize_with_version(&mut w, 1)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -1720,15 +1781,23 @@ pub struct TransparentCompactTx {
 impl ZainoVersionedSerde for TransparentCompactTx {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        let mut w = w;
-
-        write_vec(&mut w, &self.vin, |w, txin| txin.serialize(w))?;
-        write_vec(&mut w, &self.vout, |w, txout| txout.serialize(w))
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        let mut w = w;
+
+        write_vec(&mut w, &self.vin, |w, txin| {
+            txin.serialize_with_version(w, 1)
+        })?;
+        write_vec(&mut w, &self.vout, |w, txout| {
+            txout.serialize_with_version(w, 1)
+        })
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -1830,14 +1899,18 @@ impl TxInCompact {
 impl ZainoVersionedSerde for TxInCompact {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        let mut w = w;
-        write_fixed_le::<32, _>(&mut w, &self.prevout_txid)?;
-        write_u32_le(&mut w, self.prevout_index)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        let mut w = w;
+        write_fixed_le::<32, _>(&mut w, &self.prevout_txid)?;
+        write_u32_le(&mut w, self.prevout_index)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -1893,12 +1966,16 @@ impl ScriptType {
 impl ZainoVersionedSerde for ScriptType {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        w.write_all(&[*self as u8])
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        w.write_all(&[*self as u8])
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -2060,15 +2137,19 @@ impl<T: AsRef<[u8]>> TryFrom<(u64, T)> for TxOutCompact {
 impl ZainoVersionedSerde for TxOutCompact {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        let mut w = w;
-        write_u64_le(&mut w, self.value)?;
-        write_fixed_le::<20, _>(&mut w, &self.script_hash)?;
-        w.write_all(&[self.script_type])
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        let mut w = w;
+        write_u64_le(&mut w, self.value)?;
+        write_fixed_le::<20, _>(&mut w, &self.script_hash)?;
+        w.write_all(&[self.script_type])
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -2134,16 +2215,20 @@ impl SaplingCompactTx {
 impl ZainoVersionedSerde for SaplingCompactTx {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        let mut w = w;
-
-        write_option(&mut w, &self.value, |w, v| write_i64_le(w, *v))?;
-        write_vec(&mut w, &self.spends, |w, s| s.serialize(w))?;
-        write_vec(&mut w, &self.outputs, |w, o| o.serialize(w))
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        let mut w = w;
+
+        write_option(&mut w, &self.value, |w, v| write_i64_le(w, *v))?;
+        write_vec(&mut w, &self.spends, |w, s| s.serialize_with_version(w, 1))?;
+        write_vec(&mut w, &self.outputs, |w, o| o.serialize_with_version(w, 1))
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -2187,12 +2272,16 @@ impl CompactSaplingSpend {
 impl ZainoVersionedSerde for CompactSaplingSpend {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        write_fixed_le::<32, _>(w, &self.nf)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        write_fixed_le::<32, _>(w, &self.nf)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -2257,15 +2346,19 @@ impl CompactSaplingOutput {
 impl ZainoVersionedSerde for CompactSaplingOutput {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        let mut w = w;
-        write_fixed_le::<32, _>(&mut w, &self.cmu)?;
-        write_fixed_le::<32, _>(&mut w, &self.ephemeral_key)?;
-        write_fixed_le::<52, _>(&mut w, &self.ciphertext)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        let mut w = w;
+        write_fixed_le::<32, _>(&mut w, &self.cmu)?;
+        write_fixed_le::<32, _>(&mut w, &self.ephemeral_key)?;
+        write_fixed_le::<52, _>(&mut w, &self.ciphertext)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -2313,15 +2406,19 @@ impl OrchardCompactTx {
 impl ZainoVersionedSerde for OrchardCompactTx {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        let mut w = w;
-
-        write_option(&mut w, &self.value, |w, v| write_i64_le(w, *v))?;
-        write_vec(&mut w, &self.actions, |w, a| a.serialize(w))
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        let mut w = w;
+
+        write_option(&mut w, &self.value, |w, v| write_i64_le(w, *v))?;
+        write_vec(&mut w, &self.actions, |w, a| a.serialize_with_version(w, 1))
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -2399,16 +2496,20 @@ impl CompactOrchardAction {
 impl ZainoVersionedSerde for CompactOrchardAction {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
+    }
+
+    fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
+        Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
         let mut w = w;
         write_fixed_le::<32, _>(&mut w, &self.nullifier)?;
         write_fixed_le::<32, _>(&mut w, &self.cmx)?;
         write_fixed_le::<32, _>(&mut w, &self.ephemeral_key)?;
         write_fixed_le::<52, _>(&mut w, &self.ciphertext)
-    }
-
-    fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
-        Self::decode_v1(r)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -2460,13 +2561,17 @@ impl TxLocation {
 impl ZainoVersionedSerde for TxLocation {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        write_u32_be(&mut *w, self.block_height)?;
-        write_u16_be(&mut *w, self.tx_index)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        write_u32_be(&mut *w, self.block_height)?;
+        write_u16_be(&mut *w, self.tx_index)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -2554,15 +2659,19 @@ impl AddrHistRecord {
 impl ZainoVersionedSerde for AddrHistRecord {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        self.tx_location.serialize(&mut *w)?;
-        write_u16_be(&mut *w, self.out_index)?;
-        w.write_all(&[self.flags])?;
-        write_u64_le(&mut *w, self.value)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        self.tx_location.serialize_with_version(&mut *w, 1)?;
+        write_u16_be(&mut *w, self.out_index)?;
+        w.write_all(&[self.flags])?;
+        write_u64_le(&mut *w, self.value)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -2657,12 +2766,16 @@ impl AddrEventBytes {
 impl ZainoVersionedSerde for AddrEventBytes {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        write_fixed_le::<17, _>(w, &self.0)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        write_fixed_le::<17, _>(w, &self.0)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -2726,15 +2839,19 @@ impl ShardRoot {
 impl ZainoVersionedSerde for ShardRoot {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        let mut w = w;
-        write_fixed_le::<32, _>(&mut w, &self.hash)?;
-        write_fixed_le::<32, _>(&mut w, &self.final_block_hash)?;
-        write_u32_le(&mut w, self.final_block_height)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        let mut w = w;
+        write_fixed_le::<32, _>(&mut w, &self.hash)?;
+        write_fixed_le::<32, _>(&mut w, &self.final_block_hash)?;
+        write_u32_le(&mut w, self.final_block_height)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -2783,21 +2900,34 @@ impl BlockHeaderData {
 }
 
 impl ZainoVersionedSerde for BlockHeaderData {
-    const VERSION: u8 = version::V1;
+    const VERSION: u8 = version::V2;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        self.index.serialize(&mut *w)?;
-        self.data.serialize(w)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v2(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
-        Self::decode_v1(r)
+        Self::decode_v2(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        self.index.serialize_with_version(&mut *w, 1)?;
+        self.data.serialize_with_version(w, 1)
+    }
+
+    fn encode_v2<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        self.index.serialize_with_version(&mut *w, 2)?;
+        self.data.serialize_with_version(w, 1)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
         let index = BlockIndex::deserialize(&mut *r)?;
         let data = BlockData::deserialize(r)?;
         Ok(BlockHeaderData::new(index, data))
+    }
+
+    fn decode_v2<R: Read>(r: &mut R) -> io::Result<Self> {
+        Self::decode_v1(r)
     }
 }
 
@@ -2824,12 +2954,16 @@ impl TxidList {
 impl ZainoVersionedSerde for TxidList {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        write_vec(w, &self.txids, |w, h| h.serialize(w))
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        write_vec(w, &self.txids, |w, h| h.serialize_with_version(w, 1))
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -2895,14 +3029,18 @@ impl TransparentTxList {
 impl ZainoVersionedSerde for TransparentTxList {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        write_vec(w, &self.tx, |w, opt| {
-            write_option(w, opt, |w, t| t.serialize(w))
-        })
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        write_vec(w, &self.tx, |w, opt| {
+            write_option(w, opt, |w, t| t.serialize_with_version(w, 1))
+        })
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -2974,14 +3112,18 @@ impl SaplingTxList {
 impl ZainoVersionedSerde for SaplingTxList {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        write_vec(w, &self.tx, |w, opt| {
-            write_option(w, opt, |w, t| t.serialize(w))
-        })
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        write_vec(w, &self.tx, |w, opt| {
+            write_option(w, opt, |w, t| t.serialize_with_version(w, 1))
+        })
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -3045,14 +3187,18 @@ impl OrchardTxList {
 impl ZainoVersionedSerde for OrchardTxList {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        write_vec(w, &self.tx, |w, opt| {
-            write_option(w, opt, |w, t| t.serialize(w))
-        })
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        write_vec(w, &self.tx, |w, opt| {
+            write_option(w, opt, |w, t| t.serialize_with_version(w, 1))
+        })
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {

--- a/packages/zaino-state/src/chain_index/types/db/legacy.rs
+++ b/packages/zaino-state/src/chain_index/types/db/legacy.rs
@@ -747,7 +747,7 @@ impl BlockIndex {
 }
 
 impl ZainoVersionedSerde for BlockIndex {
-    const VERSION: u8 = version::V1;
+    const VERSION: u8 = version::V2;
 
     fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
         let mut w = w;
@@ -755,12 +755,11 @@ impl ZainoVersionedSerde for BlockIndex {
         self.hash.serialize(&mut w)?;
         self.parent_hash.serialize(&mut w)?;
         self.chainwork.serialize(&mut w)?;
-
-        write_option(&mut w, &Some(self.height), |w, h| h.serialize(w))
+        self.height.serialize(&mut *w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
-        Self::decode_v1(r)
+        Self::decode_v2(r)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {
@@ -768,14 +767,19 @@ impl ZainoVersionedSerde for BlockIndex {
         let hash = BlockHash::deserialize(&mut r)?;
         let parent_hash = BlockHash::deserialize(&mut r)?;
         let chainwork = ChainWork::deserialize(&mut r)?;
-        let height = read_option(&mut r, |r| Height::deserialize(r))?;
+        let height =
+            read_option(&mut r, |r| Height::deserialize(r))?.expect("blocks always have height");
 
-        Ok(BlockIndex::new(
-            hash,
-            parent_hash,
-            chainwork,
-            height.expect("blocks always have height"),
-        ))
+        Ok(BlockIndex::new(hash, parent_hash, chainwork, height))
+    }
+
+    fn decode_v2<R: Read>(r: &mut R) -> io::Result<Self> {
+        let mut r = r;
+        let hash = BlockHash::deserialize(&mut r)?;
+        let parent_hash = BlockHash::deserialize(&mut r)?;
+        let chainwork = ChainWork::deserialize(&mut r)?;
+        let height = Height::deserialize(&mut r)?;
+        Ok(BlockIndex::new(hash, parent_hash, chainwork, height))
     }
 }
 

--- a/packages/zaino-state/src/chain_index/types/db/metadata.rs
+++ b/packages/zaino-state/src/chain_index/types/db/metadata.rs
@@ -18,15 +18,19 @@ pub struct MempoolInfo {
 impl ZainoVersionedSerde for MempoolInfo {
     const VERSION: u8 = version::V1;
 
-    fn encode_body<W: Write>(&self, w: &mut W) -> io::Result<()> {
-        let mut w = w;
-        write_u64_le(&mut w, self.size)?;
-        write_u64_le(&mut w, self.bytes)?;
-        write_u64_le(&mut w, self.usage)
+    fn encode_latest<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        Self::encode_v1(self, w)
     }
 
     fn decode_latest<R: Read>(r: &mut R) -> io::Result<Self> {
         Self::decode_v1(r)
+    }
+
+    fn encode_v1<W: Write>(&self, w: &mut W) -> io::Result<()> {
+        let mut w = w;
+        write_u64_le(&mut w, self.size)?;
+        write_u64_le(&mut w, self.bytes)?;
+        write_u64_le(&mut w, self.usage)
     }
 
     fn decode_v1<R: Read>(r: &mut R) -> io::Result<Self> {


### PR DESCRIPTION
Context:
https://github.com/zingolabs/zaino/pull/787 updated the height field of the BlockIndex struct but did not implement this change as a V2 serialisation schema. It was not possible to implement v2 at the time due to https://github.com/zingolabs/zaino/issues/945, the serde was left in place and conversion handled in the impl, this was safe but serde should be updated in a v2 to avoid future bugs.

This PR fixes #945 and updates the serde of BlockHeaderData to both bring db serialisation in line with th defined contract and provide a proof of execution of the solution implemented.

---

Changes in this PR:
- Update `ZainoVersionedSerde` to provide serialisation of legacy formats, required for checksum validation of legacy formats used in the database (previously only deserialisation of legacy formats was possible).
- Update ZainoVersionedSerde impls in codebase (no actual format changes, these changes are purely additive).
- Add BlockHeaderData and BlockIndex v2.
- Update StoredEntry verification to work with legacy versions.
- Add encoding and StoredEntry unit tests.
- Add unit tests for BlockHeaderData and BlockIndex v1<->v2 serde.
- Update database version and add migration (metedata update only).
- Add metadata migration unit test.
- Add "mixed format database table" test (validating that the "headers" table in ZainoDB works as expcted when holding both v1 and v2 BlockHeaderData structs)
- Add ZainoDB changelog entry.

NOTE: 
Because BlockHeaderData is stored in a [`StoredEntryVar`], and the headers lmdb table does not use fixed length optimisations, it is possible for us to simply provide the new serde implementation. 

When ZainoDB has been partially built before this update, the headers table will hold a mix of V1 and V2 BlockHeaderData structs' and `ZainoVersionedSere will handle version safe de serialisation.

When a fresh ZainoDB is built, V2 BlockHeaderData serde will be used throughout.

---

- Closes #945 
- Replaces #828 

---

After this PR, updating a struct in a db table that does not utilise "fixed sized field" performance improvements (the majority of the database falls into this category) will only require:
- implementing serde for the new version of the struct 
- updating database metadata / version
(No logic updates required, fully handled by `ZainoVersionedSerde`)