### PR TITLE
add new mempool tests (stale requested chain tip)

### DIFF
--- a/integration-tests/tests/chain_cache.rs
+++ b/integration-tests/tests/chain_cache.rs
@@ -77,6 +77,7 @@ mod chain_query_interface {
         },
         serialization::{ZcashDeserialize, ZcashDeserializeInto},
     };
+    use zaino_state::test_dependencies::chain_index::non_finalised_state::BestTip;
 
     use super::*;
 
@@ -185,16 +186,19 @@ mod chain_query_interface {
                         test_manager.local_net.get_activation_heights().await,
                     )),
                 };
-                let chain_index = NodeBackedChainIndex::new(
-                    ValidatorConnector::State(chain_index::source::State {
-                        read_state_service: state_service.read_state_service().clone(),
-                        mempool_fetcher: json_service.clone(),
-                        network: config.network,
-                    }),
-                    config,
-                )
-                .await
-                .unwrap();
+
+                // **NOTE** The "fetch" backend is currently the backend used in the wild, and
+                // by zallet, although we want to push the community to transition to the
+                // "state" backend these tests using the "fetch" backend is currently useful
+                // for debugging bugs raised byt zallet devs.
+                let source = ValidatorConnector::Fetch(json_service.clone());
+                // let source = ValidatorConnector::State(chain_index::source::State {
+                //     read_state_service: state_service.read_state_service().clone(),
+                //     mempool_fetcher: json_service.clone(),
+                //     network: config.network,
+                // });
+                let chain_index = NodeBackedChainIndex::new(source, config).await.unwrap();
+
                 let index_reader = chain_index.subscriber();
                 tokio::time::sleep(Duration::from_secs(3)).await;
 
@@ -236,7 +240,7 @@ mod chain_query_interface {
         }
     }
 
-    #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
+    // #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
     #[tokio::test(flavor = "multi_thread")]
     async fn get_block_range_zebrad() {
         get_block_range::<Zebrad, StateService>(&ValidatorKind::Zebrad).await
@@ -245,7 +249,7 @@ mod chain_query_interface {
     #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
     #[tokio::test(flavor = "multi_thread")]
     async fn get_block_range_zcashd() {
-        get_block_range::<Zcashd, StateService>(&ValidatorKind::Zcashd).await
+        get_block_range::<Zcashd, FetchService>(&ValidatorKind::Zcashd).await
     }
 
     async fn get_block_range<C, Service>(validator: &ValidatorKind)
@@ -289,7 +293,7 @@ mod chain_query_interface {
         }
     }
 
-    #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
+    // #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
     #[tokio::test(flavor = "multi_thread")]
     async fn find_fork_point_zebrad() {
         find_fork_point::<Zebrad, StateService>(&ValidatorKind::Zebrad).await
@@ -298,7 +302,7 @@ mod chain_query_interface {
     #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
     #[tokio::test(flavor = "multi_thread")]
     async fn find_fork_point_zcashd() {
-        find_fork_point::<Zcashd, StateService>(&ValidatorKind::Zcashd).await
+        find_fork_point::<Zcashd, FetchService>(&ValidatorKind::Zcashd).await
     }
 
     async fn find_fork_point<C, Service>(validator: &ValidatorKind)
@@ -333,7 +337,7 @@ mod chain_query_interface {
         }
     }
 
-    #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
+    // #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
     #[tokio::test(flavor = "multi_thread")]
     async fn get_raw_transaction_zebrad() {
         get_raw_transaction::<Zebrad, StateService>(&ValidatorKind::Zebrad).await
@@ -342,7 +346,7 @@ mod chain_query_interface {
     #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
     #[tokio::test(flavor = "multi_thread")]
     async fn get_raw_transaction_zcashd() {
-        get_raw_transaction::<Zcashd, StateService>(&ValidatorKind::Zcashd).await
+        get_raw_transaction::<Zcashd, FetchService>(&ValidatorKind::Zcashd).await
     }
 
     async fn get_raw_transaction<C, Service>(validator: &ValidatorKind)
@@ -398,7 +402,7 @@ mod chain_query_interface {
         }
     }
 
-    #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
+    // #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
     #[tokio::test(flavor = "multi_thread")]
     async fn get_transaction_status_zebrad() {
         get_transaction_status::<Zebrad, StateService>(&ValidatorKind::Zebrad).await
@@ -407,7 +411,7 @@ mod chain_query_interface {
     #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
     #[tokio::test(flavor = "multi_thread")]
     async fn get_transaction_status_zcashd() {
-        get_transaction_status::<Zcashd, StateService>(&ValidatorKind::Zcashd).await
+        get_transaction_status::<Zcashd, FetchService>(&ValidatorKind::Zcashd).await
     }
 
     async fn get_transaction_status<C, Service>(validator: &ValidatorKind)
@@ -456,7 +460,7 @@ mod chain_query_interface {
     #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
     #[tokio::test(flavor = "multi_thread")]
     async fn sync_large_chain_zcashd() {
-        sync_large_chain::<Zcashd, StateService>(&ValidatorKind::Zcashd).await
+        sync_large_chain::<Zcashd, FetchService>(&ValidatorKind::Zcashd).await
     }
 
     async fn sync_large_chain<C, Service>(validator: &ValidatorKind)
@@ -532,6 +536,7 @@ mod chain_query_interface {
         }
     }
 
+    // #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
     #[tokio::test(flavor = "multi_thread")]
     async fn get_subtree_roots_zebrad() {
         get_subtree_roots::<Zebrad, StateService>(&ValidatorKind::Zebrad).await
@@ -636,5 +641,189 @@ mod chain_query_interface {
             valid_chain_index_subtree_roots_response,
             formatted_valid_validator_subtree_roots
         );
+    }
+
+    // #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_mempool_stream_fresh_snapshot_repeated_zebrad() {
+        get_mempool_stream_fresh_snapshot_repeated::<Zebrad, FetchService>(&ValidatorKind::Zebrad)
+            .await
+    }
+
+    #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_mempool_stream_fresh_snapshot_repeated_zcashd() {
+        get_mempool_stream_fresh_snapshot_repeated::<Zcashd, FetchService>(&ValidatorKind::Zcashd)
+            .await
+    }
+
+    async fn get_mempool_stream_fresh_snapshot_repeated<C, Service>(validator: &ValidatorKind)
+    where
+        C: ValidatorExt,
+        Service: zaino_state::ZcashService<Config: TryFrom<ZainodConfig, Error = IndexerError>>
+            + Send
+            + Sync
+            + 'static,
+        IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
+    {
+        use futures::StreamExt as _;
+        use tokio::time::{timeout, Duration};
+
+        let (test_manager, _json_service, _option_state_service, _chain_index, indexer) =
+            create_test_manager_and_chain_index::<C, Service>(validator, None, false, false).await;
+
+        test_manager
+            .generate_blocks_and_poll_chain_index(5, &indexer)
+            .await;
+
+        for iteration in 0..5 {
+            let snapshot = indexer.snapshot_nonfinalized_state();
+            let snapshot_tip = snapshot.best_tip;
+
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            let mut mempool_stream =
+                indexer
+                    .get_mempool_stream(Some(&snapshot))
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "fresh snapshot unexpectedly returned None on iteration {iteration}: \
+                     snapshot best tip height={:?} hash={:?}",
+                            snapshot_tip.height, snapshot_tip.blockhash,
+                        )
+                    });
+
+            test_manager
+                .generate_blocks_and_poll_chain_index(1, &indexer)
+                .await;
+
+            timeout(Duration::from_secs(20), async {
+                while let Some(item) = mempool_stream.next().await {
+                    item.expect("mempool stream yielded unexpected error");
+                }
+            })
+            .await
+            .expect("mempool stream did not close after chain tip changed");
+        }
+    }
+
+    // #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn zallet_like_steady_state_loop_zebrad() {
+        zallet_like_steady_state_loop::<Zebrad, FetchService>(&ValidatorKind::Zebrad).await
+    }
+
+    #[ignore = "prone to timeouts and hangs, to be fixed in chain index integration"]
+    #[tokio::test(flavor = "multi_thread")]
+    async fn zallet_like_steady_state_loop_zcashd() {
+        zallet_like_steady_state_loop::<Zcashd, FetchService>(&ValidatorKind::Zcashd).await
+    }
+
+    async fn zallet_like_steady_state_loop<C, Service>(validator: &ValidatorKind)
+    where
+        C: ValidatorExt,
+        Service: zaino_state::ZcashService<Config: TryFrom<ZainodConfig, Error = IndexerError>>
+            + Send
+            + Sync
+            + 'static,
+        IndexerError: From<<<Service as ZcashService>::Subscriber as ZcashIndexer>::Error>,
+    {
+        use futures::{StreamExt as _, TryStreamExt as _};
+        use tokio::time::{timeout, Duration};
+        use zaino_state::Height;
+
+        let (test_manager, _json_service, _option_state_service, _chain_index, indexer) =
+            create_test_manager_and_chain_index::<C, Service>(validator, None, false, false).await;
+
+        test_manager
+            .generate_blocks_and_poll_chain_index(5, &indexer)
+            .await;
+
+        let initial_snapshot = indexer.snapshot_nonfinalized_state();
+        let mut prev_tip: BestTip = indexer.best_chaintip(&initial_snapshot).await.unwrap();
+
+        for iteration in 0..5 {
+            let snapshot = indexer.snapshot_nonfinalized_state();
+            let current_tip = indexer.best_chaintip(&snapshot).await.unwrap();
+
+            let fork_point = indexer
+            .find_fork_point(&snapshot, &prev_tip.blockhash)
+            .await
+            .unwrap()
+            .unwrap_or_else(|| {
+                panic!(
+                    "no fork point found on iteration {iteration}: prev_tip=({:?}, {:?}) current_tip=({:?}, {:?})",
+                    prev_tip.height,
+                    prev_tip.blockhash,
+                    current_tip.height,
+                    current_tip.blockhash,
+                )
+            });
+
+            assert!(
+                fork_point.1 <= current_tip.height,
+                "fork point height {:?} above current tip {:?} on iteration {iteration}",
+                fork_point.1,
+                current_tip.height,
+            );
+
+            if fork_point.1 < current_tip.height {
+                let start_height = Height::from(fork_point.1 + 1);
+                let end_height = Some(current_tip.height);
+
+                let blocks_to_apply = indexer
+                .get_block_range(&snapshot, start_height, end_height)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "expected block range on iteration {iteration}: start={:?} end={:?} snapshot_tip={:?}",
+                        start_height,
+                        end_height,
+                        snapshot.best_tip,
+                    )
+                });
+
+                let applied_blocks = blocks_to_apply.try_collect::<Vec<_>>().await.unwrap();
+
+                let expected_count = u32::from(current_tip.height) - u32::from(fork_point.1);
+
+                assert_eq!(
+                    applied_blocks.len(),
+                    expected_count as usize,
+                    "unexpected number of applied blocks on iteration {iteration}",
+                );
+            }
+
+            let mut mempool_stream =
+                indexer
+                    .get_mempool_stream(Some(&snapshot))
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "fresh snapshot unexpectedly returned None on iteration {iteration}: \
+                     snapshot best tip height={:?} hash={:?}, \
+                     current tip height={:?} hash={:?}, \
+                     prev_tip height={:?} hash={:?}",
+                            snapshot.best_tip.height,
+                            snapshot.best_tip.blockhash,
+                            current_tip.height,
+                            current_tip.blockhash,
+                            prev_tip.height,
+                            prev_tip.blockhash,
+                        )
+                    });
+
+            test_manager
+                .generate_blocks_and_poll_chain_index(1, &indexer)
+                .await;
+
+            timeout(Duration::from_secs(20), async {
+                while let Some(item) = mempool_stream.next().await {
+                    item.expect("mempool stream yielded unexpected error");
+                }
+            })
+            .await
+            .expect("mempool stream did not close after chain tip changed");
+
+            prev_tip = current_tip;
+        }
     }
 }

--- a/packages/zaino-state/src/chain_index/tests/mempool.rs
+++ b/packages/zaino-state/src/chain_index/tests/mempool.rs
@@ -10,7 +10,7 @@ use crate::{
         source::test::MockchainSource,
         tests::vectors::{build_active_mockchain_source, load_test_vectors, TestVectorBlockData},
     },
-    Mempool, MempoolKey, MempoolValue,
+    BlockchainSource as _, Mempool, MempoolKey, MempoolValue,
 };
 
 async fn spawn_mempool_and_mockchain() -> (
@@ -263,7 +263,7 @@ async fn get_mempool_info() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn get_mempool_stream() {
+async fn get_mempool_stream_no_expected_chain_tip() {
     let (_mempool, subscriber, mockchain, block_data) = spawn_mempool_and_mockchain().await;
     let mut subscriber = subscriber;
 
@@ -332,4 +332,116 @@ async fn get_mempool_stream() {
     .expect("mempool stream did not close after mining a new block");
 
     handle.await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_mempool_stream_correct_expected_chain_tip() {
+    let (_mempool, subscriber, mockchain, block_data) = spawn_mempool_and_mockchain().await;
+    let mut subscriber = subscriber;
+
+    mockchain.mine_blocks(150);
+    let active_chain_tip_height = dbg!(mockchain.active_height());
+    let active_chain_tip_hash = mockchain.get_best_block_hash().await.unwrap().unwrap();
+
+    sleep(Duration::from_millis(2000)).await;
+
+    let mempool_index = (active_chain_tip_height as usize) + 1;
+
+    let mempool_transactions: Vec<_> = block_data
+        .get(mempool_index)
+        .map(|b| {
+            b.transactions
+                .iter()
+                .filter(|tx| !tx.is_coinbase())
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    let (mut rx, handle) = subscriber
+        .get_mempool_stream(Some(active_chain_tip_hash.into()))
+        .await
+        .unwrap();
+
+    let expected_count = mempool_transactions.len();
+    let mut received: HashMap<String, Vec<u8>> = HashMap::new();
+
+    let collect_deadline = Duration::from_secs(2);
+
+    timeout(collect_deadline, async {
+        while received.len() < expected_count {
+            match rx.recv().await {
+                Some(Ok((MempoolKey { txid: k }, MempoolValue { serialized_tx: v }))) => {
+                    received.insert(k, v.as_ref().as_ref().to_vec());
+                }
+                Some(Err(e)) => panic!("stream yielded error: {e:?}"),
+                None => break,
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for initial mempool stream items");
+
+    let expected: HashMap<String, Vec<u8>> = mempool_transactions
+        .iter()
+        .map(|tx| {
+            let key = tx.hash().to_string();
+            let st: zebra_chain::transaction::SerializedTransaction = tx.as_ref().into();
+            (key, st.as_ref().to_vec())
+        })
+        .collect();
+
+    assert_eq!(received.len(), expected.len(), "entry count mismatch");
+    for (k, bytes) in expected.iter() {
+        let got = received
+            .get(k)
+            .unwrap_or_else(|| panic!("missing tx {k} in stream"));
+        assert_eq!(got, bytes, "bytes mismatch for {k}");
+    }
+
+    mockchain.mine_blocks(1);
+
+    timeout(Duration::from_secs(5), async {
+        while let Some(_msg) = rx.recv().await {}
+    })
+    .await
+    .expect("mempool stream did not close after mining a new block");
+
+    handle.await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_mempool_stream_stale_expected_chain_tip() {
+    let (_mempool, subscriber, mockchain, _block_data) = spawn_mempool_and_mockchain().await;
+    let mut subscriber = subscriber;
+
+    mockchain.mine_blocks(149);
+    let state_chain_tip_hash = mockchain.get_best_block_hash().await.unwrap().unwrap();
+
+    sleep(Duration::from_millis(2000)).await;
+
+    mockchain.mine_blocks(1);
+
+    sleep(Duration::from_millis(2000)).await;
+
+    let result = subscriber
+        .get_mempool_stream(Some(state_chain_tip_hash.into()))
+        .await;
+
+    match result {
+        Err(crate::error::MempoolError::IncorrectChainTip {
+            expected_chain_tip,
+            current_chain_tip,
+        }) => {
+            assert_eq!(expected_chain_tip, state_chain_tip_hash);
+            assert_ne!(current_chain_tip, state_chain_tip_hash);
+        }
+        Ok((_rx, handle)) => {
+            handle.abort();
+            panic!("expected IncorrectChainTip error, got Ok");
+        }
+        Err(other) => {
+            panic!("expected IncorrectChainTip error, got {other:?}");
+        }
+    }
 }

--- a/packages/zaino-state/src/chain_index/tests/mockchain_tests.rs
+++ b/packages/zaino-state/src/chain_index/tests/mockchain_tests.rs
@@ -327,7 +327,67 @@ async fn get_filtered_mempool_transactions() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-async fn get_mempool_stream() {
+async fn get_mempool_stream_no_expected_chain_tip_snapshot() {
+    let (blocks, _indexer, index_reader, mockchain) =
+        load_test_vectors_and_sync_chain_index(true).await;
+
+    let block_data: Vec<zebra_chain::block::Block> = blocks
+        .iter()
+        .map(|TestVectorBlockData { zebra_block, .. }| zebra_block.clone())
+        .collect();
+
+    sleep(Duration::from_millis(2000)).await;
+
+    let next_mempool_height_index = (dbg!(mockchain.active_height()) as usize) + 1;
+    let mut mempool_transactions: Vec<_> = block_data
+        .get(next_mempool_height_index)
+        .map(|b| {
+            b.transactions
+                .iter()
+                .filter(|tx| !tx.is_coinbase())
+                .cloned()
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    mempool_transactions.sort_by_key(|transaction| transaction.hash());
+
+    let mempool_stream_task = tokio::spawn(async move {
+        let mut mempool_stream = index_reader
+            .get_mempool_stream(None)
+            .expect("failed to create mempool stream");
+
+        let mut indexer_mempool_transactions: Vec<zebra_chain::transaction::Transaction> =
+            Vec::new();
+
+        while let Some(tx_bytes_res) = mempool_stream.next().await {
+            let tx_bytes = tx_bytes_res.expect("stream error");
+            let tx: zebra_chain::transaction::Transaction =
+                tx_bytes.zcash_deserialize_into().expect("deserialize tx");
+            indexer_mempool_transactions.push(tx);
+        }
+
+        indexer_mempool_transactions.sort_by_key(|tx| tx.hash());
+        indexer_mempool_transactions
+    });
+
+    sleep(Duration::from_millis(500)).await;
+
+    mockchain.mine_blocks(1);
+
+    let indexer_mempool_stream_transactions =
+        mempool_stream_task.await.expect("collector task failed");
+
+    assert_eq!(
+        mempool_transactions
+            .iter()
+            .map(|tx| tx.as_ref().clone())
+            .collect::<Vec<_>>(),
+        indexer_mempool_stream_transactions,
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+async fn get_mempool_stream_correct_expected_chain_tip_snapshot() {
     let (blocks, _indexer, index_reader, mockchain) =
         load_test_vectors_and_sync_chain_index(true).await;
 


### PR DESCRIPTION
Adds mempool tests.

Zallet has been having issues with zaino's mempool interface. this PR adds new unit and integration tests to validate the expected behaviour of the API and to try to model the conditions zallet makes.

TLDR: No bugs could be found in zaino but these are useful tests to have (particularly the new unit tests.)