### PR TITLE
Fix integration tests

### DIFF
--- a/integration-tests/tests/chain_cache.rs
+++ b/integration-tests/tests/chain_cache.rs
@@ -52,10 +52,9 @@ where
 #[allow(deprecated)]
 mod chain_query_interface {
 
-    use std::{path::PathBuf, time::Duration};
+    use std::time::Duration;
 
     use futures::TryStreamExt as _;
-    use tempfile::TempDir;
     use zaino_common::{CacheConfig, DatabaseConfig, ServiceConfig, StorageConfig};
     use zaino_state::{
         chain_index::{
@@ -158,7 +157,11 @@ mod chain_query_interface {
                     StorageConfig {
                         cache: CacheConfig::default(),
                         database: DatabaseConfig {
-                            path: test_manager.data_dir.as_path().to_path_buf().join("zaino"),
+                            path: test_manager
+                                .data_dir
+                                .as_path()
+                                .to_path_buf()
+                                .join("state-service-zaino"),
                             ..Default::default()
                         },
                     },
@@ -167,12 +170,14 @@ mod chain_query_interface {
                 ))
                 .await
                 .unwrap();
-                let temp_dir: TempDir = tempfile::tempdir().unwrap();
-                let db_path: PathBuf = temp_dir.path().to_path_buf();
                 let config = BlockCacheConfig {
                     storage: StorageConfig {
                         database: DatabaseConfig {
-                            path: db_path,
+                            path: test_manager
+                                .data_dir
+                                .as_path()
+                                .to_path_buf()
+                                .join("chain-index-zaino"),
                             ..Default::default()
                         },
                         ..Default::default()
@@ -207,12 +212,14 @@ mod chain_query_interface {
                 )
             }
             ValidatorKind::Zcashd => {
-                let temp_dir: TempDir = tempfile::tempdir().unwrap();
-                let db_path: PathBuf = temp_dir.path().to_path_buf();
                 let config = BlockCacheConfig {
                     storage: StorageConfig {
                         database: DatabaseConfig {
-                            path: db_path,
+                            path: test_manager
+                                .data_dir
+                                .as_path()
+                                .to_path_buf()
+                                .join("chain-index-zaino"),
                             ..Default::default()
                         },
                         ..Default::default()
@@ -500,9 +507,7 @@ mod chain_query_interface {
                 indexer
                     .get_mempool_stream(Some(&snapshot))
                     .unwrap_or_else(|| {
-                        panic!(
-                            "fresh snapshot unexpectedly returned None on iteration {iteration}"
-                        )
+                        panic!("fresh snapshot unexpectedly returned None on iteration {iteration}")
                     });
 
             test_manager
@@ -542,7 +547,6 @@ mod chain_query_interface {
     {
         use futures::{StreamExt as _, TryStreamExt as _};
         use tokio::time::{timeout, Duration};
-        use zaino_state::Height;
 
         let (test_manager, _json_service, _option_state_service, _chain_index, indexer) =
             create_test_manager_and_chain_index::<C, Service>(validator, None, false, false).await;
@@ -580,18 +584,17 @@ mod chain_query_interface {
             );
 
             if fork_point.1 < current_tip.height {
-                let start_height = Height::from(fork_point.1 + 1);
+                let start_height = fork_point.1 + 1;
                 let end_height = Some(current_tip.height);
 
                 let blocks_to_apply = indexer
-                .get_block_range(&snapshot, start_height, end_height)
-                .unwrap_or_else(|| {
-                    panic!(
-                        "expected block range on iteration {iteration}: start={:?} end={:?}",
-                        start_height,
-                        end_height,
-                    )
-                });
+                    .get_block_range(&snapshot, start_height, end_height)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "expected block range on iteration {iteration}: start={:?} end={:?}",
+                            start_height, end_height,
+                        )
+                    });
 
                 let applied_blocks = blocks_to_apply.try_collect::<Vec<_>>().await.unwrap();
 
@@ -612,10 +615,7 @@ mod chain_query_interface {
                             "fresh snapshot unexpectedly returned None on iteration {iteration}: \
                      current tip height={:?} hash={:?}, \
                      prev_tip height={:?} hash={:?}",
-                            current_tip.height,
-                            current_tip.hash,
-                            prev_tip.height,
-                            prev_tip.hash,
+                            current_tip.height, current_tip.hash, prev_tip.height, prev_tip.hash,
                         )
                     });
 

--- a/integration-tests/tests/json_server.rs
+++ b/integration-tests/tests/json_server.rs
@@ -56,7 +56,7 @@ async fn create_zcashd_test_manager_and_fetch_services(
                     .data_dir()
                     .path()
                     .to_path_buf()
-                    .join("zaino"),
+                    .join("zcashd-fetch-service-zaino"),
                 ..Default::default()
             },
             ..Default::default()
@@ -72,7 +72,10 @@ async fn create_zcashd_test_manager_and_fetch_services(
 
     println!("Launching zaino fetch service..");
     let zaino_fetch_service = FetchService::spawn(FetchServiceConfig::new(
-        test_manager.full_node_rpc_listen_address.to_string(),
+        test_manager
+            .zaino_json_rpc_listen_address
+            .expect("zaino jsonrpc address must be active for these tests")
+            .to_string(),
         test_manager.json_server_cookie_dir.clone(),
         None,
         None,
@@ -84,7 +87,7 @@ async fn create_zcashd_test_manager_and_fetch_services(
                     .data_dir()
                     .path()
                     .to_path_buf()
-                    .join("zaino"),
+                    .join("zaino-fetch-service-zaino"),
                 ..Default::default()
             },
             ..Default::default()

--- a/integration-tests/tests/state_service.rs
+++ b/integration-tests/tests/state_service.rs
@@ -93,7 +93,7 @@ async fn create_test_manager_and_services<V: ValidatorExt>(
                     .data_dir()
                     .path()
                     .to_path_buf()
-                    .join("zaino"),
+                    .join("fetch-service-zaino"),
                 ..Default::default()
             },
             ..Default::default()
@@ -135,7 +135,7 @@ async fn create_test_manager_and_services<V: ValidatorExt>(
                     .data_dir()
                     .path()
                     .to_path_buf()
-                    .join("zaino"),
+                    .join("state-srvice-zaino"),
                 ..Default::default()
             },
             ..Default::default()

--- a/integration-tests/zaino-testutils/src/lib.rs
+++ b/integration-tests/zaino-testutils/src/lib.rs
@@ -350,7 +350,11 @@ where
 
         let mut config = C::Config::default();
         config.set_test_parameters(
-            PoolType::Transparent,
+            if validator == &ValidatorKind::Zebrad {
+                PoolType::Transparent
+            } else {
+                PoolType::ORCHARD
+            },
             activation_heights.into(),
             chain_cache.clone(),
         );

--- a/packages/zaino-serve/src/rpc/jsonrpc/service.rs
+++ b/packages/zaino-serve/src/rpc/jsonrpc/service.rs
@@ -411,6 +411,41 @@ pub trait ZcashIndexerRpc {
         height: Option<i32>,
     ) -> Result<GetNetworkSolPsResponse, ErrorObjectOwned>;
 }
+
+// Currently all errors are hidden from downstream client, a full fix should be implemented. this is a temporary fix to
+// get zaino working, propagating a 500 error code to "block not found". This is still not the full correct behaviour
+// but fixes the current bugs in zaino and gets tests running.
+fn getblock_error_object_from_indexer_error<Error>(error: Error) -> ErrorObjectOwned
+where
+    Error: std::error::Error + 'static,
+{
+    let mut current_error: Option<&(dyn std::error::Error + 'static)> = Some(&error);
+
+    while let Some(error_source) = current_error {
+        if let Some(zaino_fetch::jsonrpsee::error::TransportError::ErrorStatusCode(500)) =
+            error_source.downcast_ref::<zaino_fetch::jsonrpsee::error::TransportError>()
+        {
+            return ErrorObjectOwned::owned(
+                zaino_fetch::jsonrpsee::connector::RpcError::new_from_legacycode(
+                    zebra_rpc::server::error::LegacyCode::InvalidParameter,
+                    "block not found",
+                )
+                .code as i32,
+                "block not found",
+                None::<()>,
+            );
+        }
+
+        current_error = error_source.source();
+    }
+
+    ErrorObjectOwned::owned(
+        ErrorCode::InternalError.code(),
+        "Internal server error",
+        Some(error.to_string()),
+    )
+}
+
 /// Uses ErrorCode::InvalidParams as this is converted to zcash legacy "minsc" ErrorCode in RPC middleware.
 #[jsonrpsee::core::async_trait]
 impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonRpcClient<Indexer> {
@@ -634,13 +669,7 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .z_get_block(hash_or_height, verbosity)
             .await
-            .map_err(|e| {
-                ErrorObjectOwned::owned(
-                    ErrorCode::InvalidParams.code(),
-                    "Internal server error",
-                    Some(e.to_string()),
-                )
-            })
+            .map_err(getblock_error_object_from_indexer_error)
     }
 
     async fn get_block_header(

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -2048,12 +2048,24 @@ impl NonFinalizedSnapshot for NonfinalizedBlockCacheSnapshot {
 }
 
 impl NonFinalizedSnapshot for ChainIndexSnapshot {
-    fn get_chainblock_by_hash(&self, _target_hash: &types::BlockHash) -> Option<&IndexedBlock> {
-        None
+    fn get_chainblock_by_hash(&self, target_hash: &types::BlockHash) -> Option<&IndexedBlock> {
+        match self {
+            ChainIndexSnapshot::NonFinalizedStateExists {
+                non_finalized_snapshot,
+            } => non_finalized_snapshot.get_chainblock_by_hash(target_hash),
+
+            ChainIndexSnapshot::StillSyncingFinalizedState { .. } => None,
+        }
     }
 
-    fn get_chainblock_by_height(&self, _target_height: &types::Height) -> Option<&IndexedBlock> {
-        None
+    fn get_chainblock_by_height(&self, target_height: &types::Height) -> Option<&IndexedBlock> {
+        match self {
+            ChainIndexSnapshot::NonFinalizedStateExists {
+                non_finalized_snapshot,
+            } => non_finalized_snapshot.get_chainblock_by_height(target_height),
+
+            ChainIndexSnapshot::StillSyncingFinalizedState { .. } => None,
+        }
     }
 
     fn max_serviceable_height(&self) -> &types::Height {
@@ -2061,6 +2073,7 @@ impl NonFinalizedSnapshot for ChainIndexSnapshot {
             ChainIndexSnapshot::NonFinalizedStateExists {
                 non_finalized_snapshot,
             } => non_finalized_snapshot.max_serviceable_height(),
+
             ChainIndexSnapshot::StillSyncingFinalizedState {
                 validator_finalized_height,
             } => validator_finalized_height,


### PR DESCRIPTION
This PR fixes several bugs in zaino's integration test suite and fixes 2 real bugs in production code that were uncovered once tests were running.

Test bug Fixes:
- Miner pool type had been changed to transparent for zcashd tests, these tests are not implemented to work with transparent (extra shields would need to be added), this broke many zcashd tests.
- Json server tests were not actually testing zaino's JsonRPC server, they were comparing zcashd against zcashd, this has been fixed.
- Several test modules used the same ZainoDB dir for multiple ZainoDB instances, while it seams this was not causing the errors, this was updated so that every ZainoDB uses its  own directory.


Production bug fixes:
- ChainIndex had been hard-coded to return `None` for both `get_indexed_block_by_hash` and `get_indexed_block_by_height`, this was the main bug causing test failures, this has been fixed to return None only when the non-finalised state is still running its initial sync (or has not yet been initialised).
- The `get_block` method in Zainos JsonRPC server hides the real errors returned by the backing validator. This has not been completely fixed but a temporary fix has been implemented (propagating 500 error codes as "block not found"). This is only a temporary fix that enables Zaino's JsonRPC server to serve Zaino's FetchService.