### PR TITLE
Simplify migration testing and metadata only migration implementation

### DIFF
--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -745,13 +745,226 @@ impl ZainoDB {
     pub(crate) async fn get_metadata(&self) -> Result<DbMetadata, FinalisedStateError> {
         self.db.get_metadata().await
     }
+}
 
-    /// Returns the internal router (test-only).
+#[cfg(test)]
+impl ZainoDB {
+    /// Returns the internal router.
     ///
-    /// This is intended for unit/integration tests that need to observe or manipulate routing state
-    /// during migrations. Production code should not depend on the router directly.
-    #[cfg(test)]
+    /// This is a test-only escape hatch for unit and integration tests that need direct access to
+    /// the routed backend, usually to inspect metadata, validate migration results, or exercise
+    /// backend-specific capability methods after a test database has been constructed.
+    ///
+    /// Production code should use the public `ZainoDB` API instead of depending on the router
+    /// directly.
     pub(crate) fn router(&self) -> &Router {
         &self.db
+    }
+
+    /// Opens an existing test database and migrates it to `target_version`.
+    ///
+    /// This helper is intended to be called after a historical fixture database has already been
+    /// created on disk, for example by [`ZainoDB::build_clean_v1_0_0`]. It does not create a new
+    /// database if none exists. A missing database is treated as a test setup error.
+    ///
+    /// The method:
+    /// - rejects target versions newer than the current compiled [`DB_VERSION_V1`],
+    /// - discovers the existing on-disk major database version,
+    /// - opens the matching backend implementation,
+    /// - reads the precise metadata version stored on disk,
+    /// - runs migrations when the stored version is older than `target_version`, and
+    /// - verifies that the final metadata version exactly matches `target_version`.
+    ///
+    /// This is useful when a test needs to start from a known old database version and assert that
+    /// migrations stop at a specific target version rather than always migrating to the latest
+    /// supported version.
+    pub(crate) async fn spawn_with_target_version<T>(
+        cfg: BlockCacheConfig,
+        source: T,
+        target_version: DbVersion,
+    ) -> Result<Self, FinalisedStateError>
+    where
+        T: BlockchainSource,
+    {
+        if target_version.major() > DB_VERSION_V1.major() {
+            return Err(FinalisedStateError::Custom(format!(
+                "unsupported database version: {target_version}"
+            )));
+        }
+        if target_version.major() == DB_VERSION_V1.major() && target_version > DB_VERSION_V1 {
+            return Err(FinalisedStateError::Custom(format!(
+                "unsupported database version: {target_version}"
+            )));
+        }
+
+        let version_opt = Self::try_find_current_db_version(&cfg).await;
+
+        let backend = match version_opt {
+            Some(version) => {
+                info!(version, "Opening ZainoDB from file");
+                match version {
+                    0 => DbBackend::spawn_v0(&cfg).await?,
+                    1 => DbBackend::spawn_v1(&cfg).await?,
+                    _ => {
+                        return Err(FinalisedStateError::Custom(format!(
+                            "unsupported database version: DbV{version}"
+                        )));
+                    }
+                }
+            }
+            None => {
+                return Err(FinalisedStateError::Custom(
+                    "expected existing v1.0.0 migration-test database, found no database"
+                        .to_string(),
+                ));
+            }
+        };
+        let current_version = backend.get_metadata().await?.version();
+
+        let router = Arc::new(Router::new(Arc::new(backend)));
+
+        if current_version < target_version {
+            info!(
+                from_version = %current_version,
+                to_version = %target_version,
+                "Starting ZainoDB migration"
+            );
+            let mut migration_manager = MigrationManager {
+                router: Arc::clone(&router),
+                cfg: cfg.clone(),
+                current_version,
+                target_version,
+                source,
+            };
+            migration_manager.migrate().await?;
+        }
+
+        let metadata = router.get_metadata().await?;
+        if metadata.version() != target_version {
+            return Err(FinalisedStateError::Custom(format!(
+                "database version mismatch after test spawn: expected {}, found {}",
+                target_version,
+                metadata.version()
+            )));
+        }
+
+        Ok(Self { db: router, cfg })
+    }
+
+    /// Builds a clean v1.0.0 database fixture from `source`.
+    ///
+    /// This helper creates a test-only v1 backend initialized with v1.0.0 metadata, fetches every
+    /// block from genesis through the source's best height, converts each block into an
+    /// [`IndexedBlock`], and writes it using the v1.0.0 block writer.
+    ///
+    /// The resulting database is intended to represent a pre-migration v1.0.0 database. Tests should
+    /// usually shut it down and reopen it through [`ZainoDB::spawn_with_target_version`] or
+    /// [`ZainoDB::build_db_to_version`] to exercise migration behavior.
+    ///
+    /// The supplied source must provide:
+    /// - a best block height,
+    /// - every block from genesis through that height, and
+    /// - Sapling and Orchard commitment tree roots for each block.
+    pub(crate) async fn build_clean_v1_0_0<T>(
+        cfg: &BlockCacheConfig,
+        source: T,
+    ) -> Result<DbBackend, FinalisedStateError>
+    where
+        T: BlockchainSource,
+    {
+        let db = DbBackend::spawn_v1_0_0(cfg).await?;
+        db.wait_until_ready().await;
+
+        let tip = source.get_best_block_height().await?.ok_or_else(|| {
+            FinalisedStateError::BlockchainSourceError(BlockchainSourceError::Unrecoverable(
+                "source has no best block height".to_string(),
+            ))
+        })?;
+        let tip = Height::from(tip);
+
+        let mut parent_chainwork = ChainWork::from_u256(0.into());
+
+        for height in GENESIS_HEIGHT.0..=tip.0 {
+            let block = source
+                .get_block(zebra_state::HashOrHeight::Height(
+                    zebra_chain::block::Height(height),
+                ))
+                .await?
+                .ok_or_else(|| {
+                    FinalisedStateError::BlockchainSourceError(
+                        BlockchainSourceError::Unrecoverable(format!(
+                            "source missing block at height {height}"
+                        )),
+                    )
+                })?;
+
+            let block_hash = BlockHash::from(block.hash().0);
+            let (sapling_opt, orchard_opt) = source.get_commitment_tree_roots(block_hash).await?;
+            let (sapling_root, sapling_size) = sapling_opt.ok_or_else(|| {
+                FinalisedStateError::BlockchainSourceError(BlockchainSourceError::Unrecoverable(
+                    format!("missing Sapling commitment tree root for block {block_hash}"),
+                ))
+            })?;
+            let (orchard_root, orchard_size) = orchard_opt.ok_or_else(|| {
+                FinalisedStateError::BlockchainSourceError(BlockchainSourceError::Unrecoverable(
+                    format!("missing Orchard commitment tree root for block {block_hash}"),
+                ))
+            })?;
+
+            let metadata = BlockMetadata::new(
+                sapling_root,
+                sapling_size as u32,
+                orchard_root,
+                orchard_size as u32,
+                parent_chainwork,
+                cfg.network.to_zebra_network(),
+            );
+            let block_with_metadata = BlockWithMetadata::new(block.as_ref(), metadata);
+            let chain_block = IndexedBlock::try_from(block_with_metadata).map_err(|_| {
+                FinalisedStateError::BlockchainSourceError(BlockchainSourceError::Unrecoverable(
+                    format!("error building block data at height {height}"),
+                ))
+            })?;
+            parent_chainwork = chain_block.context.chainwork;
+
+            db.write_block_v1_0_0(chain_block).await?;
+        }
+
+        Ok(db)
+    }
+
+    /// Builds a v1.0.0 fixture database and migrates it to `target_version`.
+    ///
+    /// This is the high-level migration-test constructor. It first creates a clean v1.0.0 database
+    /// using [`ZainoDB::build_clean_v1_0_0`], shuts that backend down so all LMDB state is flushed
+    /// and released, then reopens the same database through [`ZainoDB::spawn_with_target_version`].
+    ///
+    /// During the reopen step, the stored v1.0.0 metadata is used as the migration starting point
+    /// and `target_version` is used as the explicit migration target.
+    ///
+    /// Use this helper when a test wants a fully initialized [`ZainoDB`] at a specific version after
+    /// exercising the migration path from v1.0.0. The target version must be at least v1.0.0 and no
+    /// newer than the current compiled [`DB_VERSION_V1`].
+    pub(crate) async fn build_db_to_version<T>(
+        cfg: BlockCacheConfig,
+        source: T,
+        target_version: DbVersion,
+    ) -> Result<Self, FinalisedStateError>
+    where
+        T: BlockchainSource,
+    {
+        let v1_0_0 = DbVersion::new(1, 0, 0);
+        if target_version < v1_0_0 {
+            return Err(FinalisedStateError::Custom(format!(
+                "target version {} is older than v1.0.0",
+                target_version
+            )));
+        }
+
+        let db = Self::build_clean_v1_0_0(&cfg, source.clone()).await?;
+        db.shutdown().await?;
+        drop(db);
+
+        Self::spawn_with_target_version(cfg, source, target_version).await
     }
 }

--- a/packages/zaino-state/src/chain_index/finalised_state/db.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db.rs
@@ -738,6 +738,36 @@ impl TransparentHistExt for DbBackend {
 }
 
 #[cfg(test)]
+impl DbBackend {
+    /// Spawn a test-only v1 backend initialized as a v1.0.0 database.
+    ///
+    /// Used by migration tests to create a historical v1.0.0 database fixture before reopening it
+    /// through the current startup / migration path.
+    pub(crate) async fn spawn_v1_0_0(cfg: &BlockCacheConfig) -> Result<Self, FinalisedStateError> {
+        Ok(Self::V1(DbV1::spawn_v1_0_0(cfg).await?))
+    }
+
+    /// Writes a block using the v1.0.0 format.
+    ///
+    /// This intentionally writes only the core v1 tables and uses v1 item encodings.
+    ///
+    /// This method does not perform safety checks and must not be used in production code.
+    ///
+    /// Used for migration tests.
+    pub(crate) async fn write_block_v1_0_0(
+        &self,
+        block: IndexedBlock,
+    ) -> Result<(), FinalisedStateError> {
+        match self {
+            Self::V1(db) => db.write_block_v1_0_0(block).await,
+            Self::V0(_) => Err(FinalisedStateError::Custom(
+                "v1.0.0 test fixture writer requires a v1 backend".to_string(),
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
 mod shutdown {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -648,3 +648,130 @@ impl Drop for DbV1 {
         }
     }
 }
+
+#[cfg(test)]
+impl DbV1 {
+    /// Spawns a test-only [`DbV1`] using the v1.0.0 database metadata.
+    ///
+    /// This method is intended for migration tests that need to create an old v1.0.0 database
+    /// before opening it through the current startup / migration path.
+    ///
+    /// This method:
+    /// - chooses the normal V1 path suffix (`.../<network>/v1`),
+    /// - configures LMDB map size and reader slots,
+    /// - opens or creates the v1.0.0 named databases,
+    /// - writes a `"metadata"` record with database version `1.0.0`, and
+    /// - spawns the background validator / maintenance task.
+    ///
+    /// Unlike [`DbV1::spawn`], this method intentionally does **not** call
+    /// [`DbV1::check_schema_version`], because that would initialize fresh metadata using the
+    /// current [`DB_VERSION_V1`] value instead of the historical v1.0.0 value required by the tests.
+    pub(crate) async fn spawn_v1_0_0(
+        config: &BlockCacheConfig,
+    ) -> Result<Self, FinalisedStateError> {
+        info!("Launching ZainoDB");
+
+        // Prepare database details and path.
+        let db_size_bytes = config.storage.database.size.to_byte_count();
+        let db_path_dir = match config.network.to_zebra_network().kind() {
+            NetworkKind::Mainnet => "mainnet",
+            NetworkKind::Testnet => "testnet",
+            NetworkKind::Regtest => "regtest",
+        };
+        let db_path = config.storage.database.path.join(db_path_dir).join("v1");
+        if !db_path.exists() {
+            fs::create_dir_all(&db_path)?;
+        }
+
+        // Check system rescources to set max db reeaders, clamped between 512 and 4096.
+        let cpu_cnt = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(4);
+
+        // Sets LMDB max_readers based on CPU count (cpu * 32), clamped between 512 and 4096.
+        // Allows high async read concurrency while keeping memory use low (~192B per slot).
+        // The 512 min ensures reasonable capacity even on low-core systems.
+        let max_readers = u32::try_from((cpu_cnt * 32).clamp(512, 4096))
+            .expect("max_readers was clamped to fit in u32");
+
+        // Open LMDB environment and set environmental details.
+        let env = Environment::new()
+            .set_max_dbs(12)
+            .set_map_size(db_size_bytes)
+            .set_max_readers(max_readers)
+            .set_flags(EnvironmentFlags::NO_TLS | EnvironmentFlags::NO_READAHEAD)
+            .open(&db_path)?;
+
+        // Open individual LMDB DBs.
+        let headers =
+            super::open_or_create_db(&env, "headers_1_0_0", DatabaseFlags::empty()).await?;
+        let txids = super::open_or_create_db(&env, "txids_1_0_0", DatabaseFlags::empty()).await?;
+        let transparent =
+            super::open_or_create_db(&env, "transparent_1_0_0", DatabaseFlags::empty()).await?;
+        let sapling =
+            super::open_or_create_db(&env, "sapling_1_0_0", DatabaseFlags::empty()).await?;
+        let orchard =
+            super::open_or_create_db(&env, "orchard_1_0_0", DatabaseFlags::empty()).await?;
+        let commitment_tree_data =
+            super::open_or_create_db(&env, "commitment_tree_data_1_0_0", DatabaseFlags::empty())
+                .await?;
+        let hashes = super::open_or_create_db(&env, "hashes_1_0_0", DatabaseFlags::empty()).await?;
+
+        let metadata = super::open_or_create_db(&env, "metadata", DatabaseFlags::empty()).await?;
+
+        // Create the DbV1 instance. We declare the variable in the outer scope and
+        // initialise it in the two cfg arms so `zaino_db` is available afterwards.
+        let mut zaino_db: Self;
+
+        zaino_db = Self {
+            env: Arc::new(env),
+            headers,
+            txids,
+            transparent,
+            sapling,
+            orchard,
+            commitment_tree_data,
+            heights: hashes,
+            metadata,
+            validated_tip: Arc::new(AtomicU32::new(0)),
+            validated_set: DashSet::new(),
+            db_handler: std::sync::Mutex::new(None),
+            cancel_token: CancellationToken::new(),
+            status: NamedAtomicStatus::new("ZainoDB", StatusType::Spawning),
+            config: config.clone(),
+        };
+
+        // Initialise the metadata entry before we touch any tables.
+        tokio::task::block_in_place(|| {
+            let mut txn = zaino_db.env.begin_rw_txn()?;
+
+            let entry = StoredEntryFixed::new(
+                b"metadata",
+                DbMetadata {
+                    version: DbVersion {
+                        major: 1,
+                        minor: 0,
+                        patch: 0,
+                    },
+                    schema_hash: [0u8; 32],
+                    migration_status: MigrationStatus::Empty,
+                },
+            );
+            txn.put(
+                zaino_db.metadata,
+                b"metadata",
+                &entry.to_bytes()?,
+                WriteFlags::NO_OVERWRITE,
+            )?;
+
+            txn.commit()?;
+
+            Ok::<(), FinalisedStateError>(())
+        })?;
+
+        // Spawn handler task to perform background validation and trailing tx cleanup.
+        zaino_db.spawn_handler().await?;
+
+        Ok(zaino_db)
+    }
+}

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -1,6 +1,8 @@
 //! ZainoDB::V1 core write functionality.
 
 use super::*;
+#[cfg(test)]
+use crate::version;
 
 /// [`DbWrite`] capability implementation for [`DbV1`].
 ///
@@ -1028,6 +1030,168 @@ impl DbV1 {
             Ok(())
         })
     }
+}
 
-    // *** Internal DB methods ***
+#[cfg(test)]
+impl DbV1 {
+    /// Writes a block using the v1.0.0 format.
+    ///
+    /// This intentionally writes only the core v1 tables and uses v1 item encodings.
+    ///
+    /// This method does not perform safety checks and must not be used in production code.
+    ///
+    /// Used for migration tests.
+    pub(crate) async fn write_block_v1_0_0(
+        &self,
+        block: IndexedBlock,
+    ) -> Result<(), FinalisedStateError> {
+        self.status.store(StatusType::Syncing);
+
+        let block_hash = block.context.index.hash;
+        let block_hash_bytes = block_hash.to_bytes()?;
+        let block_height = block.context.index.height;
+        let block_height_bytes = block_height.to_bytes()?;
+
+        let height_entry_bytes = StoredEntryFixed::<Height>::to_bytes_with_item_version(
+            &block_hash_bytes,
+            &block.context.index.height,
+            version::V1,
+        )?;
+
+        let header = BlockHeaderData::new(block.context, *block.data());
+        let header_entry_bytes = StoredEntryVar::<BlockHeaderData>::to_bytes_with_item_version(
+            &block_height_bytes,
+            &header,
+            version::V1,
+        )?;
+
+        let commitment_tree_entry_bytes =
+            StoredEntryFixed::<CommitmentTreeData>::to_bytes_with_item_version(
+                &block_height_bytes,
+                block.commitment_tree_data(),
+                version::V1,
+            )?;
+
+        let tx_len = block.transactions().len();
+        let mut txids = Vec::with_capacity(tx_len);
+        let mut txid_set: HashSet<TransactionHash> = HashSet::with_capacity(tx_len);
+        let mut transparent = Vec::with_capacity(tx_len);
+        let mut sapling = Vec::with_capacity(tx_len);
+        let mut orchard = Vec::with_capacity(tx_len);
+
+        for tx in block.transactions() {
+            let hash = tx.txid();
+
+            if txid_set.insert(*hash) {
+                txids.push(*hash);
+            }
+
+            let transparent_data =
+                if tx.transparent().inputs().is_empty() && tx.transparent().outputs().is_empty() {
+                    None
+                } else {
+                    Some(tx.transparent().clone())
+                };
+            transparent.push(transparent_data);
+
+            let sapling_data =
+                if tx.sapling().spends().is_empty() && tx.sapling().outputs().is_empty() {
+                    None
+                } else {
+                    Some(tx.sapling().clone())
+                };
+            sapling.push(sapling_data);
+
+            let orchard_data = if tx.orchard().actions().is_empty() {
+                None
+            } else {
+                Some(tx.orchard().clone())
+            };
+            orchard.push(orchard_data);
+        }
+
+        let txid_list = TxidList::new(txids);
+        let txid_entry_bytes = StoredEntryVar::<TxidList>::to_bytes_with_item_version(
+            &block_height_bytes,
+            &txid_list,
+            version::V1,
+        )?;
+
+        let transparent_tx_list = TransparentTxList::new(transparent);
+        let transparent_entry_bytes =
+            StoredEntryVar::<TransparentTxList>::to_bytes_with_item_version(
+                &block_height_bytes,
+                &transparent_tx_list,
+                version::V1,
+            )?;
+
+        let sapling_tx_list = SaplingTxList::new(sapling);
+        let sapling_entry_bytes = StoredEntryVar::<SaplingTxList>::to_bytes_with_item_version(
+            &block_height_bytes,
+            &sapling_tx_list,
+            version::V1,
+        )?;
+
+        let orchard_tx_list = OrchardTxList::new(orchard);
+        let orchard_entry_bytes = StoredEntryVar::<OrchardTxList>::to_bytes_with_item_version(
+            &block_height_bytes,
+            &orchard_tx_list,
+            version::V1,
+        )?;
+
+        tokio::task::block_in_place(|| {
+            let mut txn = self.env.begin_rw_txn()?;
+
+            txn.put(
+                self.headers,
+                &block_height_bytes,
+                &header_entry_bytes,
+                WriteFlags::NO_OVERWRITE,
+            )?;
+            txn.put(
+                self.heights,
+                &block_hash_bytes,
+                &height_entry_bytes,
+                WriteFlags::NO_OVERWRITE,
+            )?;
+            txn.put(
+                self.txids,
+                &block_height_bytes,
+                &txid_entry_bytes,
+                WriteFlags::NO_OVERWRITE,
+            )?;
+            txn.put(
+                self.transparent,
+                &block_height_bytes,
+                &transparent_entry_bytes,
+                WriteFlags::NO_OVERWRITE,
+            )?;
+            txn.put(
+                self.sapling,
+                &block_height_bytes,
+                &sapling_entry_bytes,
+                WriteFlags::NO_OVERWRITE,
+            )?;
+            txn.put(
+                self.orchard,
+                &block_height_bytes,
+                &orchard_entry_bytes,
+                WriteFlags::NO_OVERWRITE,
+            )?;
+            txn.put(
+                self.commitment_tree_data,
+                &block_height_bytes,
+                &commitment_tree_entry_bytes,
+                WriteFlags::NO_OVERWRITE,
+            )?;
+
+            txn.commit()?;
+            self.env.sync(true)?;
+
+            Ok::<_, FinalisedStateError>(())
+        })?;
+
+        self.status.store(StatusType::Ready);
+        Ok(())
+    }
 }

--- a/packages/zaino-state/src/chain_index/finalised_state/entry.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/entry.rs
@@ -181,6 +181,44 @@ impl<T: ZainoVersionedSerde + FixedEncodedLen> StoredEntryFixed<T> {
             .expect("Failed to finalize hash");
         output
     }
+
+    /// Builds serialized stored-entry bytes using a specific inner item version.
+    ///
+    /// This is required when writing historical database values whose inner item must be encoded
+    /// with an older version than `T::VERSION`.
+    ///
+    /// The returned bytes are:
+    /// - StoredEntryFixed version tag
+    /// - inner item bytes encoded with `item_version`
+    /// - checksum over `encoded_key || inner_item_bytes`
+    ///
+    /// This method returns serialized bytes directly because `StoredEntryFixed<T>` does not store
+    /// the inner item version. Constructing `Self` alone would lose the requested item version
+    /// before the value is written.
+    #[cfg(test)]
+    pub(crate) fn to_bytes_with_item_version<K: AsRef<[u8]>>(
+        key: K,
+        item: &T,
+        item_version: u8,
+    ) -> io::Result<Vec<u8>> {
+        let item_bytes = item.to_bytes_with_version(item_version)?;
+
+        if item_bytes.len() != T::VERSIONED_LEN {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "encoded fixed-length item has an unexpected length",
+            ));
+        }
+
+        let checksum = Self::blake2b256(&[key.as_ref(), &item_bytes].concat());
+
+        let mut stored_entry_bytes = Vec::with_capacity(1 + T::VERSIONED_LEN + 32);
+        stored_entry_bytes.push(Self::VERSION);
+        stored_entry_bytes.extend_from_slice(&item_bytes);
+        stored_entry_bytes.extend_from_slice(&checksum);
+
+        Ok(stored_entry_bytes)
+    }
 }
 
 /// Versioned on-disk encoding for fixed-length checksummed entries.
@@ -314,6 +352,38 @@ impl<T: ZainoVersionedSerde> StoredEntryVar<T> {
             .finalize_variable(&mut output)
             .expect("Failed to finalize hash");
         output
+    }
+
+    /// Builds serialized stored-entry bytes using a specific inner item version.
+    ///
+    /// This is required when writing historical database values whose inner item must be encoded
+    /// with an older version than `T::VERSION`.
+    ///
+    /// The returned bytes are:
+    /// - StoredEntryVar version tag
+    /// - CompactSize length of the inner item bytes
+    /// - inner item bytes encoded with `item_version`
+    /// - checksum over `encoded_key || inner_item_bytes`
+    ///
+    /// This method returns serialized bytes directly because `StoredEntryVar<T>` does not store
+    /// the inner item version. Constructing `Self` alone would lose the requested item version
+    /// before the value is written.
+    #[cfg(test)]
+    pub(crate) fn to_bytes_with_item_version<K: AsRef<[u8]>>(
+        key: K,
+        item: &T,
+        item_version: u8,
+    ) -> io::Result<Vec<u8>> {
+        let item_bytes = item.to_bytes_with_version(item_version)?;
+        let checksum = Self::blake2b256(&[key.as_ref(), &item_bytes].concat());
+
+        let mut stored_entry_bytes = Vec::new();
+        stored_entry_bytes.push(Self::VERSION);
+        CompactSize::write(&mut stored_entry_bytes, item_bytes.len())?;
+        stored_entry_bytes.extend_from_slice(&item_bytes);
+        write_fixed_le::<32, _>(&mut stored_entry_bytes, &checksum)?;
+
+        Ok(stored_entry_bytes)
     }
 }
 

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -221,12 +221,38 @@ pub trait Migration<T: BlockchainSource> {
     ///
     /// # Errors
     /// Returns `FinalisedStateError` if the migration cannot proceed safely or deterministically.
+    ///
+    /// **Default**: Metadata-only migration.
+    ///
+    /// Use this for migrations where no LMDB data layout changes are required.
     async fn migrate(
         &self,
         router: Arc<Router>,
-        cfg: BlockCacheConfig,
-        source: T,
-    ) -> Result<(), FinalisedStateError>;
+        _cfg: BlockCacheConfig,
+        _source: T,
+    ) -> Result<(), FinalisedStateError> {
+        info!(
+            "Starting metadata-only migration from {} to {}.",
+            Self::CURRENT_VERSION,
+            Self::TO_VERSION,
+        );
+
+        let mut metadata: DbMetadata = router.get_metadata().await?;
+
+        metadata.version = Self::TO_VERSION;
+        metadata.schema_hash = crate::chain_index::finalised_state::db::v1::DB_SCHEMA_V1_HASH;
+        metadata.migration_status = MigrationStatus::Empty;
+
+        router.update_metadata(metadata).await?;
+
+        info!(
+            "Metadata-only migration from {} to {} complete.",
+            Self::CURRENT_VERSION,
+            Self::TO_VERSION,
+        );
+
+        Ok(())
+    }
 }
 
 /// Orchestrates a sequence of migration steps until `target_version` is reached.
@@ -564,31 +590,4 @@ impl<T: BlockchainSource> Migration<T> for Migration1_0_0To1_1_0 {
         minor: 1,
         patch: 0,
     };
-
-    async fn migrate(
-        &self,
-        router: Arc<Router>,
-        _cfg: BlockCacheConfig,
-        _source: T,
-    ) -> Result<(), FinalisedStateError> {
-        info!("Starting v1.0.0 → v1.1.0 migration (metadata-only).");
-
-        let mut metadata: DbMetadata = router.get_metadata().await?;
-
-        // Advance the version marker to reflect the new API contract (v1.1.0), and refresh the
-        // persisted schema hash to match the repository's recorded schema contract.
-        // There are no on-disk layout changes; BlockIndex V2 is supported in-place because the
-        // headers table stores a variable-length BlockHeaderData which nests a versioned BlockIndex.
-        metadata.version = <Self as Migration<T>>::TO_VERSION;
-        metadata.schema_hash = crate::chain_index::finalised_state::db::v1::DB_SCHEMA_V1_HASH;
-
-        // Outside of migrations this should be `Empty`. This step performs no build phases, so we
-        // ensure we do not leave a stale in-progress status behind.
-        metadata.migration_status = MigrationStatus::Empty;
-
-        router.update_metadata(metadata).await?;
-
-        info!("v1.0.0 to v1.1.0 migration complete.");
-        Ok(())
-    }
 }

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/migrations.rs
@@ -1,25 +1,20 @@
 //! Holds database migration tests.
 
 use std::path::PathBuf;
-use std::sync::Arc;
 use tempfile::TempDir;
 use zaino_common::network::ActivationHeights;
 use zaino_common::{DatabaseConfig, Network, StorageConfig};
 
 use crate::chain_index::finalised_state::capability::{
-    BlockCoreExt as _, DbCore as _, DbRead as _, DbVersion, DbWrite as _, MigrationStatus,
+    DbCore as _, DbRead as _, DbVersion, MigrationStatus,
 };
-use crate::chain_index::finalised_state::db::v1::DB_SCHEMA_V1_HASH;
 use crate::chain_index::finalised_state::db::DbBackend;
-use crate::chain_index::finalised_state::entry::StoredEntryVar;
 use crate::chain_index::finalised_state::ZainoDB;
 use crate::chain_index::tests::init_tracing;
 use crate::chain_index::tests::vectors::{
-    build_mockchain_source, load_test_vectors, TestVectorData,
+    build_active_mockchain_source, build_mockchain_source, load_test_vectors, TestVectorData,
 };
-use crate::{
-    version, BlockCacheConfig, BlockHeaderData, CompactSize, Height, ZainoVersionedSerde as _,
-};
+use crate::{BlockCacheConfig, Height};
 
 #[tokio::test(flavor = "multi_thread")]
 async fn v0_to_v1_full() {
@@ -219,17 +214,15 @@ async fn v0_to_v1_partial() {
 async fn v1_0_to_v1_1_metadata_migration() {
     init_tracing();
 
-    // Prepare test blocks/source (we won't rely on heavy rebuild in this metadata-only migration)
     let TestVectorData { blocks, .. } = load_test_vectors().unwrap();
 
     let temp_dir: TempDir = tempfile::tempdir().unwrap();
     let db_path: PathBuf = temp_dir.path().to_path_buf();
 
-    // BlockCacheConfig: use v1 target like other tests
     let v1_config = BlockCacheConfig {
         storage: StorageConfig {
             database: DatabaseConfig {
-                path: db_path.clone(),
+                path: db_path,
                 ..Default::default()
             },
             ..Default::default()
@@ -238,90 +231,51 @@ async fn v1_0_to_v1_1_metadata_migration() {
         network: Network::Regtest(ActivationHeights::default()),
     };
 
-    let source = build_mockchain_source(blocks.clone());
+    let source = build_active_mockchain_source(150, blocks.clone());
 
-    // Build v1 database.
-    let zaino_db = ZainoDB::spawn(v1_config.clone(), source.clone())
-        .await
-        .unwrap();
-    crate::chain_index::tests::vectors::sync_db_with_blockdata(
-        zaino_db.router(),
-        blocks.clone(),
-        None,
-    )
-    .await;
-
-    zaino_db.wait_until_ready().await;
-    dbg!(zaino_db.status());
-    dbg!(zaino_db.db_height().await.unwrap());
-
-    // 2) Coerce the metadata to look like an older 1.0.0 DB with a stale schema hash and an
-    //    in-progress migration status so the migration has work to do.
-    let mut metadata = zaino_db.get_metadata().await.unwrap();
-    metadata.version = DbVersion {
-        major: 1,
-        minor: 0,
-        patch: 0,
-    };
-    // An obviously different schema hash (any non-matching 32 bytes will do)
-    metadata.schema_hash = [0u8; 32];
-    // Set a non-empty migration status to ensure migration clears it
-    metadata.migration_status = MigrationStatus::PartialBuidInProgress;
-
-    zaino_db.router().update_metadata(metadata).await.unwrap();
-
-    // shutdown this backend so ZainoDB::spawn will open the same DB and perform migration
-    dbg!(zaino_db.shutdown().await.unwrap());
-
-    // Let the filesystem settle (tests elsewhere do a brief sleep)
-    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-
-    // 3) Spawn ZainoDB which should detect current_version == 1.0.0 < target 1.1.0 and run the metadata
-    //    migration. We await until ready so migration completes.
-    let zaino_db = ZainoDB::spawn(v1_config, source).await.unwrap();
-    zaino_db.wait_until_ready().await;
-
-    // 4) Read persisted metadata and assert migration effects.
-    let post_meta = zaino_db.get_metadata().await.unwrap();
-    assert_eq!(
-        post_meta.version,
+    let zaino_db = ZainoDB::build_db_to_version(
+        v1_config,
+        source,
         DbVersion {
             major: 1,
             minor: 1,
-            patch: 0
+            patch: 0,
+        },
+    )
+    .await
+    .unwrap();
+
+    zaino_db.wait_until_ready().await;
+
+    let metadata = zaino_db.get_metadata().await.unwrap();
+
+    assert_eq!(
+        metadata.version,
+        DbVersion {
+            major: 1,
+            minor: 1,
+            patch: 0,
         }
     );
-    assert_eq!(post_meta.migration_status, MigrationStatus::Empty);
-    assert_eq!(post_meta.schema_hash, DB_SCHEMA_V1_HASH);
+    assert_eq!(metadata.migration_status, MigrationStatus::Empty);
+    assert_eq!(
+        metadata.schema_hash,
+        crate::chain_index::finalised_state::db::v1::DB_SCHEMA_V1_HASH
+    );
+
+    let db_height = zaino_db.db_height().await.unwrap().unwrap();
+    assert_eq!(db_height, Height(150));
 
     zaino_db.shutdown().await.unwrap();
 }
 
-/// Tests that a database containing a mix of V1-encoded and V2-encoded
-/// `BlockHeaderData` entries — which arises when a v1.0.0 deployment is upgraded
-/// to v1.1.0 mid-chain — deserialises every header correctly and returns the right
-/// height for every block.
-///
-/// Scenario:
-///   Phase 1 – write first half of the chain using the normal V2 path, then
-///              backpatch those header entries in LMDB to use the V1 wire format
-///              (simulating a v1.0.0 on-disk state) and downgrade the stored
-///              metadata to 1.0.0.
-///   Phase 2 – reopen with ZainoDB (target 1.1.0); the metadata-only migration
-///              runs, bumping the version without touching the headers table.
-///   Phase 3 – write the second half using the current V2 path.
-///   Phase 4 – assert that every header (V1 or V2 on-disk) deserialises to the
-///              correct height.
 #[tokio::test(flavor = "multi_thread")]
 async fn v1_0_to_v1_1_mixed_blockheaderdata_formats() {
     init_tracing();
 
     let TestVectorData { blocks, .. } = load_test_vectors().unwrap();
 
-    // Split at the midpoint so the DB will eventually hold both encoding formats.
-    let split = blocks.len() / 2;
-    let first_half = blocks[..split].to_vec();
-    let second_half = blocks[split..].to_vec();
+    let initial_active_height = Height(150);
 
     let temp_dir: TempDir = tempfile::tempdir().unwrap();
     let db_path: PathBuf = temp_dir.path().to_path_buf();
@@ -329,7 +283,7 @@ async fn v1_0_to_v1_1_mixed_blockheaderdata_formats() {
     let v1_config = BlockCacheConfig {
         storage: StorageConfig {
             database: DatabaseConfig {
-                path: db_path.clone(),
+                path: db_path,
                 ..Default::default()
             },
             ..Default::default()
@@ -338,188 +292,135 @@ async fn v1_0_to_v1_1_mixed_blockheaderdata_formats() {
         network: Network::Regtest(ActivationHeights::default()),
     };
 
-    let source = build_mockchain_source(blocks.clone());
+    let source = build_active_mockchain_source(initial_active_height.0, blocks.clone());
 
-    // ── Phase 1: build first half (V2 write path), collect headers, downgrade metadata ──
+    let old_db = ZainoDB::build_clean_v1_0_0(&v1_config, source.clone())
+        .await
+        .unwrap();
 
-    // Spawn the v1 backend directly so we can call `get_block_header` without
-    // going through ZainoDB's migration logic.
-    let db = DbBackend::spawn_v1(&v1_config).await.unwrap();
-    crate::chain_index::tests::vectors::sync_db_with_blockdata(&db, first_half.clone(), None).await;
+    let old_db_height = old_db.db_height().await.unwrap().unwrap();
+    assert_eq!(old_db_height, initial_active_height);
 
-    // Wait for the background validator to mark all first-half blocks as known-good
-    // so that `get_block_header` can take the fast path.
-    db.wait_until_ready().await;
-
-    // Read back the decoded headers; we will re-encode them as V1 below.
-    let mut first_half_headers: Vec<(Height, BlockHeaderData)> = Vec::new();
-    for block_data in &first_half {
-        let h = Height(block_data.height);
-        let header = db.get_block_header(h).await.unwrap();
-        first_half_headers.push((h, header));
-    }
-
-    // Downgrade stored metadata to 1.0.0 so ZainoDB::spawn will trigger the
-    // minor migration when we reopen.
-    let mut meta = db.get_metadata().await.unwrap();
-    meta.version = DbVersion {
-        major: 1,
-        minor: 0,
-        patch: 0,
-    };
-    meta.schema_hash = [0u8; 32]; // stale hash; migration will refresh it
-    db.update_metadata(meta).await.unwrap();
-
-    db.shutdown().await.unwrap();
-    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-
-    // ── Phase 2: overwrite first-half headers with correctly-checksummed V1 bytes ──
-    //
-    // We open the LMDB environment directly (the ZainoDB is shut down, so there is
-    // no active writer) and replace each header entry with bytes that carry a V1-
-    // encoded BlockHeaderData (BlockIndex with *optional* height) and a checksum
-    // computed over those V1 bytes.  After this the `headers_1_0_0` table holds:
-    //
-    //   heights  0 .. split-1  → StoredEntryVar with V1-encoded BlockHeaderData
-    //   heights  split .. N-1  → (not yet written)
-    {
-        use lmdb::{Environment, EnvironmentFlags, Transaction as _, WriteFlags};
-
-        let lmdb_path = db_path.join("regtest").join("v1");
-        let env = Environment::new()
-            .set_max_dbs(12)
-            .set_map_size(128 * 1024 * 1024) // 128 MiB – plenty for the test DB
-            .set_flags(EnvironmentFlags::NO_TLS)
-            .open(&lmdb_path)
-            .unwrap();
-
-        let headers_db = env.open_db(Some("headers_1_0_0")).unwrap();
-        let mut txn = env.begin_rw_txn().unwrap();
-
-        for (height, header) in &first_half_headers {
-            // Key = Height::to_bytes() = [V1 tag][big-endian u32]
-            let height_key = height.to_bytes().unwrap();
-
-            // Re-encode this header using the V1 wire format:
-            //   [V1 tag = 1][BlockIndex V1 body (optional height)][BlockData V1 body]
-            let v1_item_bytes = header.to_bytes_with_version(version::V1).unwrap();
-
-            // Checksum must be computed over the *exact* bytes that will be stored so
-            // that StoredEntryVar::verify() finds a match on its V1 iteration.
-            // checksum = blake2b256(height_key || v1_item_bytes)
-            let checksum = StoredEntryVar::<BlockHeaderData>::blake2b256(
-                &[height_key.as_slice(), v1_item_bytes.as_slice()].concat(),
-            );
-
-            // Build the full LMDB value for a StoredEntryVar<BlockHeaderData>:
-            //   [StoredEntry V1 outer tag][CompactSize(item_len)][item_bytes][32-byte checksum]
-            //
-            // The StoredEntry outer tag is always V1 here because StoredEntryVar::VERSION = V1.
-            // The "V1/V2" distinction lives *inside* item_bytes (the first byte of item_bytes
-            // is the BlockHeaderData version tag).
-            let mut stored_bytes: Vec<u8> = Vec::new();
-            stored_bytes.push(version::V1); // StoredEntryVar outer version tag
-            CompactSize::write(&mut stored_bytes, v1_item_bytes.len()).unwrap();
-            stored_bytes.extend_from_slice(&v1_item_bytes);
-            stored_bytes.extend_from_slice(&checksum);
-
-            // Overwrite the existing V2 entry with the V1 one.
-            txn.put(headers_db, &height_key, &stored_bytes, WriteFlags::empty())
-                .unwrap();
+    let old_metadata = old_db.get_metadata().await.unwrap();
+    assert_eq!(
+        old_metadata.version,
+        DbVersion {
+            major: 1,
+            minor: 0,
+            patch: 0,
         }
+    );
+    assert_eq!(old_metadata.migration_status, MigrationStatus::Empty);
 
-        txn.commit().unwrap();
-        env.sync(true).unwrap();
-    }
+    old_db.shutdown().await.unwrap();
+    drop(old_db);
 
     tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
-    // ── Phase 3: reopen at v1.1.0 – migration runs; write second half (V2) ──
-    //
-    // ZainoDB detects current_version 1.0.0 < target 1.1.0 and runs
-    // Migration1_0_0To1_1_0, which is metadata-only and leaves the headers table
-    // (including our freshly-written V1 entries) untouched.
-    let zaino_db = ZainoDB::spawn(v1_config.clone(), source.clone())
+    let blocks_to_mine = source.max_chain_height() - source.active_height();
+    assert!(
+        blocks_to_mine > 0,
+        "test vectors must contain blocks above the initial active height"
+    );
+
+    source.mine_blocks(blocks_to_mine);
+
+    let target_height = Height(source.active_height());
+    assert!(
+        target_height > initial_active_height,
+        "mock chain source must advance beyond the old v1.0.0 database height"
+    );
+
+    let zaino_db = std::sync::Arc::new(
+        ZainoDB::spawn_with_target_version(
+            v1_config,
+            source.clone(),
+            DbVersion {
+                major: 1,
+                minor: 1,
+                patch: 0,
+            },
+        )
         .await
-        .unwrap();
+        .unwrap(),
+    );
+
     zaino_db.wait_until_ready().await;
 
-    // Confirm the metadata migration completed correctly.
-    let post_meta = zaino_db.get_metadata().await.unwrap();
+    let migrated_metadata = zaino_db.get_metadata().await.unwrap();
     assert_eq!(
-        post_meta.version,
+        migrated_metadata.version,
         DbVersion {
             major: 1,
             minor: 1,
             patch: 0,
-        },
-        "DB version should be 1.1.0 after migration"
+        }
     );
+    assert_eq!(migrated_metadata.migration_status, MigrationStatus::Empty);
     assert_eq!(
-        post_meta.migration_status,
-        MigrationStatus::Empty,
-        "Migration status should be Empty after the metadata-only migration"
-    );
-    assert_eq!(
-        post_meta.schema_hash, DB_SCHEMA_V1_HASH,
-        "Schema hash should be refreshed to the current value"
+        migrated_metadata.schema_hash,
+        crate::chain_index::finalised_state::db::v1::DB_SCHEMA_V1_HASH
     );
 
-    // Write the second half; these use the current (V2) BlockHeaderData format,
-    // so the DB now holds V1 headers at 0..split-1 and V2 headers at split..N-1.
-    crate::chain_index::tests::vectors::sync_db_with_blockdata(
-        zaino_db.router(),
-        second_half.clone(),
-        None,
-    )
-    .await;
+    let migrated_db_height = zaino_db.db_height().await.unwrap().unwrap();
+    assert_eq!(
+        migrated_db_height, initial_active_height,
+        "metadata migration must not append newly active blocks"
+    );
+
+    zaino_db
+        .sync_to_height(target_height, &source)
+        .await
+        .unwrap();
+
     zaino_db.wait_until_ready().await;
 
-    // ── Phase 4: verify every header decodes correctly with the right height ──
-    //
-    // The initial block scan in the background task has already called
-    // validate_block_blocking() for every height, which internally invokes
-    // StoredEntryVar::verify().  For V1-encoded entries that method tries V2 first
-    // (no match), then V1 (match).  Reaching Ready status here means all blocks
-    // passed validation.
-    let zaino_db = Arc::new(zaino_db);
-    let reader = zaino_db.to_reader();
+    let synced_db_height = zaino_db.db_height().await.unwrap().unwrap();
+    assert_eq!(synced_db_height, target_height);
 
-    // V1-format headers (first half) – these were written before the format bump.
-    for block_data in &first_half {
-        let h = Height(block_data.height);
-        let header = reader
-            .get_block_header(h)
-            .await
-            .unwrap_or_else(|e| panic!("failed to read V1-format header at height {}: {e}", h.0));
-        assert_eq!(
-            header.context.index.height, h,
-            "V1-format header at height {} returned wrong height",
-            h.0
-        );
+    {
+        let reader = zaino_db.to_reader();
+
+        for height in 0..=initial_active_height.0 {
+            let height = Height(height);
+
+            let header = reader
+                .get_block_header(height)
+                .await
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "failed to read v1.0.0-format BlockHeaderData at height {}: {error}",
+                        height.0
+                    )
+                });
+
+            assert_eq!(
+                header.context.index.height, height,
+                "v1.0.0-format BlockHeaderData at height {} returned wrong height",
+                height.0
+            );
+        }
+
+        for height in (initial_active_height.0 + 1)..=target_height.0 {
+            let height = Height(height);
+
+            let header = reader
+                .get_block_header(height)
+                .await
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "failed to read current-format BlockHeaderData at height {}: {error}",
+                        height.0
+                    )
+                });
+
+            assert_eq!(
+                header.context.index.height, height,
+                "current-format BlockHeaderData at height {} returned wrong height",
+                height.0
+            );
+        }
     }
-
-    // V2-format headers (second half) – written after the migration.
-    for block_data in &second_half {
-        let h = Height(block_data.height);
-        let header = reader
-            .get_block_header(h)
-            .await
-            .unwrap_or_else(|e| panic!("failed to read V2-format header at height {}: {e}", h.0));
-        assert_eq!(
-            header.context.index.height, h,
-            "V2-format header at height {} returned wrong height",
-            h.0
-        );
-    }
-
-    // The overall DB tip should cover the full chain.
-    let db_height = zaino_db.db_height().await.unwrap().unwrap();
-    let expected_tip = Height((blocks.len() - 1) as u32);
-    assert_eq!(
-        db_height, expected_tip,
-        "DB tip should be the last block's height after building the full chain"
-    );
 
     zaino_db.shutdown().await.unwrap();
 }


### PR DESCRIPTION
- Adds test only helpers to simplify migration testing.
- Adds default metadata only migration to simplify metadata only migrations.