### PR TITLE
Rc 0 4 0 slow sync

### DIFF
--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -662,6 +662,18 @@ impl ZainoDB {
         // Await the reporter to ensure clean shutdown; ignore errors if it panicked/was aborted.
         let _ = reporter_handle.await;
 
+        // The env is opened with `NO_SYNC`, so the blocks written above are committed but may not
+        // be on disk yet. Force a durability checkpoint at the end of a completed batch: a
+        // `sync_to_height` that returns `Ok` is then guaranteed durable, so a later crash can only
+        // roll back to this height, never lose a range already reported as synced. On the error
+        // path the partial progress stays committed and is flushed by the next checkpoint /
+        // shutdown, so we leave the original error unmasked.
+        if result.is_ok() {
+            let env = self.db.backend(CapabilityRequest::WriteCore)?.env();
+            tokio::task::block_in_place(|| env.sync(true))
+                .map_err(FinalisedStateError::LmdbError)?;
+        }
+
         result
     }
 

--- a/packages/zaino-state/src/chain_index/finalised_state/db.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db.rs
@@ -321,6 +321,15 @@ impl DbBackend {
         }
     }
 
+    /// Provides access to the transparent DB table, required for Migration1_1_0To1_2_0 Stage B to
+    /// read block transparent data directly (bypassing per-height block re-validation).
+    pub(crate) fn transparent_db(&self) -> Result<Database, FinalisedStateError> {
+        match self {
+            Self::V1(db) => Ok(db.transparent_db()),
+            Self::V0(_) => Err(FinalisedStateError::FeatureUnavailable("v1 transparent db")),
+        }
+    }
+
     /// Provides access to the finalised txout-set accumulator DB table.
     pub(crate) fn tx_out_set_info_accumulator_db(&self) -> Result<Database, FinalisedStateError> {
         match self {

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -698,6 +698,16 @@ impl DbV1 {
         self.txids
     }
 
+    /// Provides access to the transparent DB table, required for Migration1_1_0To1_2_0 Stage B to
+    /// read stored block transparent data directly. Reading the table raw (rather than via the
+    /// `BlockTransparentExt` accessor) deliberately bypasses `validate_block_blocking`: the
+    /// migration backfills from already-on-disk, already-trusted data, so per-height block
+    /// re-validation (merkle-root recompute + full-payload checksums) is redundant cost. The
+    /// background validator started at spawn is responsible for validating the on-disk chain.
+    pub(crate) fn transparent_db(&self) -> Database {
+        self.transparent
+    }
+
     /// **Temporary 0.4.0-alpha.1 cache compatibility.**
     ///
     /// The 0.4.0-alpha.1 build shipped a v1.1.0 → v1.2.0 migration (and write path) that did not

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -143,6 +143,19 @@ pub(crate) const TX_OUT_SET_INFO_ACCUMULATOR_DATABASE_NAME: &str =
 /// Singleton key for the finalised txout-set accumulator table.
 pub(crate) const TX_OUT_SET_INFO_ACCUMULATOR_KEY: &[u8] = b"tx_out_set_info_accumulator";
 
+/// Number of committed block writes / migration heights between explicit
+/// `env.sync(true)` durability checkpoints.
+///
+/// The LMDB environment is opened with `MDB_NOSYNC` (see [`DbV1::spawn`]), so an individual
+/// `txn.commit()` is *not* flushed to disk. Because the environment does not use `WRITE_MAP`,
+/// LMDB still guarantees ACI on crash — only durability (D) is lost: a crash rolls the database
+/// back to the last on-disk-consistent transaction, it never corrupts it (copy-on-write + dual
+/// meta pages always leave a recoverable committed snapshot). Forcing a sync every
+/// `SYNC_CHECKPOINT_INTERVAL` writes bounds how much committed-but-unflushed tail a crash can
+/// discard. The tail is always safe to re-do: clean sync resumes from the on-disk tip and
+/// re-fetches the missing blocks, and migrations resume idempotently from their progress keys.
+pub(crate) const SYNC_CHECKPOINT_INTERVAL: u32 = 1000;
+
 /// [`DbCore`] capability implementation for [`DbV1`].
 ///
 /// This trait exposes lifecycle operations and a high-level status indicator.
@@ -330,11 +343,23 @@ impl DbV1 {
             .expect("max_readers was clamped to fit in u32");
 
         // Open LMDB environment and set environmental details.
+        //
+        // `NO_SYNC`: commits are not fsynced. The core write path now does many random-key
+        // inserts per block (the `spent` and `txid_location` B-trees are keyed by 32-byte
+        // hashes), which made per-commit fsync the dominant sync cost once those trees outgrew
+        // the page cache. Under `NO_SYNC` the OS batches that write-back; we force durability at
+        // explicit checkpoints (`SYNC_CHECKPOINT_INTERVAL`) and on graceful shutdown instead.
+        // `WRITE_MAP` is unset, so a crash never corrupts the database — it only discards the
+        // unflushed tail of recent commits, which clean sync and migrations safely re-do.
         let env = Environment::new()
             .set_max_dbs(15)
             .set_map_size(db_size_bytes)
             .set_max_readers(max_readers)
-            .set_flags(EnvironmentFlags::NO_TLS | EnvironmentFlags::NO_READAHEAD)
+            .set_flags(
+                EnvironmentFlags::NO_TLS
+                    | EnvironmentFlags::NO_READAHEAD
+                    | EnvironmentFlags::NO_SYNC,
+            )
             .open(&db_path)?;
 
         // Open individual LMDB DBs.
@@ -873,11 +898,23 @@ impl DbV1 {
             .expect("max_readers was clamped to fit in u32");
 
         // Open LMDB environment and set environmental details.
+        //
+        // `NO_SYNC`: commits are not fsynced. The core write path now does many random-key
+        // inserts per block (the `spent` and `txid_location` B-trees are keyed by 32-byte
+        // hashes), which made per-commit fsync the dominant sync cost once those trees outgrew
+        // the page cache. Under `NO_SYNC` the OS batches that write-back; we force durability at
+        // explicit checkpoints (`SYNC_CHECKPOINT_INTERVAL`) and on graceful shutdown instead.
+        // `WRITE_MAP` is unset, so a crash never corrupts the database — it only discards the
+        // unflushed tail of recent commits, which clean sync and migrations safely re-do.
         let env = Environment::new()
             .set_max_dbs(15)
             .set_map_size(db_size_bytes)
             .set_max_readers(max_readers)
-            .set_flags(EnvironmentFlags::NO_TLS | EnvironmentFlags::NO_READAHEAD)
+            .set_flags(
+                EnvironmentFlags::NO_TLS
+                    | EnvironmentFlags::NO_READAHEAD
+                    | EnvironmentFlags::NO_SYNC,
+            )
             .open(&db_path)?;
 
         // Open individual LMDB DBs.

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -536,9 +536,10 @@ impl DbV1 {
                 }
             }
 
-            // `txn.commit()` is durable: the LMDB env is opened without NO_SYNC, so commit
-            // fsyncs the data and meta pages. Validation below is read-only and observes the
-            // committed state without any further sync, so no explicit `env.sync` is needed here.
+            // `txn.commit()` makes the block visible to subsequent readers (LMDB MVCC), but the
+            // env is opened with `NO_SYNC`, so it is *not* fsynced here. Durability is forced at
+            // `SYNC_CHECKPOINT_INTERVAL` boundaries below and on graceful shutdown. Validation
+            // is read-only and observes the just-committed state from the map regardless of sync.
             txn.commit()?;
 
             zaino_db.validate_block_blocking(block_height, block_hash)?;
@@ -565,9 +566,17 @@ impl DbV1 {
 
         match post_result {
             Ok(_) => {
-                // The block (and its `txid_location` entries) were durably committed inside the
-                // blocking task above; validation succeeded and wrote nothing, so no extra sync.
+                // The block was committed inside the blocking task above. Under `NO_SYNC` that
+                // commit is not yet on disk; force a durability checkpoint every
+                // `SYNC_CHECKPOINT_INTERVAL` blocks so a crash can only lose a bounded tail (which
+                // the syncer re-fetches from the on-disk tip). Genesis is checkpointed too so a
+                // brand-new cache has a durable root.
                 self.status.store(StatusType::Ready);
+                if block_height.0 % SYNC_CHECKPOINT_INTERVAL == 0 {
+                    tokio::task::block_in_place(|| self.env.sync(true)).map_err(|e| {
+                        FinalisedStateError::Custom(format!("LMDB checkpoint sync failed: {e}"))
+                    })?;
+                }
                 if block.context.index.height.0 % 100 == 0 {
                     info!(
                         "Successfully committed block {} at height {} to ZainoDB.",

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -187,7 +187,7 @@ use crate::{
     chain_index::{
         finalised_state::{
             capability::{CapabilityRequest, DbMetadata},
-            db::v1::{DB_VERSION_V1, TX_OUT_SET_INFO_ACCUMULATOR_KEY},
+            db::v1::{DB_VERSION_V1, SYNC_CHECKPOINT_INTERVAL, TX_OUT_SET_INFO_ACCUMULATOR_KEY},
             entry::{StoredEntryFixed, StoredEntryVar},
         },
         source::BlockchainSource,
@@ -576,6 +576,12 @@ impl<T: BlockchainSource> Migration<T> for Migration0To1 {
 
         info!("promoting v1 database to primary.");
 
+        // The migrated v1 data is about to become primary and v0 is wiped below. Under `NO_SYNC`
+        // the shadow's tail blocks and its `Complete` status may not be on disk yet; force them
+        // durable now so a crash during or after promotion can never lose migrated blocks that
+        // exist only in v1 (v0 is removed and cannot serve as a fallback).
+        shadow.env().sync(true)?;
+
         // Promote V1 to primary
         let db_v0 = router.promote_shadow()?;
 
@@ -844,6 +850,13 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
                     txn.commit()?;
                 }
 
+                // Durability checkpoint (the env is opened with `NO_SYNC`): bound how much
+                // backfill a crash can discard. The lost tail is re-done idempotently from the
+                // Stage A progress key on resume.
+                if next_height % SYNC_CHECKPOINT_INTERVAL == 0 {
+                    env.sync(true)?;
+                }
+
                 if next_height % 50_000 == 0 {
                     info!(
                         height = next_height,
@@ -855,6 +868,10 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
 
                 next_height = height.0 + 1;
             }
+
+            // Make the completed `txid_location` index a durable boundary so a crash during
+            // Stage B never has to re-run Stage A.
+            env.sync(true)?;
 
             info!(
                 db_tip,
@@ -1097,6 +1114,13 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
                     txn.commit()?;
                 }
 
+                // Durability checkpoint (the env is opened with `NO_SYNC`): bound how much
+                // backfill a crash can discard. The lost tail is re-done idempotently from the
+                // Stage B progress key on resume.
+                if next_height_to_migrate % SYNC_CHECKPOINT_INTERVAL == 0 {
+                    env.sync(true)?;
+                }
+
                 if next_height_to_migrate % 10_000 == 0 {
                     info!(
                         height = next_height_to_migrate,
@@ -1116,7 +1140,28 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
             );
         }
 
-        // ===== Finalise: remove both progress keys and advance metadata to v1.2.0. =====
+        // ===== Finalise: advance metadata to v1.2.0, then remove the progress keys. =====
+        //
+        // Ordering matters under `NO_SYNC`. The recorded version is the migration's completion
+        // gate, so it must become durable *before* the progress keys are removed:
+        //
+        // 1. Flush all backfilled `spent` / accumulator work so the version we are about to
+        //    record truthfully reflects on-disk state.
+        // 2. Record version v1.2.0 and force it durable. A crash before this leaves the version
+        //    < v1.2.0 with the progress keys intact, so the migration is re-selected and resumes
+        //    cheaply (the stages skip past `db_tip`, then re-finalise).
+        // 3. Only now remove the progress keys: the version gate is durably set, so they are
+        //    dead metadata. Removing them last guarantees a crash never leaves "keys deleted but
+        //    version still v1.1.0", which would force a full, wasteful re-migration.
+        env.sync(true)?;
+
+        let mut metadata: DbMetadata = router.get_metadata().await?;
+        metadata.version = <Self as Migration<T>>::TO_VERSION;
+        metadata.schema_hash = crate::chain_index::finalised_state::db::v1::DB_SCHEMA_V1_HASH;
+        metadata.migration_status = MigrationStatus::Empty;
+        router.update_metadata(metadata).await?;
+        env.sync(true)?;
+
         {
             let mut txn = env.begin_rw_txn()?;
 
@@ -1132,12 +1177,7 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
 
             txn.commit()?;
         }
-
-        let mut metadata: DbMetadata = router.get_metadata().await?;
-        metadata.version = <Self as Migration<T>>::TO_VERSION;
-        metadata.schema_hash = crate::chain_index::finalised_state::db::v1::DB_SCHEMA_V1_HASH;
-        metadata.migration_status = MigrationStatus::Empty;
-        router.update_metadata(metadata).await?;
+        env.sync(true)?;
 
         // Turn transparent history extension back on now the indices are built.
         router.extend_primary_caps(Capability::TRANSPARENT_HIST_EXT);

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -186,7 +186,7 @@ use super::{
 use crate::{
     chain_index::{
         finalised_state::{
-            capability::{BlockTransparentExt as _, CapabilityRequest, DbMetadata},
+            capability::{CapabilityRequest, DbMetadata},
             db::v1::{DB_VERSION_V1, TX_OUT_SET_INFO_ACCUMULATOR_KEY},
             entry::{StoredEntryFixed, StoredEntryVar},
         },
@@ -196,7 +196,8 @@ use crate::{
     config::BlockCacheConfig,
     error::FinalisedStateError,
     BlockHash, BlockMetadata, BlockWithMetadata, ChainWork, Height, IndexedBlock, Outpoint,
-    TransactionHash, TransparentCompactTx, TxLocation, TxidList, ZainoVersionedSerde as _,
+    TransactionHash, TransparentCompactTx, TransparentTxList, TxLocation, TxidList,
+    ZainoVersionedSerde as _,
 };
 
 use lmdb::{Transaction, WriteFlags};
@@ -694,6 +695,7 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
         let env = backend.env();
         let metadata_db = backend.metadata_db()?;
         let txids_db = backend.txids_db()?;
+        let transparent_db = backend.transparent_db()?;
         let spent_db = backend.spent_db()?;
         let txid_location_db = backend.txid_location_db()?;
         let tx_out_set_info_accumulator_db = backend.tx_out_set_info_accumulator_db()?;
@@ -911,11 +913,32 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
             while next_height_to_migrate <= db_tip {
                 let height = Height::try_from(next_height_to_migrate)
                     .map_err(|error| FinalisedStateError::Custom(error.to_string()))?;
+                let height_bytes = height.to_bytes()?;
 
-                let transparent_tx_list = router
-                    .backend(CapabilityRequest::BlockTransparentExt)?
-                    .get_block_transparent(height)
-                    .await?;
+                // Read the stored transparent list directly from the table. This intentionally
+                // bypasses the `BlockTransparentExt` accessor, which routes through
+                // `resolve_validated_hash_or_height` → `validate_block_blocking` (merkle-root
+                // recompute + full-payload checksum verification) for every height above
+                // `validated_tip`. During migration `validated_tip` is still climbing on the
+                // background validator, so that path would re-validate the whole chain inside the
+                // backfill loop — pure redundant CPU. The data here is already on disk and trusted;
+                // Stage A reads `txids` the same raw way.
+                let transparent_tx_list = {
+                    let txn = env.begin_ro_txn()?;
+                    let raw = txn
+                        .get(transparent_db, &height_bytes)
+                        .map_err(FinalisedStateError::LmdbError)?;
+                    let entry =
+                        StoredEntryVar::<TransparentTxList>::from_bytes(raw).map_err(|error| {
+                            FinalisedStateError::Custom(format!("transparent corrupt data: {error}"))
+                        })?;
+                    if !entry.verify(&height_bytes) {
+                        return Err(FinalisedStateError::Custom(
+                            "transparent checksum mismatch".to_string(),
+                        ));
+                    }
+                    entry.inner().clone()
+                };
 
                 let txids = {
                     let mut txids = Vec::with_capacity(transparent_tx_list.tx().len());


### PR DESCRIPTION
[fixed 1.1.0->1.2.0 migration, moved db to f_sync](https://github.com/zingolabs/zaino/commit/6a2090399a0c03a4ed1140ab5191e10d6c444ae6)