### PR TITLE
Add ChainIndex::get_outpoint_spenders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ and this library adheres to Rust's notion of
   `ephemeral_finalised_state` config option (default `false`) that runs Zaino
   without a persistent finalised-state database, serving finalised reads from
   the backing validator via an ephemeral passthrough.
+- `ChainIndex::get_outpoint_spenders` — resolves, for each transparent
+  outpoint, the txid that spent it on the best chain (or `None` if unspent),
+  with a `ChainScope` selecting finalised-only or full-chain search.
 ### Changed
 - Finalised-state sync and the v1.1.0 -> v1.2.0 migration are substantially
   faster on large/mainnet caches. The txout-set accumulator is built in bulk at

--- a/live-tests/e2e/tests/devtool.rs
+++ b/live-tests/e2e/tests/devtool.rs
@@ -1970,7 +1970,9 @@ async fn sole_recipient_outpoint(
     use zaino_state::ChainIndex as _;
 
     let utxos = indexer
-        .get_address_utxos(GetAddressBalanceRequest::new(vec![recipient_taddr.to_string()]))
+        .get_address_utxos(GetAddressBalanceRequest::new(vec![
+            recipient_taddr.to_string()
+        ]))
         .await
         .unwrap();
     assert_eq!(
@@ -2009,6 +2011,35 @@ async fn sole_spender_at(
         "exactly one tx (the shield) should touch the taddr at the spend height"
     );
     txids[0]
+}
+
+/// Funds `recipient_taddr` with a single fresh UTXO of `amount`, mines it in, syncs
+/// both wallets, and returns that outpoint. Leaves exactly one UTXO at the address
+/// (see [`sole_recipient_outpoint`]).
+async fn fund_recipient(
+    svc: &mut zaino_testutils::StateAndFetchServices<Zebrad>,
+    clients: &mut e2e::devtool::DevtoolClients,
+    recipient_taddr: &str,
+    amount: u64,
+) -> zaino_state::chain_index::types::Outpoint {
+    clients.sync_faucet().await;
+    clients.send_from_faucet(recipient_taddr, amount).await;
+    svc.generate_blocks_and_wait_for_tips(1).await;
+    clients.sync_recipient().await;
+    sole_recipient_outpoint(&svc.fetch_subscriber.indexer, recipient_taddr).await
+}
+
+/// Shields the recipient's transparent funds — spending its sole UTXO — mines the
+/// shield in, and returns the txid that spent it (see [`sole_spender_at`]).
+async fn spend_and_record(
+    svc: &mut zaino_testutils::StateAndFetchServices<Zebrad>,
+    clients: &mut e2e::devtool::DevtoolClients,
+    recipient_taddr: &str,
+) -> zaino_state::chain_index::types::TransactionHash {
+    clients.shield_recipient().await;
+    svc.generate_blocks_and_wait_for_tips(1).await;
+    let spend_height = svc.fetch_subscriber.tip_height().await as u32;
+    sole_spender_at(&svc.fetch_subscriber.indexer, recipient_taddr, spend_height).await
 }
 
 /// Rewrite of `zebra::get::chain_cache::get_outpoint_spenders` (retired with the
@@ -2060,42 +2091,21 @@ async fn get_outpoint_spenders_fetch_vs_state() {
     let recipient_taddr = clients.get_recipient_address("transparent").await;
 
     // ---- Phase 1: an outpoint that is SPENT and FINALISED ----
-    clients.sync_faucet().await;
-    clients.send_from_faucet(&recipient_taddr, FUNDING_AMOUNT).await;
-    svc.generate_blocks_and_wait_for_tips(1).await;
-    clients.sync_recipient().await;
-    let outpoint_finalised = sole_recipient_outpoint(&svc.fetch_subscriber.indexer, &recipient_taddr).await;
-
-    clients.shield_recipient().await;
-    svc.generate_blocks_and_wait_for_tips(1).await;
-    let spend_height = svc.fetch_subscriber.tip_height().await as u32;
-    let spender_finalised =
-        sole_spender_at(&svc.fetch_subscriber.indexer, &recipient_taddr, spend_height).await;
+    let outpoint_finalised =
+        fund_recipient(&mut svc, &mut clients, &recipient_taddr, FUNDING_AMOUNT).await;
+    let spender_finalised = spend_and_record(&mut svc, &mut clients, &recipient_taddr).await;
 
     // Bury the spend below the finalised floor.
     svc.generate_blocks_and_wait_for_tips(FINALITY_DEPTH).await;
 
     // ---- Phase 2: an outpoint that is SPENT but stays NON-FINALISED ----
-    clients.sync_faucet().await;
-    clients.send_from_faucet(&recipient_taddr, FUNDING_AMOUNT).await;
-    svc.generate_blocks_and_wait_for_tips(1).await;
-    clients.sync_recipient().await;
     let outpoint_nonfinalised =
-        sole_recipient_outpoint(&svc.fetch_subscriber.indexer, &recipient_taddr).await;
-
-    clients.shield_recipient().await;
-    svc.generate_blocks_and_wait_for_tips(1).await;
-    let spend_height = svc.fetch_subscriber.tip_height().await as u32;
-    let spender_nonfinalised =
-        sole_spender_at(&svc.fetch_subscriber.indexer, &recipient_taddr, spend_height).await;
+        fund_recipient(&mut svc, &mut clients, &recipient_taddr, FUNDING_AMOUNT).await;
+    let spender_nonfinalised = spend_and_record(&mut svc, &mut clients, &recipient_taddr).await;
 
     // ---- Phase 3: an outpoint that is created but left UNSPENT ----
-    clients.sync_faucet().await;
-    clients.send_from_faucet(&recipient_taddr, FUNDING_AMOUNT).await;
-    svc.generate_blocks_and_wait_for_tips(1).await;
-    clients.sync_recipient().await;
     let outpoint_unspent =
-        sole_recipient_outpoint(&svc.fetch_subscriber.indexer, &recipient_taddr).await;
+        fund_recipient(&mut svc, &mut clients, &recipient_taddr, FUNDING_AMOUNT).await;
 
     let outpoints = vec![outpoint_finalised, outpoint_nonfinalised, outpoint_unspent];
 
@@ -2506,7 +2516,10 @@ mod zebrad {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    #[cfg_attr(not(feature = "devtool-incompatible"), ignore = "heavy: mines ~110 orchard-coinbase blocks (~110 halo2 proofs) to bury a finalised spend below NON_FINALIZED_DEPTH; un-ignore for manual / dedicated CI")]
+    #[cfg_attr(
+        not(feature = "devtool-incompatible"),
+        ignore = "heavy: mines ~110 orchard-coinbase blocks (~110 halo2 proofs) to bury a finalised spend below NON_FINALIZED_DEPTH; un-ignore for manual / dedicated CI"
+    )]
     async fn get_outpoint_spenders_fetch_vs_state() {
         crate::get_outpoint_spenders_fetch_vs_state().await;
     }

--- a/live-tests/e2e/tests/devtool.rs
+++ b/live-tests/e2e/tests/devtool.rs
@@ -1958,6 +1958,177 @@ async fn get_block_deltas_coinbase_only_block_has_no_inputs() {
     svc.test_manager.close().await;
 }
 
+/// The recipient's sole transparent outpoint, read from the chain index. Each
+/// phase of [`get_outpoint_spenders_fetch_vs_state`] drains the recipient's
+/// transparent funds (by shielding) before funding it again, so at the call
+/// site exactly one UTXO — the funding under test — sits at `recipient_taddr`
+/// (the miner pays coinbase to the shielded pool, never this address).
+async fn sole_recipient_outpoint(
+    indexer: &zaino_state::NodeBackedChainIndexSubscriber,
+    recipient_taddr: &str,
+) -> zaino_state::chain_index::types::Outpoint {
+    use zaino_state::ChainIndex as _;
+
+    let utxos = indexer
+        .get_address_utxos(GetAddressBalanceRequest::new(vec![recipient_taddr.to_string()]))
+        .await
+        .unwrap();
+    assert_eq!(
+        utxos.len(),
+        1,
+        "recipient taddr should hold exactly one funding UTXO"
+    );
+    let (_, txid, output_index, ..) = utxos[0].into_parts();
+    zaino_state::chain_index::types::Outpoint::new(txid.0, output_index.index())
+}
+
+/// The single transaction touching `recipient_taddr` at `height` — the shield
+/// that spent the funding outpoint (the credit landed in an earlier block).
+/// Zebra's address index records a tx against an address when the address is an
+/// input *or* an output, so the shield's spend of the recipient's UTXO appears
+/// here. This is the independent ground truth for the expected spender txid,
+/// in the same `TransactionHash` type `get_outpoint_spenders` returns.
+async fn sole_spender_at(
+    indexer: &zaino_state::NodeBackedChainIndexSubscriber,
+    recipient_taddr: &str,
+    height: u32,
+) -> zaino_state::chain_index::types::TransactionHash {
+    use zaino_state::ChainIndex as _;
+
+    let txids = indexer
+        .get_address_txids(GetAddressTxIdsRequest::new(
+            vec![recipient_taddr.to_string()],
+            Some(height),
+            Some(height),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        txids.len(),
+        1,
+        "exactly one tx (the shield) should touch the taddr at the spend height"
+    );
+    txids[0]
+}
+
+/// Rewrite of `zebra::get::chain_cache::get_outpoint_spenders` (retired with the
+/// zingolib wallet harness) for the devtool wallet + `StateAndFetchServices`
+/// structure. End-to-end check of `ChainIndex::get_outpoint_spenders` and its
+/// `ChainScope` against a real regtest chain, driven through both backends.
+///
+/// Builds three transparent outpoints at the recipient address — one spent and
+/// buried past the finalised floor, one spent but left in the non-finalised
+/// window, and one left unspent — then asserts both `ChainScope`s resolve each
+/// correctly: `FullChain` sees both spends, `Finalised` sees only the buried
+/// one. Asserting the fetch and state indexers return the same result also
+/// covers the `*_fetch_vs_state` agreement. This is the only place the
+/// finalised `TxLocation -> txid` resolution runs end-to-end (the in-tree
+/// mockchain vectors spend nothing below the floor, and proptest blocks can't
+/// be finalised).
+///
+/// Each spend is a `shield_recipient` of the recipient's *received* transparent
+/// output (the non-ignored `shield_for_validator` path), not a faucet-coinbase
+/// shield, so it sidesteps the devtool coinbase-maturity bug that gates
+/// `address_deltas`. The shield drains all transparent funds, so the recipient
+/// holds exactly one UTXO per phase and the spent outpoint is unambiguous.
+async fn get_outpoint_spenders_fetch_vs_state() {
+    use zaino_state::chain_index::types::ChainScope;
+    use zaino_state::ChainIndex as _;
+
+    // `NON_FINALIZED_DEPTH` is 100; mining this many blocks past a spend buries
+    // it under the finalised floor so `ChainScope::Finalised` can resolve it.
+    // A small margin above 100 keeps the boundary unambiguous.
+    const FINALITY_DEPTH: u32 = 105;
+    const FUNDING_AMOUNT: u64 = 250_000;
+
+    let mut svc = zaino_testutils::launch_state_and_fetch_services_mining_to::<Zebrad>(
+        zaino_testutils::SHIELDED_FUNDING_POOL,
+        &ValidatorKind::Zebrad,
+        None,
+        true,
+        Some(zebra_chain::parameters::NetworkKind::Regtest),
+    )
+    .await;
+    let mut clients = e2e::devtool::build_clients(
+        svc.test_manager
+            .zaino_grpc_listen_address
+            .expect("zaino enabled")
+            .port(),
+    )
+    .await;
+
+    let recipient_taddr = clients.get_recipient_address("transparent").await;
+
+    // ---- Phase 1: an outpoint that is SPENT and FINALISED ----
+    clients.sync_faucet().await;
+    clients.send_from_faucet(&recipient_taddr, FUNDING_AMOUNT).await;
+    svc.generate_blocks_and_wait_for_tips(1).await;
+    clients.sync_recipient().await;
+    let outpoint_finalised = sole_recipient_outpoint(&svc.fetch_subscriber.indexer, &recipient_taddr).await;
+
+    clients.shield_recipient().await;
+    svc.generate_blocks_and_wait_for_tips(1).await;
+    let spend_height = svc.fetch_subscriber.tip_height().await as u32;
+    let spender_finalised =
+        sole_spender_at(&svc.fetch_subscriber.indexer, &recipient_taddr, spend_height).await;
+
+    // Bury the spend below the finalised floor.
+    svc.generate_blocks_and_wait_for_tips(FINALITY_DEPTH).await;
+
+    // ---- Phase 2: an outpoint that is SPENT but stays NON-FINALISED ----
+    clients.sync_faucet().await;
+    clients.send_from_faucet(&recipient_taddr, FUNDING_AMOUNT).await;
+    svc.generate_blocks_and_wait_for_tips(1).await;
+    clients.sync_recipient().await;
+    let outpoint_nonfinalised =
+        sole_recipient_outpoint(&svc.fetch_subscriber.indexer, &recipient_taddr).await;
+
+    clients.shield_recipient().await;
+    svc.generate_blocks_and_wait_for_tips(1).await;
+    let spend_height = svc.fetch_subscriber.tip_height().await as u32;
+    let spender_nonfinalised =
+        sole_spender_at(&svc.fetch_subscriber.indexer, &recipient_taddr, spend_height).await;
+
+    // ---- Phase 3: an outpoint that is created but left UNSPENT ----
+    clients.sync_faucet().await;
+    clients.send_from_faucet(&recipient_taddr, FUNDING_AMOUNT).await;
+    svc.generate_blocks_and_wait_for_tips(1).await;
+    clients.sync_recipient().await;
+    let outpoint_unspent =
+        sole_recipient_outpoint(&svc.fetch_subscriber.indexer, &recipient_taddr).await;
+
+    let outpoints = vec![outpoint_finalised, outpoint_nonfinalised, outpoint_unspent];
+
+    // Both backends must agree and resolve each scope correctly.
+    for indexer in [&svc.fetch_subscriber.indexer, &svc.state_subscriber.indexer] {
+        let snapshot = indexer.snapshot_nonfinalized_state().await.unwrap();
+
+        // FullChain resolves both the finalised and the non-finalised spend.
+        let full = indexer
+            .get_outpoint_spenders(&snapshot, outpoints.clone(), ChainScope::FullChain)
+            .await
+            .unwrap();
+        assert_eq!(
+            full,
+            vec![Some(spender_finalised), Some(spender_nonfinalised), None],
+            "FullChain must see both spends and leave the unspent outpoint as None"
+        );
+
+        // Finalised resolves only the buried spend.
+        let finalised = indexer
+            .get_outpoint_spenders(&snapshot, outpoints.clone(), ChainScope::Finalised)
+            .await
+            .unwrap();
+        assert_eq!(
+            finalised,
+            vec![Some(spender_finalised), None, None],
+            "Finalised must see only the buried spend"
+        );
+    }
+
+    svc.test_manager.close().await;
+}
+
 /// Port of `monitor_unverified_mempool` (wallet_to_validator): broadcast two
 /// unmined sends, observe them in the validator mempool, then mine them in.
 ///
@@ -2332,6 +2503,12 @@ mod zebrad {
     #[tokio::test(flavor = "multi_thread")]
     async fn get_block_deltas_coinbase_only_block_has_no_inputs() {
         crate::get_block_deltas_coinbase_only_block_has_no_inputs().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[cfg_attr(not(feature = "devtool-incompatible"), ignore = "heavy: mines ~110 orchard-coinbase blocks (~110 halo2 proofs) to bury a finalised spend below NON_FINALIZED_DEPTH; un-ignore for manual / dedicated CI")]
+    async fn get_outpoint_spenders_fetch_vs_state() {
+        crate::get_outpoint_spenders_fetch_vs_state().await;
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/packages/zaino-state/CHANGELOG.md
+++ b/packages/zaino-state/CHANGELOG.md
@@ -8,6 +8,11 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+- `ChainIndex` / `NodeBackedChainIndexSubscriber` gain `get_outpoint_spenders` —
+  for each transparent `Outpoint`, returns the txid that spent it on the best
+  chain (index-aligned with the input, `None` if unspent or unknown).
+- `chain_index::types::ChainScope` — new enum (`Finalised`, `FullChain`)
+  selecting how far `get_outpoint_spenders` searches.
 - Optional ("ephemeral") finalised state: with `ChainIndexConfig::ephemeral`,
   no finalised database is opened. Finalised reads are served by an ephemeral
   passthrough (`finalised_source::ephemeral::EphemeralFinalisedState`) directly

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -2496,12 +2496,9 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
                 };
                 for tx in block.transactions() {
                     let txid = *tx.txid();
-                    for input in tx.transparent().inputs() {
-                        // Coinbase inputs do not spend a real outpoint.
-                        if input.is_null_prevout() {
-                            continue;
-                        }
-                        let outpoint = Outpoint::new(*input.prevout_txid(), input.prevout_index());
+                    // `spent_outpoints` already skips coinbase null prevouts and builds each
+                    // `Outpoint`, keeping the construction in one place (see #1332).
+                    for outpoint in tx.transparent().spent_outpoints() {
                         nfs_spenders.insert(outpoint, txid);
                     }
                 }

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -539,6 +539,26 @@ pub trait ChainIndex {
         address_strings: GetAddressBalanceRequest,
     ) -> impl std::future::Future<Output = Result<Vec<GetAddressUtxos>, Self::Error>>;
 
+    /// For each outpoint, returns the txid of the transaction that spent it on the best
+    /// chain, or `None` if the outpoint is unspent or unknown.
+    ///
+    /// The output is aligned with the input by index: `result[i]` corresponds to
+    /// `outpoints[i]`. An outpoint is spent at most once on the best chain. `scope` selects
+    /// how far the search reaches: [`ChainScope::FullChain`] searches the non-finalised best
+    /// chain first then the finalised index; [`ChainScope::Finalised`] searches only the
+    /// finalised index, yielding reorg-stable results.
+    ///
+    /// [`ChainScope::FullChain`]: types::ChainScope::FullChain
+    /// [`ChainScope::Finalised`]: types::ChainScope::Finalised
+    fn get_outpoint_spenders(
+        &self,
+        snapshot: &Self::Snapshot,
+        outpoints: Vec<types::Outpoint>,
+        scope: types::ChainScope,
+    ) -> impl std::future::Future<
+        Output = Result<Vec<Option<types::TransactionHash>>, Self::Error>,
+    >;
+
     // ********** Metadata methods **********
 
     /// Returns Information about the mempool state:
@@ -2447,6 +2467,88 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
             .get_address_utxos(address_strings)
             .await
             .map_err(ChainIndexError::backing_validator)
+    }
+
+    async fn get_outpoint_spenders(
+        &self,
+        snapshot: &Self::Snapshot,
+        outpoints: Vec<types::Outpoint>,
+        scope: types::ChainScope,
+    ) -> Result<Vec<Option<types::TransactionHash>>, Self::Error> {
+        use std::collections::HashMap;
+
+        let mut result: Vec<Option<TransactionHash>> = vec![None; outpoints.len()];
+
+        // 1) Non-finalised best chain (FullChain scope only). Scan only the blocks reachable
+        //    via `heights_to_hashes` (the `blocks` map also holds reorged-away blocks, which
+        //    must not count). One pass builds an outpoint -> spending-txid map regardless of
+        //    how many outpoints we look up. Under `Finalised` scope this is skipped so results
+        //    are reorg-stable.
+        if let (
+            types::ChainScope::FullChain,
+            ChainIndexSnapshot::NonFinalizedStateExists {
+                non_finalized_snapshot,
+            },
+        ) = (scope, snapshot)
+        {
+            let mut nfs_spenders: HashMap<Outpoint, TransactionHash> = HashMap::new();
+            for hash in non_finalized_snapshot.heights_to_hashes.values() {
+                let Some(block) = non_finalized_snapshot.blocks.get(hash) else {
+                    continue;
+                };
+                for tx in block.transactions() {
+                    let txid = *tx.txid();
+                    for input in tx.transparent().inputs() {
+                        // Coinbase inputs do not spend a real outpoint.
+                        if input.is_null_prevout() {
+                            continue;
+                        }
+                        let outpoint =
+                            Outpoint::new(*input.prevout_txid(), input.prevout_index());
+                        nfs_spenders.insert(outpoint, txid);
+                    }
+                }
+            }
+            for (i, outpoint) in outpoints.iter().enumerate() {
+                if let Some(txid) = nfs_spenders.get(outpoint) {
+                    result[i] = Some(*txid);
+                }
+            }
+        }
+
+        // 2) Finalised lookup for the still-unresolved outpoints, batched into one DB call.
+        let unresolved_indices: Vec<usize> = result
+            .iter()
+            .enumerate()
+            .filter_map(|(i, r)| r.is_none().then_some(i))
+            .collect();
+        if unresolved_indices.is_empty() {
+            return Ok(result);
+        }
+        let unresolved_outpoints: Vec<Outpoint> =
+            unresolved_indices.iter().map(|&i| outpoints[i]).collect();
+        let locations = self
+            .finalized_state
+            .get_outpoint_spenders(unresolved_outpoints)
+            .await?;
+
+        // 3) Resolve each finalised `TxLocation` to a txid. Dedup identical locations so a
+        //    block spending several queried outpoints is only fetched once. `get_txid` is a
+        //    single keyed lookup, far cheaper than reconstructing the whole block.
+        let mut slots_by_location: HashMap<types::TxLocation, Vec<usize>> = HashMap::new();
+        for (slot, location) in unresolved_indices.into_iter().zip(locations) {
+            if let Some(location) = location {
+                slots_by_location.entry(location).or_default().push(slot);
+            }
+        }
+        for (location, slots) in slots_by_location {
+            let txid = self.finalized_state.get_txid(location).await?;
+            for slot in slots {
+                result[slot] = Some(txid);
+            }
+        }
+
+        Ok(result)
     }
 
     // ********** Metadata methods **********

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -555,9 +555,7 @@ pub trait ChainIndex {
         snapshot: &Self::Snapshot,
         outpoints: Vec<types::Outpoint>,
         scope: types::ChainScope,
-    ) -> impl std::future::Future<
-        Output = Result<Vec<Option<types::TransactionHash>>, Self::Error>,
-    >;
+    ) -> impl std::future::Future<Output = Result<Vec<Option<types::TransactionHash>>, Self::Error>>;
 
     // ********** Metadata methods **********
 
@@ -2503,8 +2501,7 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
                         if input.is_null_prevout() {
                             continue;
                         }
-                        let outpoint =
-                            Outpoint::new(*input.prevout_txid(), input.prevout_index());
+                        let outpoint = Outpoint::new(*input.prevout_txid(), input.prevout_index());
                         nfs_spenders.insert(outpoint, txid);
                     }
                 }

--- a/packages/zaino-state/src/chain_index/tests/mockchain_tests.rs
+++ b/packages/zaino-state/src/chain_index/tests/mockchain_tests.rs
@@ -4,12 +4,12 @@ use crate::{
         source::mockchain_source::MockchainSource,
         tests::{
             poll::poll_until,
-            vectors::{load_test_vectors, TestVectorBlockData},
+            vectors::{indexed_block_chain, load_test_vectors, TestVectorBlockData},
         },
-        types::{BestChainLocation, TransactionHash},
+        types::{BestChainLocation, ChainScope, TransactionHash},
         ChainIndex, NodeBackedChainIndexSubscriber,
     },
-    BlockchainSource as _,
+    BlockchainSource as _, Outpoint,
 };
 use tokio::time::{sleep, Duration};
 use tokio_stream::StreamExt as _;
@@ -795,4 +795,114 @@ async fn get_address_utxos() {
         .await;
 
     assert!(invalid_address_result.is_err());
+}
+
+/// Walks zaino's own indexed view of the test-vector chain and derives, for every
+/// non-coinbase transparent input, the `(outpoint, spending txid)` it represents, plus
+/// every transparent outpoint created on the chain.
+///
+/// Ground truth is built from `CompactTxData` — the exact representation
+/// `get_outpoint_spenders` scans — so the assertions also confirm the outpoint byte order
+/// matches between an indexed input and the looked-up key.
+fn outpoint_spend_ground_truth(
+    blocks: &[TestVectorBlockData],
+) -> (Vec<(Outpoint, TransactionHash)>, Vec<Outpoint>) {
+    let mut spends = Vec::new();
+    let mut created = Vec::new();
+    for block in indexed_block_chain(blocks) {
+        for tx in block.transactions() {
+            let txid = *tx.txid();
+            let transparent = tx.transparent();
+            for output_index in 0..transparent.outputs().len() {
+                created.push(Outpoint::new(txid.0, output_index as u32));
+            }
+            for input in transparent.inputs() {
+                if input.is_null_prevout() {
+                    continue;
+                }
+                spends.push((
+                    Outpoint::new(*input.prevout_txid(), input.prevout_index()),
+                    txid,
+                ));
+            }
+        }
+    }
+    (spends, created)
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_outpoint_spenders() {
+    let (blocks, _indexer, index_reader, _mockchain) =
+        load_test_vectors_and_sync_chain_index(MockchainMode::Static).await;
+    let snapshot = index_reader.snapshot_nonfinalized_state().await.unwrap();
+
+    let (spends, created) = outpoint_spend_ground_truth(&blocks);
+    assert!(
+        !spends.is_empty(),
+        "test vectors must contain transparent spends"
+    );
+
+    // Every spent outpoint resolves to its spending txid, index-aligned with the input.
+    let outpoints: Vec<Outpoint> = spends.iter().map(|(op, _)| *op).collect();
+    let result = index_reader
+        .get_outpoint_spenders(&snapshot, outpoints, ChainScope::FullChain)
+        .await
+        .unwrap();
+    assert_eq!(result.len(), spends.len());
+    for ((outpoint, expected_txid), got) in spends.iter().zip(result) {
+        assert_eq!(got, Some(*expected_txid), "wrong spender for {outpoint:?}");
+    }
+
+    // Outpoints that were created but never spent must report `None`.
+    let spent_set: std::collections::HashSet<Outpoint> =
+        spends.iter().map(|(op, _)| *op).collect();
+    let unspent: Vec<Outpoint> = created
+        .into_iter()
+        .filter(|op| !spent_set.contains(op))
+        .collect();
+    assert!(!unspent.is_empty(), "expected some unspent outputs");
+    let unspent_result = index_reader
+        .get_outpoint_spenders(&snapshot, unspent.clone(), ChainScope::FullChain)
+        .await
+        .unwrap();
+    assert_eq!(unspent_result.len(), unspent.len());
+    assert!(unspent_result.iter().all(Option::is_none));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn get_outpoint_spenders_empty_and_single() {
+    let (blocks, _indexer, index_reader, _mockchain) =
+        load_test_vectors_and_sync_chain_index(MockchainMode::Static).await;
+    let snapshot = index_reader.snapshot_nonfinalized_state().await.unwrap();
+
+    // Empty input -> empty output.
+    assert!(index_reader
+        .get_outpoint_spenders(&snapshot, Vec::new(), ChainScope::FullChain)
+        .await
+        .unwrap()
+        .is_empty());
+
+    let (spends, created) = outpoint_spend_ground_truth(&blocks);
+
+    // Length-1 query (the "single request" path) returns the expected spender.
+    let (op, txid) = spends.first().unwrap();
+    assert_eq!(
+        index_reader
+            .get_outpoint_spenders(&snapshot, vec![*op], ChainScope::FullChain)
+            .await
+            .unwrap(),
+        vec![Some(*txid)],
+    );
+
+    // ...and a length-1 query for an unspent outpoint returns `None`.
+    let spent_set: std::collections::HashSet<Outpoint> =
+        spends.iter().map(|(op, _)| *op).collect();
+    let unspent = created.into_iter().find(|op| !spent_set.contains(op)).unwrap();
+    assert_eq!(
+        index_reader
+            .get_outpoint_spenders(&snapshot, vec![unspent], ChainScope::FullChain)
+            .await
+            .unwrap(),
+        vec![None],
+    );
 }

--- a/packages/zaino-state/src/chain_index/tests/mockchain_tests.rs
+++ b/packages/zaino-state/src/chain_index/tests/mockchain_tests.rs
@@ -816,14 +816,11 @@ fn outpoint_spend_ground_truth(
             for output_index in 0..transparent.outputs().len() {
                 created.push(Outpoint::new(txid.0, output_index as u32));
             }
-            for input in transparent.inputs() {
-                if input.is_null_prevout() {
-                    continue;
-                }
-                spends.push((
-                    Outpoint::new(*input.prevout_txid(), input.prevout_index()),
-                    txid,
-                ));
+            // Spend-walking goes through the canonical `spent_outpoints` helper (#1332),
+            // whose null-prevout filtering and outpoint construction are pinned by its own
+            // unit tests; here we only pair each spent outpoint with its spending txid.
+            for outpoint in transparent.spent_outpoints() {
+                spends.push((outpoint, txid));
             }
         }
     }

--- a/packages/zaino-state/src/chain_index/tests/mockchain_tests.rs
+++ b/packages/zaino-state/src/chain_index/tests/mockchain_tests.rs
@@ -854,8 +854,7 @@ async fn get_outpoint_spenders() {
     }
 
     // Outpoints that were created but never spent must report `None`.
-    let spent_set: std::collections::HashSet<Outpoint> =
-        spends.iter().map(|(op, _)| *op).collect();
+    let spent_set: std::collections::HashSet<Outpoint> = spends.iter().map(|(op, _)| *op).collect();
     let unspent: Vec<Outpoint> = created
         .into_iter()
         .filter(|op| !spent_set.contains(op))
@@ -895,9 +894,11 @@ async fn get_outpoint_spenders_empty_and_single() {
     );
 
     // ...and a length-1 query for an unspent outpoint returns `None`.
-    let spent_set: std::collections::HashSet<Outpoint> =
-        spends.iter().map(|(op, _)| *op).collect();
-    let unspent = created.into_iter().find(|op| !spent_set.contains(op)).unwrap();
+    let spent_set: std::collections::HashSet<Outpoint> = spends.iter().map(|(op, _)| *op).collect();
+    let unspent = created
+        .into_iter()
+        .find(|op| !spent_set.contains(op))
+        .unwrap();
     assert_eq!(
         index_reader
             .get_outpoint_spenders(&snapshot, vec![unspent], ChainScope::FullChain)

--- a/packages/zaino-state/src/chain_index/types.rs
+++ b/packages/zaino-state/src/chain_index/types.rs
@@ -50,5 +50,6 @@ pub use primitives::{
 
 // Re-export helper types
 pub use helpers::{
-    BestChainLocation, BlockMetadata, BlockWithMetadata, NonBestChainLocation, TreeRootData,
+    BestChainLocation, BlockMetadata, BlockWithMetadata, ChainScope, NonBestChainLocation,
+    TreeRootData,
 };

--- a/packages/zaino-state/src/chain_index/types/db/legacy.rs
+++ b/packages/zaino-state/src/chain_index/types/db/legacy.rs
@@ -3029,18 +3029,23 @@ mod spent_outpoints {
 
     #[test]
     fn skips_null_prevout_and_maps_each_input() {
+        // Asymmetric txid bytes (first byte != last) so the assertion also catches a
+        // byte-order reversal in outpoint construction, not merely a wrong value —
+        // a palindromic array like `[7u8; 32]` reversed is indistinguishable from itself.
+        let txid_a: [u8; 32] = std::array::from_fn(|i| i as u8);
+        let txid_b: [u8; 32] = std::array::from_fn(|i| (i as u8).wrapping_add(100));
         let tx = TransparentCompactTx::new(
             vec![
-                TxInCompact::null_prevout(),    // coinbase input → skipped
-                TxInCompact::new([7u8; 32], 3), // spends output 3 of txid 0x07..
-                TxInCompact::new([8u8; 32], 0), // spends output 0 of txid 0x08..
+                TxInCompact::null_prevout(), // coinbase input → skipped
+                TxInCompact::new(txid_a, 3), // spends output 3 of txid_a
+                TxInCompact::new(txid_b, 0), // spends output 0 of txid_b
             ],
             vec![],
         );
 
         assert_eq!(
             tx.spent_outpoints().collect::<Vec<_>>(),
-            vec![Outpoint::new([7u8; 32], 3), Outpoint::new([8u8; 32], 0)],
+            vec![Outpoint::new(txid_a, 3), Outpoint::new(txid_b, 0)],
         );
     }
 

--- a/packages/zaino-state/src/chain_index/types/helpers.rs
+++ b/packages/zaino-state/src/chain_index/types/helpers.rs
@@ -14,6 +14,19 @@
 use super::db::legacy::*;
 use crate::chain_index::types::{BlockContext, ChainWork, CompactDifficulty};
 
+/// Selects how far [`ChainIndex::get_outpoint_spenders`] searches for a spend.
+///
+/// [`ChainIndex::get_outpoint_spenders`]: crate::chain_index::ChainIndex::get_outpoint_spenders
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChainScope {
+    /// Finalised DB only. Reorg-stable: never reports a spend that lives only in a
+    /// non-finalised block.
+    Finalised,
+    /// Non-finalised best chain first, then the finalised DB. Reports the latest known
+    /// spend but may include spends that a reorg could roll back.
+    FullChain,
+}
+
 /// The location of a transaction in the best chain
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum BestChainLocation {


### PR DESCRIPTION
Adds a method to the chain index that, given a batch of transparent outpoints, returns whether (and where) each was spent on the best chain. Lets clients check spend status of their own outpoints.

- Completes task 2 of https://github.com/zingolabs/zaino/issues/801

---
- Shape
```
  fn get_outpoint_spenders(
      &self,
      snapshot: &Self::Snapshot,
      outpoints: Vec<types::Outpoint>,
      scope: types::ChainScope,
  ) -> impl Future<Output = Result<Vec<Option<types::TransactionHash>>, Self::Error>>;
```
  - Output is index-aligned with the input: result[i] is the spender of outpoints[i].
  - Some(txid) = the tx that spent that outpoint; None = unspent or unknown.

  - ChainScope: finalised vs. full chain

  New enum gates how far the search reaches:

  - Finalised — finalised DB only. Reorg-stable: never reports a spend that lives solely in a non-finalised block, at the cost of not seeing recent spends.
  - FullChain — scans the non-finalised best chain first, then falls back to the finalised DB for anything still unresolved. Reports the latest known spend but may include spends a reorg could roll back.

  The non-finalised pass deliberately walks only blocks reachable via heights_to_hashes (the blocks map also holds reorged-away blocks, which must not count). The finalised lookup is batched into a single DB call, and
  identical TxLocations are deduped so a block spending several queried outpoints is only resolved to a txid once.

  Mempool is currently excluded

  Neither scope consults the mempool, only mined blocks (non-finalised best chain + finalised DB) are searched. So a spend that exists only as an unmined mempool tx will report None. This keeps results tied to actual
  chain state; mempool-aware lookups can be layered on later if needed but wallets are expected to track the mempool state separately.

  Tests

  - mockchain (get_outpoint_spenders, get_outpoint_spenders_empty_and_single): derives ground truth from the indexed test-vector chain — every transparent spend resolves to its spending txid, created-but-unspent
  outpoints return None, plus empty/single-element edge cases.
  - integration (get_outpoint_spenders_{zebrad,zcashd}, #[ignore]d as slow): end-to-end against a real regtest chain, building a spent+finalised, a spent+non-finalised, and an unspent outpoint, then asserting FullChain
  sees both spends while Finalised sees only the buried one. This is the only place the finalised TxLocation → txid resolution runs end-to-end.