### PR TITLE
Add gettxout JSON-RPC passthrough

### DIFF
--- a/integration-tests/tests/json_server.rs
+++ b/integration-tests/tests/json_server.rs
@@ -605,6 +605,63 @@ async fn get_raw_transaction_inner() {
     test_manager.close().await;
 }
 
+async fn get_tx_out_inner() {
+    let (mut test_manager, _zcashd_service, zcashd_subscriber, _zaino_service, zaino_subscriber) =
+        create_zcashd_test_manager_and_fetch_services(true).await;
+
+    let mut clients = test_manager
+        .clients
+        .take()
+        .expect("Clients are not initialized");
+    let recipient_taddr = clients.get_recipient_address("transparent").await;
+
+    clients.faucet.sync_and_await().await.unwrap();
+
+    from_inputs::quick_send(
+        &mut clients.faucet,
+        vec![(recipient_taddr.as_str(), 250_000, None)],
+    )
+    .await
+    .unwrap();
+    generate_blocks_and_poll_all_chain_indexes(
+        1,
+        &test_manager,
+        zaino_subscriber.clone(),
+        zcashd_subscriber.clone(),
+    )
+    .await;
+
+    let zcashd_utxos = zcashd_subscriber
+        .z_get_address_utxos(GetAddressBalanceRequest::new(vec![recipient_taddr.clone()]))
+        .await
+        .unwrap();
+    let (_, txid, output_index, ..) = zcashd_utxos[0].into_parts();
+
+    let zcashd_tx_out = zcashd_subscriber
+        .get_tx_out(txid.to_string(), output_index.index(), Some(true))
+        .await
+        .unwrap();
+    let zaino_tx_out = zaino_subscriber
+        .get_tx_out(txid.to_string(), output_index.index(), Some(true))
+        .await
+        .unwrap();
+
+    assert_eq!(zcashd_tx_out, zaino_tx_out);
+
+    let zcashd_missing_tx_out = zcashd_subscriber
+        .get_tx_out(txid.to_string(), output_index.index() + 100, None)
+        .await
+        .unwrap();
+    let zaino_missing_tx_out = zaino_subscriber
+        .get_tx_out(txid.to_string(), output_index.index() + 100, None)
+        .await
+        .unwrap();
+
+    assert_eq!(zcashd_missing_tx_out, zaino_missing_tx_out);
+
+    test_manager.close().await;
+}
+
 async fn get_address_tx_ids_inner() {
     let (mut test_manager, _zcashd_service, zcashd_subscriber, _zaino_service, zaino_subscriber) =
         create_zcashd_test_manager_and_fetch_services(true).await;
@@ -998,6 +1055,11 @@ mod zcashd {
         #[tokio::test(flavor = "multi_thread")]
         async fn get_raw_transaction() {
             get_raw_transaction_inner().await;
+        }
+
+        #[tokio::test(flavor = "multi_thread")]
+        async fn get_tx_out() {
+            get_tx_out_inner().await;
         }
 
         #[tokio::test(flavor = "multi_thread")]

--- a/packages/zaino-fetch/src/jsonrpsee/connector.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/connector.rs
@@ -36,8 +36,8 @@ use crate::jsonrpsee::{
         GetBalanceError, GetBalanceResponse, GetBlockCountResponse, GetBlockError, GetBlockHash,
         GetBlockResponse, GetBlockchainInfoResponse, GetInfoResponse, GetMempoolInfoResponse,
         GetSubtreesError, GetSubtreesResponse, GetTransactionResponse, GetTreestateError,
-        GetTreestateResponse, GetUtxosError, GetUtxosResponse, SendTransactionError,
-        SendTransactionResponse, TxidsError, TxidsResponse,
+        GetTreestateResponse, GetTxOutResponse, GetUtxosError, GetUtxosResponse,
+        SendTransactionError, SendTransactionResponse, TxidsError, TxidsResponse,
     },
 };
 
@@ -761,6 +761,38 @@ impl JsonRpSeeConnector {
         };
 
         self.send_request("getrawtransaction", params).await
+    }
+
+    /// Returns details about an unspent transaction output.
+    ///
+    /// zcashd reference: [`gettxout`](https://zcash.github.io/rpc/gettxout.html)
+    /// method: post
+    /// tags: transaction
+    ///
+    /// # Parameters
+    ///
+    /// - `txid`: (string, required, example="mytxid") The transaction ID that contains the output.
+    /// - `n`: (number, required) The output index number.
+    /// - `include_mempool`: (bool, optional, default=true) Whether to include the mempool in the search.
+    pub async fn get_tx_out(
+        &self,
+        txid: String,
+        n: u32,
+        include_mempool: Option<bool>,
+    ) -> Result<GetTxOutResponse, RpcRequestError<Infallible>> {
+        let params = match include_mempool {
+            Some(include_mempool) => vec![
+                serde_json::to_value(txid).map_err(RpcRequestError::JsonRpc)?,
+                serde_json::to_value(n).map_err(RpcRequestError::JsonRpc)?,
+                serde_json::to_value(include_mempool).map_err(RpcRequestError::JsonRpc)?,
+            ],
+            None => vec![
+                serde_json::to_value(txid).map_err(RpcRequestError::JsonRpc)?,
+                serde_json::to_value(n).map_err(RpcRequestError::JsonRpc)?,
+            ],
+        };
+
+        self.send_request("gettxout", params).await
     }
 
     /// Returns the transaction ids made by the provided transparent addresses.

--- a/packages/zaino-fetch/src/jsonrpsee/response.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response.rs
@@ -106,6 +106,19 @@ impl ResponseToError for GetDifficultyResponse {
     type RpcError = Infallible;
 }
 
+/// Response to a `gettxout` RPC request.
+///
+/// The result is either the validator's output object or `null` when the
+/// output is spent or missing. This intentionally preserves the passthrough
+/// JSON payload without exposing Zebra's Rust response type in Zaino's API.
+#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(transparent)]
+pub struct GetTxOutResponse(pub Option<serde_json::Value>);
+
+impl ResponseToError for GetTxOutResponse {
+    type RpcError = Infallible;
+}
+
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(untagged)]
 /// A wrapper to allow both types of error timestamp

--- a/packages/zaino-serve/src/rpc/jsonrpc/service.rs
+++ b/packages/zaino-serve/src/rpc/jsonrpc/service.rs
@@ -8,7 +8,9 @@ use zaino_fetch::jsonrpsee::response::peer_info::GetPeerInfo;
 use zaino_fetch::jsonrpsee::response::z_validate_address::{
     ZValidateAddressResponse, DEPRECATION_NOTICE as Z_VALIDATE_DEPRECATION,
 };
-use zaino_fetch::jsonrpsee::response::{GetMempoolInfoResponse, GetNetworkSolPsResponse};
+use zaino_fetch::jsonrpsee::response::{
+    GetMempoolInfoResponse, GetNetworkSolPsResponse, GetTxOutResponse,
+};
 use zaino_state::{LightWalletIndexer, ZcashIndexer};
 
 use zebra_chain::{block::Height, subtree::NoteCommitmentSubtreeIndex};
@@ -350,6 +352,25 @@ pub trait ZcashIndexerRpc {
         txid_hex: String,
         verbose: Option<u8>,
     ) -> Result<GetRawTransaction, ErrorObjectOwned>;
+
+    /// Returns details about an unspent transaction output.
+    ///
+    /// zcashd reference: [`gettxout`](https://zcash.github.io/rpc/gettxout.html)
+    /// method: post
+    /// tags: transaction
+    ///
+    /// # Parameters
+    ///
+    /// - `txid`: (string, required, example="mytxid") The transaction ID that contains the output.
+    /// - `n`: (number, required) The output index number.
+    /// - `include_mempool`: (bool, optional, default=true) Whether to include the mempool in the search.
+    #[method(name = "gettxout")]
+    async fn get_tx_out(
+        &self,
+        txid: String,
+        n: u32,
+        include_mempool: Option<bool>,
+    ) -> Result<GetTxOutResponse, ErrorObjectOwned>;
 
     /// Returns the transaction ids made by the provided transparent addresses.
     ///
@@ -719,6 +740,25 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
         self.service_subscriber
             .inner_ref()
             .get_raw_transaction(txid_hex, verbose)
+            .await
+            .map_err(|e| {
+                ErrorObjectOwned::owned(
+                    ErrorCode::InvalidParams.code(),
+                    "Internal server error",
+                    Some(e.to_string()),
+                )
+            })
+    }
+
+    async fn get_tx_out(
+        &self,
+        txid: String,
+        n: u32,
+        include_mempool: Option<bool>,
+    ) -> Result<GetTxOutResponse, ErrorObjectOwned> {
+        self.service_subscriber
+            .inner_ref()
+            .get_tx_out(txid, n, include_mempool)
             .await
             .map_err(|e| {
                 ErrorObjectOwned::owned(

--- a/packages/zaino-state/src/backends/fetch.rs
+++ b/packages/zaino-state/src/backends/fetch.rs
@@ -36,7 +36,7 @@ use zaino_fetch::{
             z_validate_address::{
                 ZValidateAddressResponse, DEPRECATION_NOTICE as Z_VALIDATE_DEPRECATION,
             },
-            GetMempoolInfoResponse, GetNetworkSolPsResponse,
+            GetMempoolInfoResponse, GetNetworkSolPsResponse, GetTxOutResponse,
         },
     },
 };
@@ -748,6 +748,20 @@ impl ZcashIndexer for FetchServiceSubscriber {
                 zebra_chain::transaction::Hash::from(txid),
             ),
         )))
+    }
+
+    /// Returns details about an unspent transaction output.
+    ///
+    /// zcashd reference: [`gettxout`](https://zcash.github.io/rpc/gettxout.html)
+    /// method: post
+    /// tags: transaction
+    async fn get_tx_out(
+        &self,
+        txid: String,
+        n: u32,
+        include_mempool: Option<bool>,
+    ) -> Result<GetTxOutResponse, Self::Error> {
+        Ok(self.fetcher.get_tx_out(txid, n, include_mempool).await?)
     }
 
     async fn chain_height(&self) -> Result<Height, Self::Error> {

--- a/packages/zaino-state/src/backends/state.rs
+++ b/packages/zaino-state/src/backends/state.rs
@@ -40,7 +40,7 @@ use zaino_fetch::{
                 InvalidZValidateAddress, KnownZValidateAddress, ZValidateAddressResponse,
                 DEPRECATION_NOTICE as Z_VALIDATE_DEPRECATION,
             },
-            GetMempoolInfoResponse, GetNetworkSolPsResponse, GetSubtreesResponse,
+            GetMempoolInfoResponse, GetNetworkSolPsResponse, GetSubtreesResponse, GetTxOutResponse,
         },
     },
 };
@@ -1709,6 +1709,20 @@ impl ZcashIndexer for StateServiceSubscriber {
                 zebra_chain::transaction::Hash::from(txid),
             ),
         )))
+    }
+
+    /// Returns details about an unspent transaction output.
+    ///
+    /// zcashd reference: [`gettxout`](https://zcash.github.io/rpc/gettxout.html)
+    /// method: post
+    /// tags: transaction
+    async fn get_tx_out(
+        &self,
+        txid: String,
+        n: u32,
+        include_mempool: Option<bool>,
+    ) -> Result<GetTxOutResponse, Self::Error> {
+        Ok(self.rpc_client.get_tx_out(txid, n, include_mempool).await?)
     }
 
     async fn get_address_tx_ids(

--- a/packages/zaino-state/src/indexer.rs
+++ b/packages/zaino-state/src/indexer.rs
@@ -464,6 +464,24 @@ pub trait ZcashIndexer: Send + Sync + 'static {
         verbose: Option<u8>,
     ) -> Result<GetRawTransaction, Self::Error>;
 
+    /// Returns details about an unspent transaction output.
+    ///
+    /// zcashd reference: [`gettxout`](https://zcash.github.io/rpc/gettxout.html)
+    /// method: post
+    /// tags: transaction
+    ///
+    /// # Parameters
+    ///
+    /// - `txid`: (string, required) The transaction ID that contains the output.
+    /// - `n`: (number, required) The output index number.
+    /// - `include_mempool`: (bool, optional, default=true) Whether to include the mempool in the search.
+    async fn get_tx_out(
+        &self,
+        txid: String,
+        n: u32,
+        include_mempool: Option<bool>,
+    ) -> Result<zaino_fetch::jsonrpsee::response::GetTxOutResponse, Self::Error>;
+
     /// Returns the transaction ids made by the provided transparent addresses.
     ///
     /// zcashd reference: [`getaddresstxids`](https://zcash.github.io/rpc/getaddresstxids.html)


### PR DESCRIPTION
## Summary

- Add `gettxout` to the JSON-RPC API and `ZcashIndexer` trait.
- Forward `gettxout` through the existing validator RPC connector for `FetchService` and `StateService`.
- Use a Zaino-owned `GetTxOutResponse` wrapper to preserve passthrough JSON without exposing Zebra's Rust response type.
- Add zcashd comparison coverage for an existing transparent UTXO and a missing output.

## Testing

- `cargo check -p zaino-fetch -p zaino-state -p zaino-serve`
- `git diff --check`

## Not Run

- `cargo check --manifest-path integration-tests/Cargo.toml --test json_server`

  This is currently blocked by Cargo dependency resolution because `core2 = 0.3.3` is yanked.