### PR TITLE
FIX: restrict json rpc server to private addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this library adheres to Rust's notion of
   validator.
 
 ### Added
+- `zainod` gains an `allow_unencrypted_public_json_rpc_bind` build feature that
+  lifts the new private-only JSON-RPC bind restriction for trusted
+  private-network deployments (logs a `WARN` on startup when enabled).
 - `zaino-state::chain_index::source::BlockchainSource` and
   `zaino-state::chain_index::ChainIndex` now expose transparent-address query
   methods for deltas, balances, txids, and UTXOs.
@@ -21,6 +24,11 @@ and this library adheres to Rust's notion of
   `FinalisedTxOutSetInfoAccumulator` with the non-finalised state to produce
   the full `GetTxOutSetInfoResponse`.
 ### Changed
+- The `zainod` JSON-RPC server now refuses to bind to public or unspecified
+  (`0.0.0.0` / `::`) addresses by default; `check_config` enforces the same
+  private/loopback rule already applied to gRPC. The unencrypted JSON-RPC
+  interface is intended for loopback or trusted private networks only (Z-02 /
+  Zellic #48480).
 - Integration tests now use `corez`, with Zcash, Zebra, and Zingo dependencies
   updated to releases and companion branches that no longer depend on the
   yanked `core2` crate.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,30 @@ LICENSE                            Apache-2.0 license text
 .gitignore                         Git ignore patterns
 ```
 
+## Server network exposure
+
+Zaino exposes two servers, with different defaults reflecting their transport
+security:
+
+- **gRPC** (`[grpc_settings]`): may bind to a public address only when TLS is
+  configured (`[grpc_settings.tls]` with `cert_path` / `key_path`). Binding to a
+  non-private address without TLS is rejected at startup. The
+  `no_tls_use_unencrypted_traffic` build feature disables this enforcement (and
+  logs a startup warning) — for testing or trusted networks only.
+- **JSON-RPC** (`[json_server_settings]`): has **no transport encryption** and
+  is intended for loopback or trusted private networks only. By default it may
+  bind only to private/loopback addresses (RFC1918, IPv6 ULA, or loopback);
+  public or unspecified (`0.0.0.0` / `::`) bind addresses are rejected at
+  startup. The `allow_unencrypted_public_json_rpc_bind` build feature lifts this
+  restriction (and logs a startup warning) for deployments on trusted private
+  networks where encryption is handled externally (e.g. containers behind a
+  service mesh or proxy that terminates TLS).
+
+**Security implication:** the JSON-RPC interface transmits unencrypted traffic.
+Do not expose it to untrusted networks, and only enable
+`allow_unencrypted_public_json_rpc_bind` when an external layer secures the
+connection.
+
 ## Documentation
 - [Use Cases](./docs/use_cases.md): Holds instructions and example use cases.
 - [Testing](./docs/testing.md): Holds instructions for running tests.

--- a/packages/zainod/CHANGELOG.md
+++ b/packages/zainod/CHANGELOG.md
@@ -9,10 +9,20 @@ and this crate adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+- New `allow_unencrypted_public_json_rpc_bind` build feature. The JSON-RPC
+  interface has no transport encryption and is now restricted to private /
+  loopback bind addresses by default; this feature lifts that restriction for
+  deployments on trusted private networks where encryption is handled
+  externally. It logs a `WARN` on startup when enabled.
 ### Changed
 ### Deprecated
 ### Removed
 ### Fixed
+- `check_config` now rejects JSON-RPC bind addresses that are not private or
+  loopback (matching the existing gRPC enforcement). Previously no bind-scope
+  check was applied to the JSON-RPC server, so an operator could expose the
+  unencrypted interface on a public address with no warning (Z-02 /
+  Zellic #48480).
 
 ## [0.3.1] - 2026-05-22
 

--- a/packages/zainod/Cargo.toml
+++ b/packages/zainod/Cargo.toml
@@ -20,6 +20,14 @@ path = "src/lib.rs"
 # Removes network restrictions.
 no_tls_use_unencrypted_traffic = ["zaino-serve/no_tls_use_unencrypted_traffic"]
 
+# DANGER: allows the JSON-RPC server to bind to a public (non-private,
+# non-loopback) address. The JSON-RPC interface has NO transport encryption and
+# is intended for loopback or trusted private networks only. Enabling this
+# exposes unencrypted RPC to whatever network the bind address reaches. Only use
+# for deployments on trusted private networks (e.g. containers behind a
+# mesh/proxy that terminates encryption).
+allow_unencrypted_public_json_rpc_bind = []
+
 # **Experimental and alpha features**
 # Exposes the **complete** set of experimental / alpha features currently implemented in Zaino.
 experimental_features = ["transparent_address_history_experimental"]

--- a/packages/zainod/src/config.rs
+++ b/packages/zainod/src/config.rs
@@ -7,7 +7,10 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 use tracing::info;
-#[cfg(feature = "no_tls_use_unencrypted_traffic")]
+#[cfg(any(
+    feature = "no_tls_use_unencrypted_traffic",
+    feature = "allow_unencrypted_public_json_rpc_bind"
+))]
 use tracing::warn;
 
 use crate::error::IndexerError;
@@ -169,6 +172,28 @@ impl ZainodConfig {
         {
             warn!(
                 "Zaino built using no_tls_use_unencrypted_traffic feature, proceed with caution."
+            );
+        }
+
+        // The JSON-RPC interface is unencrypted and intended for loopback / trusted
+        // private networks only. Reject public bind addresses unless explicitly unlocked.
+        #[cfg(not(feature = "allow_unencrypted_public_json_rpc_bind"))]
+        if let Some(ref json_settings) = self.json_server_settings {
+            if !is_private_listen_addr(&json_settings.json_rpc_listen_address) {
+                return Err(IndexerError::ConfigError(
+                    "JSON-RPC server may only bind to private or loopback addresses. \
+                     Build with the `allow_unencrypted_public_json_rpc_bind` feature to \
+                     override (trusted private networks only)."
+                        .to_string(),
+                ));
+            }
+        }
+
+        #[cfg(feature = "allow_unencrypted_public_json_rpc_bind")]
+        {
+            warn!(
+                "Zaino built with allow_unencrypted_public_json_rpc_bind: the JSON-RPC \
+                 server may bind to public addresses without encryption. Proceed with caution."
             );
         }
 
@@ -1082,5 +1107,84 @@ listen_address = "127.0.0.1:8137"
             format!("{:#?}", state_cfg.common),
             format!("{:#?}", fetch_cfg.common),
         );
+    }
+
+    /// Builds a default config with the JSON-RPC server bound to `addr`.
+    ///
+    /// The default config otherwise passes `check_config` (loopback gRPC,
+    /// private validator), so the JSON-RPC bind address is isolated as the only
+    /// variable under test. A non-default port avoids the gRPC/JSON-RPC
+    /// same-address check.
+    fn json_config_with(addr: &str) -> ZainodConfig {
+        ZainodConfig {
+            json_server_settings: Some(JsonRpcServerConfig {
+                json_rpc_listen_address: addr.parse().expect("test bind address must parse"),
+                cookie_dir: None,
+            }),
+            ..ZainodConfig::default()
+        }
+    }
+
+    #[test]
+    fn json_rpc_loopback_bind_is_accepted() {
+        json_config_with("127.0.0.1:8237")
+            .check_config()
+            .expect("loopback JSON-RPC bind must be accepted");
+    }
+
+    #[test]
+    fn json_rpc_private_ipv4_bind_is_accepted() {
+        json_config_with("192.168.1.10:8237")
+            .check_config()
+            .expect("RFC1918 JSON-RPC bind must be accepted");
+    }
+
+    #[test]
+    fn json_rpc_ipv6_ula_bind_is_accepted() {
+        json_config_with("[fc00::1]:8237")
+            .check_config()
+            .expect("IPv6 ULA JSON-RPC bind must be accepted");
+    }
+
+    #[test]
+    fn no_json_server_settings_is_accepted() {
+        let cfg = ZainodConfig {
+            json_server_settings: None,
+            ..ZainodConfig::default()
+        };
+        cfg.check_config()
+            .expect("config without a JSON-RPC server must be accepted");
+    }
+
+    // The rejection rule is compiled out when the override feature is enabled,
+    // so these tests only apply to the default build.
+    #[cfg(not(feature = "allow_unencrypted_public_json_rpc_bind"))]
+    #[test]
+    fn json_rpc_public_bind_is_rejected() {
+        match json_config_with("8.8.8.8:8237").check_config() {
+            Err(IndexerError::ConfigError(msg)) => assert!(
+                msg.contains("allow_unencrypted_public_json_rpc_bind"),
+                "error should name the override feature, got: {msg}"
+            ),
+            other => panic!("expected ConfigError for public JSON-RPC bind, got {other:?}"),
+        }
+    }
+
+    #[cfg(not(feature = "allow_unencrypted_public_json_rpc_bind"))]
+    #[test]
+    fn json_rpc_unspecified_bind_is_rejected() {
+        // 0.0.0.0 binds all interfaces (including public) and is not private.
+        match json_config_with("0.0.0.0:8237").check_config() {
+            Err(IndexerError::ConfigError(_)) => {}
+            other => panic!("expected ConfigError for unspecified JSON-RPC bind, got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "allow_unencrypted_public_json_rpc_bind")]
+    #[test]
+    fn json_rpc_public_bind_allowed_with_feature() {
+        json_config_with("8.8.8.8:8237")
+            .check_config()
+            .expect("public JSON-RPC bind must be accepted under the override feature");
     }
 }


### PR DESCRIPTION
Restricts Zaino's JsonRPC server to local addresses, as is intended, adds a feature to disable this restriction for custom deployments.