### PR TITLE
Decode JSON-RPC null-result successes instead of dropping them

### DIFF
--- a/packages/zaino-fetch/src/jsonrpsee/connector.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/connector.rs
@@ -54,10 +54,15 @@ struct RpcRequest<T> {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct RpcResponse<T> {
+struct RpcResponse {
     id: i64,
     jsonrpc: Option<String>,
-    result: Option<T>,
+    // Capture `result` as a raw value so a JSON `null` (the documented
+    // success shape for RPCs like `gettxout` when the output is absent)
+    // flows through to the inner type instead of being indistinguishable
+    // from a missing field.
+    #[serde(default)]
+    result: serde_json::Value,
     error: Option<RpcError>,
 }
 
@@ -338,24 +343,26 @@ impl JsonRpSeeConnector {
                 )),
                 // Success
                 200..300 => {
-                    let response: RpcResponse<R> = serde_json::from_slice(&body_bytes)
+                    let response: RpcResponse = serde_json::from_slice(&body_bytes)
                         .map_err(|e| TransportError::BadNodeData(Box::new(e), type_name::<R>()))?;
 
-                    match (response.error, response.result) {
-                        (Some(error), _) => Err(RpcRequestError::Method(
+                    match response.error {
+                        Some(error) => Err(RpcRequestError::Method(
                             R::RpcError::try_from(error).map_err(|e| {
                                 RpcRequestError::UnexpectedErrorResponse(Box::new(e))
                             })?,
                         )),
-                        (None, Some(result)) => match result.to_error() {
-                            Ok(r) => Ok(r),
-                            Err(e) => Err(RpcRequestError::Method(e)),
-                        },
-                        (None, None) => Err(RpcRequestError::Transport(
-                            TransportError::EmptyResponseBody,
-                        )),
+                        None => {
+                            let result: R =
+                                serde_json::from_value(response.result).map_err(|e| {
+                                    TransportError::BadNodeData(Box::new(e), type_name::<R>())
+                                })?;
+                            match result.to_error() {
+                                Ok(r) => Ok(r),
+                                Err(e) => Err(RpcRequestError::Method(e)),
+                            }
+                        }
                     }
-                    // Error
                 }
                 400..600 => Err(RpcRequestError::Transport(TransportError::ErrorStatusCode(
                     code,
@@ -969,7 +976,7 @@ async fn test_node_connection(
         .bytes()
         .await
         .map_err(TestNodeConnectionError::ResponseBody)?;
-    let _response: RpcResponse<serde_json::Value> =
+    let _response: RpcResponse =
         serde_json::from_slice(&body_bytes).map_err(TestNodeConnectionError::BodyJson)?;
     Ok(())
 }
@@ -1046,5 +1053,55 @@ mod tests {
             result.unwrap_err(),
             TransportError::BadNodeData(_, "address resolution")
         ));
+    }
+
+    // zcashd's documented success shape for `gettxout` when the output does not
+    // exist is `{"result": null, "error": null}`. The connector must decode
+    // that into `GetTxOutResponse(None)`, not surface as a transport error.
+    #[tokio::test]
+    async fn connector_get_tx_out_null_result_decodes_as_none() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind loopback listener");
+        let addr = listener.local_addr().expect("listener local_addr");
+
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.expect("accept");
+            let mut scratch = [0u8; 4096];
+            let _ = sock.read(&mut scratch).await;
+            let body = r#"{"id":0,"result":null,"error":null,"jsonrpc":"2.0"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: application/json\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\
+                 \r\n\
+                 {}",
+                body.len(),
+                body,
+            );
+            sock.write_all(response.as_bytes())
+                .await
+                .expect("write response");
+            let _ = sock.shutdown().await;
+        });
+
+        let url = Url::parse(&format!("http://{addr}/")).expect("parse url");
+        let connector =
+            JsonRpSeeConnector::new_with_basic_auth(url, "u".into(), "p".into())
+                .expect("build connector");
+
+        let result = connector
+            .get_tx_out("00".repeat(32), 0, None)
+            .await
+            .expect(
+                "null result for gettxout must decode to GetTxOutResponse(None), \
+                 not surface as a transport error",
+            );
+
+        assert_eq!(result, GetTxOutResponse(None));
     }
 }

--- a/packages/zaino-fetch/src/jsonrpsee/error.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/error.rs
@@ -55,10 +55,6 @@ pub enum TransportError {
         Box<dyn std::error::Error + Send + Sync + 'static>,
         &'static str,
     ),
-
-    /// Validator returned empty response body
-    #[error("no response body")]
-    EmptyResponseBody,
 }
 
 impl TransportError {


### PR DESCRIPTION
  `JsonRpSeeConnector::send_request` was treating `{"result":null,"error":null}`
  as a transport error, which broke any RPC whose documented success shape is
  null — most visibly `gettxout` for missing or spent outputs.

  `RpcResponse.result` was widened from `T` to `Option<T>` in 23f660af6b ("better
  zebra error propagation"), with a new `(None, None) => EmptyResponseBody` arm
  that swallowed legitimate null successes before the inner type could see them.
  `GetTxOutResponse(pub Option<Value>)` is already designed to deserialize from
  `null`; the outer Option just never gave it the chance.

  Capture `result` as a `serde_json::Value` with `#[serde(default)]` and decode
  it into `R` after the error field is checked. Null then flows through to the
  inner type unchanged; inner types that genuinely cannot accept null surface
  as `BadNodeData`, which is more accurate than the prior `EmptyResponseBody`.
  The variant has no remaining callers and is removed.

  Add a hermetic connector regression test (`tokio::net::TcpListener` serving a
  canned null-result envelope) so this can't silently regress without zcashd.

  Fixes: #1106

  Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>