### PR TITLE
BUG FIX:  get_block_deltas (state path)

### DIFF
--- a/live-tests/e2e/tests/devtool.rs
+++ b/live-tests/e2e/tests/devtool.rs
@@ -1828,7 +1828,7 @@ async fn get_block_deltas_resolves_transparent_spend() {
         Some(zebra_chain::parameters::NetworkKind::Regtest),
     )
     .await;
-    let mut clients = wallet_tests::devtool::build_clients(
+    let mut clients = e2e::devtool::build_clients(
         svc.test_manager
             .zaino_grpc_listen_address
             .expect("zaino enabled")

--- a/live-tests/e2e/tests/devtool.rs
+++ b/live-tests/e2e/tests/devtool.rs
@@ -1792,6 +1792,172 @@ async fn address_deltas() {
     svc.test_manager.close().await;
 }
 
+/// Regression coverage for AP-03 / Zellic #48500: the State backend used to
+/// silently drop every *non-coinbase transparent spend input* from
+/// `get_block_deltas`, because the verbosity-2 transaction object from Zebra's
+/// stateless `TransactionObject::from_transaction` leaves an input's
+/// value/address unset. The fix resolves each spend's prevout via Zebra's
+/// `ReadStateService` `Transaction` request and reads the spent output's
+/// value/address.
+///
+/// The faucet pays the recipient a transparent output; the recipient then
+/// shields it, producing a non-coinbase transparent input that references the
+/// funding output. The spend block's `InputDelta` must be present and resolve
+/// to the funding output's address and full (negated) value — pre-fix this
+/// input was dropped and `inputs` was empty, so balances overstated funds.
+///
+/// State-backend only: zebra serves no `getblockdeltas` RPC, so the fetch
+/// backend cannot answer it and there is no fetch-vs-state cross-check (cf.
+/// `address_deltas`). Funding via the shielded pool ([`SHIELDED_FUNDING_POOL`])
+/// makes the spend under test the recipient shielding a *received* output, so
+/// the test needs no transparent-coinbase maturity ritual and does not depend
+/// on the `shield_faucet` path that gates `address_deltas` behind
+/// `devtool-incompatible` (it shields the recipient's send receipt, the
+/// not-ignored `shield_for_validator` path).
+async fn get_block_deltas_resolves_transparent_spend() {
+    // The only transparent output in the funding block: the (shielded) coinbase
+    // pays the orchard pool and the faucet's change returns to orchard, so the
+    // funding output is uniquely identifiable by its amount.
+    const FUNDING_AMOUNT: i64 = 250_000;
+
+    let mut svc = zaino_testutils::launch_state_and_fetch_services_mining_to::<Zebrad>(
+        zaino_testutils::SHIELDED_FUNDING_POOL,
+        &ValidatorKind::Zebrad,
+        None,
+        true,
+        Some(zebra_chain::parameters::NetworkKind::Regtest),
+    )
+    .await;
+    let mut clients = wallet_tests::devtool::build_clients(
+        svc.test_manager
+            .zaino_grpc_listen_address
+            .expect("zaino enabled")
+            .port(),
+    )
+    .await;
+
+    // One orchard coinbase note for the faucet, then fund the recipient's
+    // transparent address with a non-coinbase transparent output.
+    svc.generate_blocks_and_wait_for_tips(1).await;
+    clients.sync_faucet().await;
+    let recipient_taddr = clients.get_recipient_address("transparent").await;
+    clients
+        .send_from_faucet(&recipient_taddr, FUNDING_AMOUNT as u64)
+        .await;
+    svc.generate_blocks_and_wait_for_tips(1).await;
+    let funding_block_hash = svc
+        .state_subscriber
+        .get_best_blockhash()
+        .await
+        .unwrap()
+        .hash()
+        .to_string();
+
+    // The recipient confirms the received output and shields it; the shielding
+    // tx spends that output, producing the non-coinbase transparent input under
+    // test.
+    clients.sync_recipient().await;
+    clients.shield_recipient().await;
+    svc.generate_blocks_and_wait_for_tips(1).await;
+    let spend_block_hash = svc
+        .state_subscriber
+        .get_best_blockhash()
+        .await
+        .unwrap()
+        .hash()
+        .to_string();
+
+    // Locate the funding output (unique by amount). Its txid and address come
+    // from the state backend, as do the spend input's `prevtxid`/`address`
+    // below, so the cross-block match stays within one backend's encoding.
+    let funding_deltas = svc
+        .state_subscriber
+        .get_block_deltas(funding_block_hash)
+        .await
+        .unwrap();
+    let funding_delta = funding_deltas
+        .deltas
+        .iter()
+        .find(|d| {
+            d.outputs
+                .iter()
+                .any(|o| o.satoshis.zatoshis() == FUNDING_AMOUNT)
+        })
+        .expect("funding tx paying the recipient should be in its block");
+    let funding_output = funding_delta
+        .outputs
+        .iter()
+        .find(|o| o.satoshis.zatoshis() == FUNDING_AMOUNT)
+        .expect("funding output paying the recipient should be present");
+    let funding_txid = funding_delta.txid.clone();
+    let funding_vout = funding_output.index;
+    let funding_address = funding_output.address.clone();
+
+    // The spend's input must be present and resolved to the funding output's
+    // address and full value (negative — it is a debit). Pre-fix `inputs` was
+    // empty and this lookup would fail.
+    let spend_deltas = svc
+        .state_subscriber
+        .get_block_deltas(spend_block_hash)
+        .await
+        .unwrap();
+    let input = spend_deltas
+        .deltas
+        .iter()
+        .flat_map(|d| d.inputs.iter())
+        .find(|i| i.prevtxid == funding_txid && i.prevout == funding_vout)
+        .expect("spend input referencing the funding output should be present");
+
+    assert_eq!(
+        input.address, funding_address,
+        "input must resolve to the prevout's address"
+    );
+    assert_eq!(
+        input.satoshis.zatoshis(),
+        -FUNDING_AMOUNT,
+        "input must resolve to the prevout's full value, negated"
+    );
+
+    svc.test_manager.close().await;
+}
+
+/// A freshly mined block carries only its (shielded) coinbase transaction: the
+/// coinbase input is skipped and `get_block_deltas` fabricates no transparent
+/// input deltas. State-backend only (cf.
+/// `get_block_deltas_resolves_transparent_spend`).
+async fn get_block_deltas_coinbase_only_block_has_no_inputs() {
+    let mut svc = zaino_testutils::launch_state_and_fetch_services_mining_to::<Zebrad>(
+        zaino_testutils::SHIELDED_FUNDING_POOL,
+        &ValidatorKind::Zebrad,
+        None,
+        true,
+        Some(zebra_chain::parameters::NetworkKind::Regtest),
+    )
+    .await;
+
+    svc.generate_blocks_and_wait_for_tips(1).await;
+    let block_hash = svc
+        .state_subscriber
+        .get_best_blockhash()
+        .await
+        .unwrap()
+        .hash()
+        .to_string();
+
+    let deltas = svc
+        .state_subscriber
+        .get_block_deltas(block_hash)
+        .await
+        .unwrap();
+
+    assert!(
+        deltas.deltas.iter().all(|d| d.inputs.is_empty()),
+        "a coinbase-only block must have no input deltas"
+    );
+
+    svc.test_manager.close().await;
+}
+
 /// Port of `monitor_unverified_mempool` (wallet_to_validator): broadcast two
 /// unmined sends, observe them in the validator mempool, then mine them in.
 ///
@@ -2156,6 +2322,16 @@ mod zebrad {
     )]
     async fn address_deltas() {
         crate::address_deltas().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_block_deltas_resolves_transparent_spend() {
+        crate::get_block_deltas_resolves_transparent_spend().await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn get_block_deltas_coinbase_only_block_has_no_inputs() {
+        crate::get_block_deltas_coinbase_only_block_has_no_inputs().await;
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/packages/zaino-state/src/backends/state.rs
+++ b/packages/zaino-state/src/backends/state.rs
@@ -93,7 +93,7 @@ use chrono::{DateTime, Utc};
 use futures::TryFutureExt as _;
 use hex::{FromHex as _, ToHex};
 use indexmap::IndexMap;
-use std::{error::Error, fmt, str::FromStr, sync::Arc};
+use std::{collections::HashMap, error::Error, fmt, str::FromStr, sync::Arc};
 use tokio::{
     sync::mpsc,
     time::{self, timeout},
@@ -1244,118 +1244,179 @@ impl ZcashIndexer for StateServiceSubscriber {
 
         match zblock {
             GetBlock::Object(boxed_block) => {
-                #[allow(clippy::result_large_err)]
-                let deltas = boxed_block
-                    .tx()
-                    .iter()
-                    .enumerate()
-                    .map(|(tx_index, tx)| match tx {
-                        GetBlockTransaction::Object(txo) => {
-                            let txid = txo.txid().to_string();
+                // Resolve each transparent spend's prevout ourselves: the
+                // verbosity-2 object from Zebra's stateless
+                // `TransactionObject::from_transaction` leaves input
+                // value/address `None`, so we look the spent output up via the
+                // best-chain `ReadRequest::Transaction` (finalized +
+                // non-finalized, so same-block prevouts resolve too).
+                let network = self.data.network();
+                let mut state = self.read_state_service.clone();
+                // Per-call cache: many inputs may reference the same prevtxid,
+                // so each previous transaction is fetched at most once.
+                let mut prevtx_cache: HashMap<
+                    zebra_chain::transaction::Hash,
+                    Arc<zebra_chain::transaction::Transaction>,
+                > = HashMap::new();
 
-                            let inputs: Vec<InputDelta> = txo
-                                .inputs()
-                                .iter()
-                                .enumerate()
-                                .filter_map(|(i, vin)| match vin {
-                                    Input::Coinbase { .. } => None,
-                                    Input::NonCoinbase {
-                                        txid: prevtxid,
-                                        vout: prevout,
-                                        value,
-                                        value_zat,
-                                        address,
-                                        ..
-                                    } => {
-                                        let zats = if let Some(z) = value_zat {
-                                            *z
-                                        } else if let Some(v) = value {
-                                            (v * 100_000_000.0).round() as i64
-                                        } else {
-                                            return None;
-                                        };
-
-                                        let addr = match address {
-                                            Some(a) => a.clone(),
-                                            None => return None,
-                                        };
-
-                                        let input_amt: Amount = match (-zats).try_into() {
-                                            Ok(a) => a,
-                                            Err(_) => return None,
-                                        };
-
-                                        Some(InputDelta {
-                                            address: addr,
-                                            satoshis: input_amt,
-                                            index: i as u32,
-                                            prevtxid: prevtxid.clone(),
-                                            prevout: *prevout,
-                                        })
-                                    }
-                                })
-                                .collect::<Vec<_>>();
-
-                            let outputs: Vec<OutputDelta> =
-                                txo.outputs()
-                                    .iter()
-                                    .filter_map(|vout| {
-                                        let addr_opt =
-                                            vout.script_pub_key().addresses().as_ref().and_then(
-                                                |v| if v.len() == 1 { v.first() } else { None },
-                                            );
-
-                                        let addr = addr_opt?.clone();
-
-                                        let output_amt: Amount<NonNegative> =
-                                            match vout.value_zat().try_into() {
-                                                Ok(a) => a,
-                                                Err(_) => return None,
-                                            };
-
-                                        Some(OutputDelta {
-                                            address: addr,
-                                            satoshis: output_amt,
-                                            index: vout.n(),
-                                        })
-                                    })
-                                    .collect::<Vec<_>>();
-
-                            Ok::<_, Self::Error>(BlockDelta {
-                                txid,
-                                index: tx_index as u32,
-                                inputs,
-                                outputs,
-                            })
+                let mut deltas = Vec::with_capacity(boxed_block.tx().len());
+                for (tx_index, tx) in boxed_block.tx().iter().enumerate() {
+                    let txo = match tx {
+                        GetBlockTransaction::Object(txo) => txo,
+                        GetBlockTransaction::Hash(_) => {
+                            return Err(StateServiceError::Custom(
+                                "Unexpected hash when expecting object".to_string(),
+                            ))
                         }
-                        GetBlockTransaction::Hash(_) => Err(StateServiceError::Custom(
-                            "Unexpected hash when expecting object".to_string(),
-                        )),
-                    })
-                    .collect::<Result<Vec<_>, _>>()?;
+                    };
+
+                    let txid = txo.txid().to_string();
+
+                    let mut inputs: Vec<InputDelta> = Vec::new();
+                    for (i, vin) in txo.inputs().iter().enumerate() {
+                        let (prevtxid, prevout) = match vin {
+                            Input::Coinbase { .. } => continue,
+                            Input::NonCoinbase {
+                                txid: prevtxid,
+                                vout: prevout,
+                                ..
+                            } => (prevtxid, *prevout),
+                        };
+
+                        let prev_hash = zebra_chain::transaction::Hash::from_str(prevtxid)
+                            .map_err(|e| {
+                                StateServiceError::Custom(format!(
+                                    "getblockdeltas: invalid prevout txid {prevtxid}: {e}"
+                                ))
+                            })?;
+
+                        let prev_tx = match prevtx_cache.get(&prev_hash) {
+                            Some(prev_tx) => prev_tx.clone(),
+                            None => {
+                                let response = state
+                                    .ready()
+                                    .and_then(|service| {
+                                        service.call(ReadRequest::Transaction(prev_hash))
+                                    })
+                                    .await?;
+                                let mined_tx = expected_read_response!(response, Transaction)
+                                    .ok_or_else(|| {
+                                        StateServiceError::Custom(format!(
+                                            "getblockdeltas: prevout tx {prevtxid} not in best chain"
+                                        ))
+                                    })?;
+                                prevtx_cache.insert(prev_hash, mined_tx.tx.clone());
+                                mined_tx.tx
+                            }
+                        };
+
+                        let output = prev_tx.outputs().get(prevout as usize).ok_or_else(|| {
+                            StateServiceError::Custom(format!(
+                                "getblockdeltas: prevout index {prevout} out of range for {prevtxid}"
+                            ))
+                        })?;
+
+                        // Nonstandard script ⇒ no derivable address ⇒ skip
+                        // (matches the outputs branch). This is the only
+                        // legitimate skip; it is not loss of a resolvable spend.
+                        let address = match output.address(&network) {
+                            Some(a) => a.to_string(),
+                            None => continue,
+                        };
+
+                        // Inputs are debits, so the amount leaves the address.
+                        let satoshis: Amount =
+                            (-output.value().zatoshis()).try_into().map_err(|e| {
+                                StateServiceError::Custom(format!(
+                                    "getblockdeltas: input amount out of range for {prevtxid}:{prevout}: {e}"
+                                ))
+                            })?;
+
+                        inputs.push(InputDelta {
+                            address,
+                            satoshis,
+                            index: i as u32,
+                            prevtxid: prevtxid.clone(),
+                            prevout,
+                        });
+                    }
+
+                    let outputs: Vec<OutputDelta> = txo
+                        .outputs()
+                        .iter()
+                        .filter_map(|vout| {
+                            let addr_opt = vout
+                                .script_pub_key()
+                                .addresses()
+                                .as_ref()
+                                .and_then(|v| if v.len() == 1 { v.first() } else { None });
+
+                            let addr = addr_opt?.clone();
+
+                            let output_amt: Amount<NonNegative> = match vout.value_zat().try_into()
+                            {
+                                Ok(a) => a,
+                                Err(_) => return None,
+                            };
+
+                            Some(OutputDelta {
+                                address: addr,
+                                satoshis: output_amt,
+                                index: vout.n(),
+                            })
+                        })
+                        .collect::<Vec<_>>();
+
+                    deltas.push(BlockDelta {
+                        txid,
+                        index: tx_index as u32,
+                        inputs,
+                        outputs,
+                    });
+                }
 
                 Ok(BlockDeltas {
                     hash: boxed_block.hash().to_string(),
                     confirmations: boxed_block.confirmations(),
-                    size: boxed_block.size().expect("size should be present"),
-                    height: boxed_block.height().expect("height should be present").0,
-                    version: boxed_block.version().expect("version should be present"),
+                    size: boxed_block.size().ok_or_else(|| {
+                        StateServiceError::Custom("getblockdeltas: block size missing".into())
+                    })?,
+                    height: boxed_block
+                        .height()
+                        .ok_or_else(|| {
+                            StateServiceError::Custom("getblockdeltas: block height missing".into())
+                        })?
+                        .0,
+                    version: boxed_block.version().ok_or_else(|| {
+                        StateServiceError::Custom("getblockdeltas: block version missing".into())
+                    })?,
                     merkle_root: boxed_block
                         .merkle_root()
-                        .expect("merkle root should be present")
+                        .ok_or_else(|| {
+                            StateServiceError::Custom(
+                                "getblockdeltas: block merkle root missing".into(),
+                            )
+                        })?
                         .encode_hex::<String>(),
                     deltas,
-                    time: boxed_block.time().expect("time should be present"),
-
-                    median_time: self.median_time_past(&boxed_block).await.unwrap(),
-                    nonce: hex::encode(boxed_block.nonce().unwrap()),
+                    time: boxed_block.time().ok_or_else(|| {
+                        StateServiceError::Custom("getblockdeltas: block time missing".into())
+                    })?,
+                    median_time: self.median_time_past(&boxed_block).await.map_err(|e| {
+                        StateServiceError::Custom(format!("getblockdeltas: median_time_past: {e}"))
+                    })?,
+                    nonce: hex::encode(boxed_block.nonce().ok_or_else(|| {
+                        StateServiceError::Custom("getblockdeltas: block nonce missing".into())
+                    })?),
                     bits: boxed_block
                         .bits()
-                        .expect("bits should be present")
+                        .ok_or_else(|| {
+                            StateServiceError::Custom("getblockdeltas: block bits missing".into())
+                        })?
                         .to_string(),
-                    difficulty: boxed_block
-                        .difficulty()
-                        .expect("difficulty should be present"),
+                    difficulty: boxed_block.difficulty().ok_or_else(|| {
+                        StateServiceError::Custom("getblockdeltas: block difficulty missing".into())
+                    })?,
                     previous_block_hash: boxed_block
                         .previous_block_hash()
                         .map(|hash| hash.to_string()),


### PR DESCRIPTION
This PR fixes get_block_deltas on the State backend so transparent spend inputs are included in block deltas instead of being dropped when their value/address is not present on Zebra’s stateless transaction object.

The fix resolves transparent prevouts through ReadStateService, reports missing or out-of-range prevouts as typed errors, keeps coinbase/nonstandard-input handling unchanged, and removes adjacent expect/unwrap panics from the same response path.