### PR TITLE
stop adding nonbest blocks to heights_to_hashes map of best blocks

### DIFF
--- a/packages/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/non_finalised_state.rs
@@ -724,7 +724,9 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
             }
         };
         let indexed_block = block.to_indexed_block(&prev_block, self).await?;
-        working_snapshot.add_block(indexed_block.clone());
+        working_snapshot
+            .blocks
+            .insert(*indexed_block.hash(), indexed_block.clone());
         Ok(indexed_block)
     }
 }


### PR DESCRIPTION
note: commit message erroneously says `hash_or_height` map instead of `heights_to_hashes` map