### PR TITLE
zainod 0.3.1: re-release for new zainod Docker Hub repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "zainod"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "config",

--- a/packages/zainod/CHANGELOG.md
+++ b/packages/zainod/CHANGELOG.md
@@ -14,6 +14,13 @@ and this crate adheres to Rust's notion of
 ### Removed
 ### Fixed
 
+## [0.3.1] - 2026-05-22
+
+Re-release of 0.3.0 to publish the binary's container image under the
+new `zainod` Docker Hub repository alongside the legacy `zaino`
+repository (#1133). No functional changes to the binary or
+`zainodlib` API since 0.3.0.
+
 ## [0.3.0] - 2026-05-19
 
 ### Added

--- a/packages/zainod/Cargo.toml
+++ b/packages/zainod/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.0"
+version = "0.3.1"
 
 [[bin]]
 name = "zainod"


### PR DESCRIPTION
## Summary

- Bump `zainod` 0.3.0 → 0.3.1 so the next release tag publishes images under the new `zingodevops/zainod` Docker Hub repository (added alongside `zingodevops/zaino` in #1133).
- No functional changes to the binary or `zainodlib` API since 0.3.0 — this is purely a re-release so the `zainod --version` string inside the container matches the new image tag.

## Why a re-release

The `0.3.0` tag was pushed earlier today (2026-05-22, against `c2a6d126`) **before** #1133 added `zainod` as a Docker Hub publish target. As a result, `zaino:0.3.0` exists on Docker Hub but `zainod:0.3.0` does not. Cutting `0.3.1` is the cleanest way to ship a `zainod:X.Y.Z` image without overwriting the existing `0.3.0` tag.

## Verification

`release.yaml` was dispatched on `stable` HEAD with `push=false` (run [#26317591637](https://github.com/zingolabs/zaino/actions/runs/26317591637)) and built both the default and `-no-tls` images successfully against the new dual-repo metadata config.

## Test plan

- [x] CI green on this PR
- [ ] After merge: tag `0.3.1` on the merge commit and push the tag
- [ ] Confirm `release.yaml` fires on tag push and publishes `zaino:0.3.1`, `zainod:0.3.1`, `zaino:0.3.1-no-tls`, `zainod:0.3.1-no-tls`
- [ ] Optional: pull `zingodevops/zainod:0.3.1` and confirm `zainod --version` reports `0.3.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)