### PR TITLE
Add getchaintips JSON-RPC support

### DIFF
--- a/packages/zaino-fetch/src/jsonrpsee/connector.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/connector.rs
@@ -30,6 +30,7 @@ use crate::jsonrpsee::{
         block_deltas::{BlockDeltas, BlockDeltasError},
         block_header::{GetBlockHeader, GetBlockHeaderError},
         block_subsidy::GetBlockSubsidy,
+        chain_tips::GetChainTipsResponse,
         mining_info::GetMiningInfoWire,
         peer_info::GetPeerInfo,
         z_validate_address::{ZValidateAddressError, ZValidateAddressResponse},
@@ -635,6 +636,18 @@ impl JsonRpSeeConnector {
         &self,
     ) -> Result<GetBlockCountResponse, RpcRequestError<Infallible>> {
         self.send_request::<(), GetBlockCountResponse>("getblockcount", ())
+            .await
+    }
+
+    /// Returns information about all known tips in the block tree.
+    ///
+    /// zcashd reference: [`getchaintips`](https://zcash.github.io/rpc/getchaintips.html)
+    /// method: post
+    /// tags: blockchain
+    pub async fn get_chain_tips(
+        &self,
+    ) -> Result<GetChainTipsResponse, RpcRequestError<Infallible>> {
+        self.send_request::<(), GetChainTipsResponse>("getchaintips", ())
             .await
     }
 

--- a/packages/zaino-fetch/src/jsonrpsee/response.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response.rs
@@ -7,6 +7,7 @@ pub mod address_deltas;
 pub mod block_deltas;
 pub mod block_header;
 pub mod block_subsidy;
+pub mod chain_tips;
 pub mod common;
 pub mod mining_info;
 pub mod peer_info;

--- a/packages/zaino-fetch/src/jsonrpsee/response/chain_tips.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/response/chain_tips.rs
@@ -1,0 +1,57 @@
+//! Types associated with the `getchaintips` RPC request.
+
+use std::convert::Infallible;
+
+use serde::{Deserialize, Serialize};
+
+use crate::jsonrpsee::connector::ResponseToError;
+
+/// Response to a `getchaintips` RPC request.
+pub type GetChainTipsResponse = Vec<ChainTip>;
+
+/// Information about a known chain tip.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ChainTip {
+    /// Height of the chain tip.
+    pub height: u32,
+    /// Block hash of the tip, in RPC display order.
+    pub hash: String,
+    /// Length of the branch connecting the tip to the active chain.
+    pub branchlen: u32,
+    /// Status of the chain tip.
+    pub status: ChainTipStatus,
+}
+
+impl ChainTip {
+    /// Creates a new chain tip response item.
+    pub fn new(height: u32, hash: String, branchlen: u32, status: ChainTipStatus) -> Self {
+        Self {
+            height,
+            hash,
+            branchlen,
+            status,
+        }
+    }
+}
+
+/// Status values returned by zcashd's `getchaintips`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ChainTipStatus {
+    /// This branch contains at least one invalid block.
+    Invalid,
+    /// Not all blocks for this branch are available, but the headers are valid.
+    HeadersOnly,
+    /// All blocks are available for this branch, but they were never fully validated.
+    ValidHeaders,
+    /// This branch is not part of the active chain, but is fully validated.
+    ValidFork,
+    /// This is the tip of the active main chain.
+    Active,
+    /// The validation state is unknown.
+    Unknown,
+}
+
+impl ResponseToError for GetChainTipsResponse {
+    type RpcError = Infallible;
+}

--- a/packages/zaino-serve/src/rpc/jsonrpc/service.rs
+++ b/packages/zaino-serve/src/rpc/jsonrpc/service.rs
@@ -3,6 +3,7 @@
 use zaino_fetch::jsonrpsee::response::block_deltas::BlockDeltas;
 use zaino_fetch::jsonrpsee::response::block_header::GetBlockHeader;
 use zaino_fetch::jsonrpsee::response::block_subsidy::GetBlockSubsidy;
+use zaino_fetch::jsonrpsee::response::chain_tips::GetChainTipsResponse;
 use zaino_fetch::jsonrpsee::response::mining_info::GetMiningInfoWire;
 use zaino_fetch::jsonrpsee::response::peer_info::GetPeerInfo;
 use zaino_fetch::jsonrpsee::response::z_validate_address::{
@@ -136,6 +137,19 @@ pub trait ZcashIndexerRpc {
     /// tags: blockchain
     #[method(name = "getblockcount")]
     async fn get_block_count(&self) -> Result<Height, ErrorObjectOwned>;
+
+    /// Returns information about all known tips in the block tree.
+    ///
+    /// zcashd reference: [`getchaintips`](https://zcash.github.io/rpc/getchaintips.html)
+    /// method: post
+    /// tags: blockchain
+    ///
+    /// zcashd implementation details:
+    /// - builds the result from block-index leaves and always includes the active tip
+    /// - reports `branchlen` as `tip.height - active_chain_find_fork(tip).height`
+    /// - sorts by descending height via `CompareBlocksByHeight`
+    #[method(name = "getchaintips")]
+    async fn get_chain_tips(&self) -> Result<GetChainTipsResponse, ErrorObjectOwned>;
 
     /// Return information about the given Zcash address.
     ///
@@ -580,6 +594,20 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
         self.service_subscriber
             .inner_ref()
             .get_block_count()
+            .await
+            .map_err(|e| {
+                ErrorObjectOwned::owned(
+                    ErrorCode::InvalidParams.code(),
+                    "Internal server error",
+                    Some(e.to_string()),
+                )
+            })
+    }
+
+    async fn get_chain_tips(&self) -> Result<GetChainTipsResponse, ErrorObjectOwned> {
+        self.service_subscriber
+            .inner_ref()
+            .get_chain_tips()
             .await
             .map_err(|e| {
                 ErrorObjectOwned::owned(

--- a/packages/zaino-state/src/backends/fetch.rs
+++ b/packages/zaino-state/src/backends/fetch.rs
@@ -31,6 +31,7 @@ use zaino_fetch::{
             block_deltas::BlockDeltas,
             block_header::GetBlockHeader,
             block_subsidy::GetBlockSubsidy,
+            chain_tips::GetChainTipsResponse,
             mining_info::GetMiningInfoWire,
             peer_info::GetPeerInfo,
             z_validate_address::{
@@ -55,12 +56,9 @@ use zaino_proto::proto::{
     },
 };
 
-use crate::{
-    chain_index::{non_finalised_state::ChainIndexSnapshot, NonFinalizedSnapshot},
-    ChainIndex, NodeBackedChainIndex, NodeBackedChainIndexSubscriber,
-};
 #[allow(deprecated)]
 use crate::{
+    chain_index::chain_tips_from_nonfinalized_snapshot,
     chain_index::{source::ValidatorConnector, types},
     config::{DonationAddress, FetchServiceConfig},
     error::FetchServiceError,
@@ -74,6 +72,10 @@ use crate::{
     },
     utils::{get_build_info, ServiceMetadata},
     BackendType,
+};
+use crate::{
+    chain_index::{non_finalised_state::ChainIndexSnapshot, NonFinalizedSnapshot},
+    ChainIndex, NodeBackedChainIndex, NodeBackedChainIndexSubscriber,
 };
 
 /// Chain fetch service backed by Zcashd's JsonRPC engine.
@@ -484,6 +486,17 @@ impl ZcashIndexer for FetchServiceSubscriber {
     /// tags: blockchain
     async fn get_block_count(&self) -> Result<Height, Self::Error> {
         Ok(self.fetcher.get_block_count().await?.into())
+    }
+
+    async fn get_chain_tips(&self) -> Result<GetChainTipsResponse, Self::Error> {
+        let snapshot = self.indexer.snapshot_nonfinalized_state().await?;
+        let Some(non_finalized_snapshot) = snapshot.get_nfs_snapshot() else {
+            return Ok(self.fetcher.get_chain_tips().await?);
+        };
+
+        Ok(chain_tips_from_nonfinalized_snapshot(
+            non_finalized_snapshot,
+        ))
     }
 
     /// Return information about the given Zcash address.

--- a/packages/zaino-state/src/backends/state.rs
+++ b/packages/zaino-state/src/backends/state.rs
@@ -34,6 +34,7 @@ use zaino_fetch::{
             block_deltas::{BlockDelta, BlockDeltas, InputDelta, OutputDelta},
             block_header::GetBlockHeader,
             block_subsidy::GetBlockSubsidy,
+            chain_tips::GetChainTipsResponse,
             mining_info::GetMiningInfoWire,
             peer_info::GetPeerInfo,
             z_validate_address::{
@@ -1478,6 +1479,17 @@ impl ZcashIndexer for StateServiceSubscriber {
         };
         let h = non_finalized_snapshot.best_tip.height;
         Ok(h.into())
+    }
+
+    async fn get_chain_tips(&self) -> Result<GetChainTipsResponse, Self::Error> {
+        let snapshot = self.indexer.snapshot_nonfinalized_state().await?;
+        let Some(non_finalized_snapshot) = snapshot.get_nfs_snapshot() else {
+            return Ok(self.rpc_client.get_chain_tips().await?);
+        };
+
+        Ok(crate::chain_index::chain_tips_from_nonfinalized_snapshot(
+            non_finalized_snapshot,
+        ))
     }
 
     async fn validate_address(

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -30,8 +30,9 @@ use non_finalised_state::NonfinalizedBlockCacheSnapshot;
 use source::{BlockchainSource, ValidatorConnector};
 use tokio_stream::StreamExt;
 use tracing::{info, instrument};
-use zaino_fetch::jsonrpsee::response::address_deltas::{
-    GetAddressDeltasParams, GetAddressDeltasResponse,
+use zaino_fetch::jsonrpsee::response::{
+    address_deltas::{GetAddressDeltasParams, GetAddressDeltasResponse},
+    chain_tips::{ChainTip, ChainTipStatus, GetChainTipsResponse},
 };
 use zaino_proto::proto::utils::{compact_block_with_pool_types, PoolTypeFilter};
 use zebra_chain::parameters::ConsensusBranchId;
@@ -57,6 +58,85 @@ pub mod types;
 
 #[cfg(test)]
 mod tests;
+
+/// Builds a zcashd-compatible `getchaintips` response from the local non-finalized snapshot.
+///
+/// zcashd enumerates block-tree leaves, always includes the active tip, and reports
+/// inactive fully-known branches as `valid-fork`. Zaino's non-finalized cache stores
+/// full blocks, not headers-only or invalid candidates, so those are the only statuses
+/// this conversion can currently emit.
+pub(crate) fn chain_tips_from_nonfinalized_snapshot(
+    snapshot: &NonfinalizedBlockCacheSnapshot,
+) -> GetChainTipsResponse {
+    let parent_hashes = snapshot
+        .blocks
+        .values()
+        .map(|block| *block.context.parent_hash())
+        .collect::<HashSet<_>>();
+
+    let mut tip_hashes = snapshot
+        .blocks
+        .keys()
+        .filter(|hash| !parent_hashes.contains(hash))
+        .copied()
+        .collect::<HashSet<_>>();
+    tip_hashes.insert(snapshot.best_tip.hash);
+
+    let mut tips = tip_hashes
+        .into_iter()
+        .filter_map(|hash| snapshot.blocks.get(&hash))
+        .map(|block| {
+            let is_active_tip = block.hash() == &snapshot.best_tip.hash;
+            let status = if is_active_tip {
+                ChainTipStatus::Active
+            } else {
+                ChainTipStatus::ValidFork
+            };
+            let branchlen = if is_active_tip {
+                0
+            } else {
+                branch_len_to_active_chain(snapshot, block)
+            };
+
+            ChainTip::new(
+                u32::from(block.height()),
+                block.hash().to_rpc_hex(),
+                branchlen,
+                status,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    tips.sort_by(|left, right| {
+        right
+            .height
+            .cmp(&left.height)
+            .then_with(|| left.hash.cmp(&right.hash))
+    });
+    tips
+}
+
+fn branch_len_to_active_chain(
+    snapshot: &NonfinalizedBlockCacheSnapshot,
+    block: &IndexedBlock,
+) -> u32 {
+    let mut branch_len = 0;
+    let mut current = block;
+
+    loop {
+        if snapshot.heights_to_hashes.get(&current.height()) == Some(current.hash()) {
+            return branch_len;
+        }
+
+        branch_len += 1;
+
+        let parent_hash = current.context.parent_hash();
+        let Some(parent) = snapshot.blocks.get(parent_hash) else {
+            return branch_len;
+        };
+        current = parent;
+    }
+}
 
 /// The interface to the chain index.
 ///

--- a/packages/zaino-state/src/indexer.rs
+++ b/packages/zaino-state/src/indexer.rs
@@ -9,6 +9,7 @@ use zaino_fetch::jsonrpsee::response::{
     block_deltas::BlockDeltas,
     block_header::GetBlockHeader,
     block_subsidy::GetBlockSubsidy,
+    chain_tips::GetChainTipsResponse,
     mining_info::GetMiningInfoWire,
     peer_info::GetPeerInfo,
     z_validate_address::ZValidateAddressResponse,
@@ -343,6 +344,17 @@ pub trait ZcashIndexer: Send + Sync + 'static {
     /// method: post
     /// tags: blockchain
     async fn get_block_count(&self) -> Result<Height, Self::Error>;
+
+    /// Returns information about all known tips in the block tree.
+    ///
+    /// zcashd reference: [`getchaintips`](https://zcash.github.io/rpc/getchaintips.html)
+    /// method: post
+    /// tags: blockchain
+    ///
+    /// zcashd builds the response from all block-index leaves, always includes the active
+    /// tip, sorts by descending height, and classifies leaves as `invalid`, `headers-only`,
+    /// `valid-headers`, `valid-fork`, `active`, or `unknown`.
+    async fn get_chain_tips(&self) -> Result<GetChainTipsResponse, Self::Error>;
 
     /// Return information about the given Zcash address.
     ///


### PR DESCRIPTION
## Summary
- add typed getchaintips response structs and validator pass-through support
- expose getchaintips through Zaino's JSON-RPC service and indexer trait
- synthesize zcashd-compatible chain tip data from Zaino's non-finalized snapshot when available

## Testing
- cargo test -p zaino-fetch -p zaino-state -p zaino-serve --no-run

Closes https://github.com/zingolabs/zaino/issues/204