### PR TITLE
RC-0.5.0 bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this library adheres to Rust's notion of
 
 ## Unreleased
 
+### Changed
+- **Breaking** — config: `storage.database.sync_write_batch_bytes` (bytes) is
+  renamed to `sync_write_batch_size` and given in **GiB** (default raised from
+  4 GiB to 32 GiB); this budget now also bounds the txout-set accumulator
+  rebuild's per-shard memory. New `storage.database.sync_checkpoint_interval`
+  (seconds, default 300) makes the bulk-sync flush interval configurable (was a
+  fixed 60s).
+
+### Fixed
+- Zaino no longer OOM-crashes during the txout-set accumulator rebuild when it
+  reaches mainnet chain tip on memory-constrained hosts; the rebuild auto-shards
+  its in-memory spent set to fit the configured `sync_write_batch_size` budget.
+
 ## [0.4.1] - 2026-06-18
 - Bump zaino-proto 0.1.2 → 0.1.3 and zainod 0.4.0 → 0.4.1 to work around
   a yanked 0.1.2 slot on crates.io. No code changes.

--- a/docs/example_configs/zainod.toml
+++ b/docs/example_configs/zainod.toml
@@ -38,3 +38,11 @@ shard_power = 4
 [storage.database]
 path = '/home/cupress/.cache/zaino'
 size = 128
+# Approximate in-memory budget (in GiB) for the bulk-sync write batch. Also bounds the per-shard
+# memory of the txout-set accumulator rebuild at chain tip (it auto-shards to fit). Lower this on
+# memory-constrained hosts to bound peak sync/rebuild RAM. Defaults to 32.
+sync_write_batch_size = 32
+# Max wall-clock time (seconds) spent buffering a bulk-sync batch before flushing. Raise it to make
+# sync less reactive but faster on large-RAM hosts where the memory budget is never reached first.
+# Defaults to 300 (5 minutes).
+sync_checkpoint_interval = 300

--- a/docs/example_configs/zainod.toml
+++ b/docs/example_configs/zainod.toml
@@ -38,11 +38,15 @@ shard_power = 4
 [storage.database]
 path = '/home/cupress/.cache/zaino'
 size = 128
-# Approximate in-memory budget (in GiB) for the bulk-sync write batch. Also bounds the per-shard
-# memory of the txout-set accumulator rebuild at chain tip (it auto-shards to fit). Lower this on
-# memory-constrained hosts to bound peak sync/rebuild RAM. Defaults to 32.
-sync_write_batch_size = 32
-# Max wall-clock time (seconds) spent buffering a bulk-sync batch before flushing. Raise it to make
-# sync less reactive but faster on large-RAM hosts where the memory budget is never reached first.
-# Defaults to 300 (5 minutes).
-sync_checkpoint_interval = 300
+# Heap budget (in GiB) for the bulk-sync write batch (buffered blocks only). Lower this on
+# memory-constrained hosts; a larger value does not speed up a small host, it just risks the
+# OOM-killer. Defaults to 8.
+sync_write_batch_size = 8
+# Heap budget (in GiB) for the from-genesis txout-set accumulator rebuild's spent set. Separate from
+# sync_write_batch_size: the rebuild auto-shards to keep peak RAM within this budget. Lower it on
+# memory-constrained hosts (more, smaller passes). Defaults to 8.
+accumulator_rebuild_memory_size = 8
+# Max wall-clock time (seconds) spent buffering a bulk-sync batch before flushing. Because the DB
+# runs with NO_SYNC, this also bounds the window of unflushed writes at risk on a hard kill /
+# eviction. Lower it to shrink that window. Defaults to 120 (2 minutes).
+sync_checkpoint_interval = 120

--- a/packages/zaino-common/CHANGELOG.md
+++ b/packages/zaino-common/CHANGELOG.md
@@ -8,7 +8,17 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+- `StorageConfig::database.sync_checkpoint_interval` (seconds, default 300) — max
+  wall-clock time spent buffering a bulk-sync write batch before flushing. Raise
+  it to make sync less reactive but faster on large-RAM hosts where the memory
+  budget is never reached before the interval.
 ### Changed
+- **Breaking** — `StorageConfig::database.sync_write_batch_bytes` (raw bytes) is
+  renamed to `sync_write_batch_size` and now expressed in **GiB** (new
+  `SyncWriteBatchSize` newtype, mirroring `DatabaseSize`); the default is raised
+  from 4 GiB to 32 GiB. This budget now also bounds the per-shard memory of the
+  finalised-state txout-set accumulator rebuild. Existing TOML configs setting
+  `sync_write_batch_bytes` must switch to `sync_write_batch_size` (in GiB).
 ### Deprecated
 ### Removed
 ### Fixed

--- a/packages/zaino-common/CHANGELOG.md
+++ b/packages/zaino-common/CHANGELOG.md
@@ -8,17 +8,26 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
-- `StorageConfig::database.sync_checkpoint_interval` (seconds, default 300) — max
-  wall-clock time spent buffering a bulk-sync write batch before flushing. Raise
-  it to make sync less reactive but faster on large-RAM hosts where the memory
-  budget is never reached before the interval.
+- `StorageConfig::database.sync_checkpoint_interval` (seconds, default 120) — max
+  wall-clock time spent buffering a bulk-sync write batch before flushing. Under
+  the env's `NO_SYNC` mode this also bounds the window of unflushed writes at risk
+  on a hard kill / eviction; lower it to shrink that window.
+- `StorageConfig::database.accumulator_rebuild_memory_size` (GiB, default 8, new
+  `AccumulatorRebuildMemorySize` newtype) — dedicated heap budget for the
+  from-genesis txout-set accumulator rebuild's spent set, kept **separate** from
+  `sync_write_batch_size` so the two operations cannot inflate each other's peak
+  memory.
 ### Changed
 - **Breaking** — `StorageConfig::database.sync_write_batch_bytes` (raw bytes) is
   renamed to `sync_write_batch_size` and now expressed in **GiB** (new
-  `SyncWriteBatchSize` newtype, mirroring `DatabaseSize`); the default is raised
-  from 4 GiB to 32 GiB. This budget now also bounds the per-shard memory of the
-  finalised-state txout-set accumulator rebuild. Existing TOML configs setting
+  `SyncWriteBatchSize` newtype, mirroring `DatabaseSize`); the default is 8 GiB.
+  It is now a heap budget for buffered blocks only — the accumulator rebuild uses
+  the separate `accumulator_rebuild_memory_size`. Existing TOML configs setting
   `sync_write_batch_bytes` must switch to `sync_write_batch_size` (in GiB).
+- **Breaking** — `DatabaseConfig` now uses `#[serde(deny_unknown_fields)]`: an
+  unrecognized key under `[storage.database]` (e.g. a stale `sync_write_batch_bytes`)
+  is a hard parse error instead of being silently ignored and falling back to the
+  default budget — the silent fallback previously OOM-killed nodes.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/packages/zaino-common/src/config/storage.rs
+++ b/packages/zaino-common/src/config/storage.rs
@@ -63,14 +63,46 @@ pub struct SyncWriteBatchSize(pub usize);
 
 impl Default for SyncWriteBatchSize {
     fn default() -> Self {
-        SyncWriteBatchSize(32) // Default to 32 GiB.
+        // 8 GiB. This is a *heap* budget for buffered blocks only; lower it on a memory-constrained
+        // host (or a cgroup-limited container). A larger value does not make a small host faster — it
+        // just risks the OOM-killer, and a kill under `NO_SYNC` is what then corrupts the on-disk DB.
+        // (Previously 32 GiB, which OOM-killed small hosts.)
+        SyncWriteBatchSize(8)
     }
 }
 
 impl SyncWriteBatchSize {
-    /// Convert to bytes.
+    /// Convert to bytes, saturating instead of overflowing on an absurd configured value.
     pub fn to_byte_count(&self) -> usize {
-        self.0 * 1024 * 1024 * 1024
+        self.0.saturating_mul(1024 * 1024 * 1024)
+    }
+}
+
+/// Memory budget (in gibibytes) for the from-genesis txout-set accumulator rebuild's in-RAM spent
+/// set.
+///
+/// Deliberately separate from [`SyncWriteBatchSize`]: the accumulator rebuild and the bulk-sync
+/// write batch are different operations with different peak-memory shapes. Coupling them caused a
+/// large block-buffer budget to be silently reused as the accumulator's per-shard cap, OOM-killing
+/// small hosts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(transparent)]
+pub struct AccumulatorRebuildMemorySize(pub usize);
+
+impl Default for AccumulatorRebuildMemorySize {
+    fn default() -> Self {
+        // 8 GiB. The rebuild auto-shards the spent set to keep each shard's `HashSet` within this
+        // budget, so raising it only trades fewer/larger passes (faster) for more peak RAM, and
+        // lowering it bounds peak RAM at the cost of more passes. Over-sharding is safe; a too-large
+        // budget on a small host is not — lower this on a memory-constrained host.
+        AccumulatorRebuildMemorySize(8)
+    }
+}
+
+impl AccumulatorRebuildMemorySize {
+    /// Convert to bytes, saturating instead of overflowing on an absurd configured value.
+    pub fn to_byte_count(&self) -> usize {
+        self.0.saturating_mul(1024 * 1024 * 1024)
     }
 }
 
@@ -78,8 +110,14 @@ impl SyncWriteBatchSize {
 ///
 /// Configures the file path and size limits for persistent storage
 /// used by Zaino services.
+///
+/// `deny_unknown_fields`: an unrecognized key under `[storage.database]` is a hard error rather
+/// than being silently ignored. This guards against the exact footgun that motivated this struct's
+/// last revision — a config still using the old `sync_write_batch_bytes` key would otherwise be
+/// dropped silently and the renamed `sync_write_batch_size` would fall back to its (large) default,
+/// OOM-killing the node. Failing loudly forces the operator to migrate the key.
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct DatabaseConfig {
     /// Database file path.
     pub path: PathBuf,
@@ -93,29 +131,37 @@ pub struct DatabaseConfig {
     /// key order. Sorting turns the random B-tree leaf faults (which dominate once the DB exceeds
     /// RAM) into a sequential sweep; larger batches mean fewer sweeps.
     ///
-    /// This same budget bounds the per-shard memory of the txout-set accumulator rebuild at chain
-    /// tip: the rebuild auto-shards so its in-RAM spent set stays within this budget. Lower it on
-    /// memory-constrained hosts to keep peak sync/rebuild RAM bounded.
-    ///
-    /// NOTE: peak RAM is roughly this budget (buffered blocks) plus the transaction's dirty pages,
-    /// and it competes with the OS page cache the sorted sweep relies on — larger is not always
-    /// better. Defaults to 32 GiB; lower it on memory-constrained hosts.
+    /// NOTE: this is a heap budget for buffered blocks; peak RAM is roughly this budget plus the
+    /// transaction's dirty pages, and it competes with the OS page cache the sorted sweep relies on
+    /// — larger is not always better, and on a memory-constrained host it risks the OOM-killer.
+    /// Defaults to 8 GiB; lower it on memory-constrained hosts. The txout-set accumulator rebuild
+    /// has its own, separate budget ([`DatabaseConfig::accumulator_rebuild_memory_size`]).
     #[serde(default)]
     pub sync_write_batch_size: SyncWriteBatchSize,
 
-    /// Maximum wall-clock time (in seconds) spent buffering a single bulk-sync write batch before
-    /// flushing, so commits (and progress) happen regularly even when block fetches are slow.
+    /// In-memory budget (in GiB) for the from-genesis txout-set accumulator rebuild's spent set.
     ///
-    /// Raise it to make sync less reactive but faster on large-RAM hosts where the memory budget
-    /// ([`DatabaseConfig::sync_write_batch_size`]) is never reached before this interval. Defaults
-    /// to 300 seconds (5 minutes).
+    /// The rebuild auto-shards by creating-txid prefix so the per-shard in-RAM spent set stays
+    /// within this budget. Kept separate from [`DatabaseConfig::sync_write_batch_size`] so the two
+    /// unrelated operations cannot inflate each other's peak memory. Defaults to 8 GiB; lower it on
+    /// memory-constrained hosts to bound peak rebuild RAM (at the cost of more, smaller passes).
+    #[serde(default)]
+    pub accumulator_rebuild_memory_size: AccumulatorRebuildMemorySize,
+
+    /// Maximum wall-clock time (in seconds) spent buffering a single bulk-sync write batch before
+    /// flushing, so commits (and durability) happen regularly even when block fetches are slow.
+    ///
+    /// Because the environment runs with `NO_SYNC`, this also bounds the window of unflushed writes
+    /// at risk on a hard kill / eviction. Raise it to make sync less reactive but faster on large-RAM
+    /// hosts where the memory budget is never reached before this interval; lower it to shrink the
+    /// crash-loss / corruption window. Defaults to 120 seconds (2 minutes).
     #[serde(default = "default_sync_checkpoint_interval")]
     pub sync_checkpoint_interval: u64,
 }
 
-/// Default [`DatabaseConfig::sync_checkpoint_interval`]: 300 seconds (5 minutes).
+/// Default [`DatabaseConfig::sync_checkpoint_interval`]: 120 seconds (2 minutes).
 fn default_sync_checkpoint_interval() -> u64 {
-    300
+    120
 }
 
 impl Default for DatabaseConfig {
@@ -124,6 +170,7 @@ impl Default for DatabaseConfig {
             path: resolve_path_with_xdg_cache_defaults("zaino"),
             size: DatabaseSize::default(),
             sync_write_batch_size: SyncWriteBatchSize::default(),
+            accumulator_rebuild_memory_size: AccumulatorRebuildMemorySize::default(),
             sync_checkpoint_interval: default_sync_checkpoint_interval(),
         }
     }
@@ -139,4 +186,31 @@ pub struct StorageConfig {
     pub cache: CacheConfig,
     /// Database configuration
     pub database: DatabaseConfig,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_database_budgets_are_the_safe_values() {
+        let database = DatabaseConfig::default();
+        assert_eq!(database.sync_write_batch_size, SyncWriteBatchSize(8));
+        assert_eq!(
+            database.accumulator_rebuild_memory_size,
+            AccumulatorRebuildMemorySize(8)
+        );
+        assert_eq!(database.sync_checkpoint_interval, 120);
+    }
+
+    #[test]
+    fn budget_byte_counts_saturate_instead_of_overflowing() {
+        assert_eq!(SyncWriteBatchSize(8).to_byte_count(), 8 * 1024 * 1024 * 1024);
+        assert_eq!(
+            AccumulatorRebuildMemorySize(8).to_byte_count(),
+            8 * 1024 * 1024 * 1024
+        );
+        // An absurd configured value saturates rather than wrapping to a tiny (or zero) budget.
+        assert_eq!(SyncWriteBatchSize(usize::MAX).to_byte_count(), usize::MAX);
+    }
 }

--- a/packages/zaino-common/src/config/storage.rs
+++ b/packages/zaino-common/src/config/storage.rs
@@ -56,6 +56,24 @@ impl DatabaseSize {
     }
 }
 
+/// Finalised-state bulk-sync write-batch memory budget, in gibibytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(transparent)]
+pub struct SyncWriteBatchSize(pub usize);
+
+impl Default for SyncWriteBatchSize {
+    fn default() -> Self {
+        SyncWriteBatchSize(32) // Default to 32 GiB.
+    }
+}
+
+impl SyncWriteBatchSize {
+    /// Convert to bytes.
+    pub fn to_byte_count(&self) -> usize {
+        self.0 * 1024 * 1024 * 1024
+    }
+}
+
 /// Database configuration.
 ///
 /// Configures the file path and size limits for persistent storage
@@ -68,23 +86,36 @@ pub struct DatabaseConfig {
     /// Database size limit. Defaults to 128 GB.
     #[serde(default)]
     pub size: DatabaseSize,
-    /// Approximate in-memory byte budget for the finalised-state bulk-sync write batch.
+    /// Approximate in-memory budget (in GiB) for the finalised-state bulk-sync write batch.
     ///
-    /// Bulk sync buffers fetched blocks up to this many bytes, then writes the whole batch in one
+    /// Bulk sync buffers fetched blocks up to this budget, then writes the whole batch in one
     /// LMDB transaction with the random-keyed `spent` / `txid_location` entries inserted in **sorted**
     /// key order. Sorting turns the random B-tree leaf faults (which dominate once the DB exceeds
     /// RAM) into a sequential sweep; larger batches mean fewer sweeps.
     ///
+    /// This same budget bounds the per-shard memory of the txout-set accumulator rebuild at chain
+    /// tip: the rebuild auto-shards so its in-RAM spent set stays within this budget. Lower it on
+    /// memory-constrained hosts to keep peak sync/rebuild RAM bounded.
+    ///
     /// NOTE: peak RAM is roughly this budget (buffered blocks) plus the transaction's dirty pages,
     /// and it competes with the OS page cache the sorted sweep relies on — larger is not always
-    /// better. Defaults to 4 GiB; raise it on large-RAM hosts.
-    #[serde(default = "default_sync_write_batch_bytes")]
-    pub sync_write_batch_bytes: u64,
+    /// better. Defaults to 32 GiB; lower it on memory-constrained hosts.
+    #[serde(default)]
+    pub sync_write_batch_size: SyncWriteBatchSize,
+
+    /// Maximum wall-clock time (in seconds) spent buffering a single bulk-sync write batch before
+    /// flushing, so commits (and progress) happen regularly even when block fetches are slow.
+    ///
+    /// Raise it to make sync less reactive but faster on large-RAM hosts where the memory budget
+    /// ([`DatabaseConfig::sync_write_batch_size`]) is never reached before this interval. Defaults
+    /// to 300 seconds (5 minutes).
+    #[serde(default = "default_sync_checkpoint_interval")]
+    pub sync_checkpoint_interval: u64,
 }
 
-/// Default [`DatabaseConfig::sync_write_batch_bytes`]: 4 GiB.
-fn default_sync_write_batch_bytes() -> u64 {
-    4 * 1024 * 1024 * 1024
+/// Default [`DatabaseConfig::sync_checkpoint_interval`]: 300 seconds (5 minutes).
+fn default_sync_checkpoint_interval() -> u64 {
+    300
 }
 
 impl Default for DatabaseConfig {
@@ -92,7 +123,8 @@ impl Default for DatabaseConfig {
         Self {
             path: resolve_path_with_xdg_cache_defaults("zaino"),
             size: DatabaseSize::default(),
-            sync_write_batch_bytes: default_sync_write_batch_bytes(),
+            sync_write_batch_size: SyncWriteBatchSize::default(),
+            sync_checkpoint_interval: default_sync_checkpoint_interval(),
         }
     }
 }

--- a/packages/zaino-common/src/config/storage.rs
+++ b/packages/zaino-common/src/config/storage.rs
@@ -205,7 +205,10 @@ mod tests {
 
     #[test]
     fn budget_byte_counts_saturate_instead_of_overflowing() {
-        assert_eq!(SyncWriteBatchSize(8).to_byte_count(), 8 * 1024 * 1024 * 1024);
+        assert_eq!(
+            SyncWriteBatchSize(8).to_byte_count(),
+            8 * 1024 * 1024 * 1024
+        );
         assert_eq!(
             AccumulatorRebuildMemorySize(8).to_byte_count(),
             8 * 1024 * 1024 * 1024

--- a/packages/zaino-common/src/lib.rs
+++ b/packages/zaino-common/src/lib.rs
@@ -18,7 +18,8 @@ pub use net::{resolve_socket_addr, try_resolve_address, AddressResolution};
 pub use config::network::{ActivationHeights, Network, ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS};
 pub use config::service::ServiceConfig;
 pub use config::storage::{
-    CacheConfig, DatabaseConfig, DatabaseSize, StorageConfig, SyncWriteBatchSize,
+    AccumulatorRebuildMemorySize, CacheConfig, DatabaseConfig, DatabaseSize, StorageConfig,
+    SyncWriteBatchSize,
 };
 pub use config::validator::ValidatorConfig;
 

--- a/packages/zaino-common/src/lib.rs
+++ b/packages/zaino-common/src/lib.rs
@@ -17,7 +17,9 @@ pub use net::{resolve_socket_addr, try_resolve_address, AddressResolution};
 // This allows existing code using `use zaino_common::Network` to continue working.
 pub use config::network::{ActivationHeights, Network, ZEBRAD_DEFAULT_ACTIVATION_HEIGHTS};
 pub use config::service::ServiceConfig;
-pub use config::storage::{CacheConfig, DatabaseConfig, DatabaseSize, StorageConfig};
+pub use config::storage::{
+    CacheConfig, DatabaseConfig, DatabaseSize, StorageConfig, SyncWriteBatchSize,
+};
 pub use config::validator::ValidatorConfig;
 
 // Keep submodule access available for more specific imports if needed

--- a/packages/zaino-state/CHANGELOG.md
+++ b/packages/zaino-state/CHANGELOG.md
@@ -32,9 +32,19 @@ and this library adheres to Rust's notion of
   `MAX_NFS_DEPTH` blocks below the tip, so the cache cannot grow unbounded when
   the finalised `db_height` lags (background sync) or is pinned at `0`
   (ephemeral mode).
+- The finalised-state bulk-sync write-batch flush interval is now configurable
+  via `storage.database.sync_checkpoint_interval` (was a fixed 60s; default now
+  300s). Raise it to make sync less reactive but faster on large-RAM hosts where
+  the memory budget is never reached before the interval.
 ### Deprecated
 ### Removed
 ### Fixed
+- The finalised-state txout-set accumulator rebuild at chain tip no longer
+  OOM-crashes on memory-constrained hosts. The rebuild now auto-shards its
+  in-memory spent set to fit the configured
+  `storage.database.sync_write_batch_size` budget (a single optimal pass when the
+  whole set fits in RAM, scaling up otherwise); the result is independent of the
+  shard count.
 
 ## [0.3.0] - 2026-06-17
 

--- a/packages/zaino-state/CHANGELOG.md
+++ b/packages/zaino-state/CHANGELOG.md
@@ -34,17 +34,31 @@ and this library adheres to Rust's notion of
   (ephemeral mode).
 - The finalised-state bulk-sync write-batch flush interval is now configurable
   via `storage.database.sync_checkpoint_interval` (was a fixed 60s; default now
-  300s). Raise it to make sync less reactive but faster on large-RAM hosts where
-  the memory budget is never reached before the interval.
+  120s). Under `NO_SYNC` this also bounds the window of unflushed writes at risk
+  on a hard kill / eviction; lower it to shrink that window.
+- The txout-set accumulator rebuild now sizes its in-memory spent set from a
+  dedicated `storage.database.accumulator_rebuild_memory_size` budget instead of
+  reusing `sync_write_batch_size`, so the bulk-sync block buffer and the rebuild
+  can no longer inflate each other's peak memory.
 ### Deprecated
 ### Removed
 ### Fixed
 - The finalised-state txout-set accumulator rebuild at chain tip no longer
-  OOM-crashes on memory-constrained hosts. The rebuild now auto-shards its
-  in-memory spent set to fit the configured
-  `storage.database.sync_write_batch_size` budget (a single optimal pass when the
-  whole set fits in RAM, scaling up otherwise); the result is independent of the
-  shard count.
+  OOM-crashes on memory-constrained hosts. It auto-shards its in-memory spent set
+  by creating-txid prefix and now enforces the per-shard budget *strictly*: each
+  shard is loaded with a hard outpoint cap (range-seeking only that shard's
+  contiguous key range rather than scanning the whole `spent` table), and any
+  shard that would exceed the cap is bisected and retried — down to single-byte
+  shards, at which point it fails with an actionable error rather than OOM-ing.
+  The result is independent of the shard count.
+- Startup `spent`-table integrity failures now report the offending entry's key,
+  value length, and leading value bytes plus a wipe-and-re-index hint (previously
+  a bare "corrupt spent entry" / "version tag N"), and the integrity and rebuild
+  scans walk the cursor explicitly so a real LMDB error propagates instead of
+  being swallowed (release) or `debug_assert!`-panicking (debug).
+- Corrected documentation that claimed `NO_SYNC` "never corrupts the database": on
+  storage that does not preserve write order (NFS, overlay filesystems, hard pod
+  eviction) a crash can leave torn pages; the recovery is to wipe and re-index.
 
 ## [0.3.0] - 2026-06-17
 

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -884,17 +884,23 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                     let non_finalized_state = match *intermediate_nfs_for_scoping {
                         Some(ref nfs) => nfs,
                         None => {
+                            // Anchor the non-finalised state at `finalised_height`
+                            // (= chain tip − NON_FINALIZED_DEPTH), never at genesis: a missing
+                            // anchor used to fall through to genesis and then re-anchor up to the
+                            // lagging finalised tip, grinding millions of blocks one at a time
+                            // (#1261). `resolve_anchor_block` serves the anchor from the finalised
+                            // DB / passthrough or builds it from the validator.
+                            let anchor = NonFinalizedState::resolve_anchor_block(
+                                &source,
+                                &fs.to_reader(),
+                                &network,
+                                finalised_height,
+                            )
+                            .await?;
                             nfs.store(Some(Arc::new(
-                                NonFinalizedState::initialize(
-                                    source,
-                                    network,
-                                    fs.to_reader()
-                                        .get_chain_block_by_height(finalised_height)
-                                        .await
-                                        .expect("todo"),
-                                )
-                                .await
-                                .expect("todo"),
+                                NonFinalizedState::initialize(source, network, Some(anchor))
+                                    .await
+                                    .map_err(source_error)?,
                             )));
                             &nfs.load_full().expect("just set to Some")
                         }

--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -688,6 +688,20 @@ impl<T: BlockchainSource> FinalisedState<T> {
             return Ok(());
         }
 
+        // Single-flight: if a background sync (or migration) is already in progress, this poll is a
+        // no-op. The indexer worker calls this method on every poll, so without this guard a
+        // long-running background sync would be re-spawned on each iteration, piling up concurrent
+        // `write_blocks_to_height` runs that contend on the single LMDB writer and multiply memory
+        // until the process is OOM-killed before any batch commits durably — leaving restarts to
+        // resume from the snapshot baseline rather than the last synced height (see issue #1261).
+        // `has_background_ops` is the union of sync and migration; migrations are already excluded
+        // above via `has_full_ephemeral_reference`, so the only thing this observes here is an
+        // in-flight sync. The running task syncs to the height it was spawned with; if the chain has
+        // advanced past it, the next poll after it completes spawns a fresh sync to the new target.
+        if self.db.has_background_ops() {
+            return Ok(());
+        }
+
         let primary = self.db.primary_backend();
         let db_height_opt = primary.db_height().await?;
 

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source.rs
@@ -1021,6 +1021,22 @@ impl<T: BlockchainSource> FinalisedSource<T> {
         }
     }
 
+    /// Resolves the accumulator-rebuild shard count for a memory budget (V1 only).
+    ///
+    /// Test hook for asserting the rebuild auto-shards to fit the configured memory budget.
+    #[cfg(test)]
+    pub(crate) fn accumulator_build_shards(
+        &self,
+        budget_bytes: u64,
+    ) -> Result<u16, FinalisedStateError> {
+        match self {
+            Self::V1(database) => database.accumulator_build_shards(budget_bytes),
+            Self::V0(_) | Self::Ephemeral(_) => Err(FinalisedStateError::FeatureUnavailable(
+                "v1 txout-set accumulator builder",
+            )),
+        }
+    }
+
     /// Writes a block using the v1.0.0 format.
     ///
     /// This intentionally writes only the core v1 tables and uses v1 item encodings.

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source.rs
@@ -1012,9 +1012,12 @@ impl<T: BlockchainSource> FinalisedSource<T> {
         &self,
         db_tip: Height,
         shards: u16,
+        max_spent_entries: u64,
     ) -> Result<FinalisedTxOutSetInfoAccumulator, FinalisedStateError> {
         match self {
-            Self::V1(database) => database.build_tx_out_set_accumulator_blocking(db_tip, shards),
+            Self::V1(database) => {
+                database.build_tx_out_set_accumulator_blocking(db_tip, shards, max_spent_entries)
+            }
             Self::V0(_) | Self::Ephemeral(_) => Err(FinalisedStateError::FeatureUnavailable(
                 "v1 txout-set accumulator builder",
             )),

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
@@ -177,7 +177,7 @@ pub(crate) const ACCUMULATOR_INCREMENTAL_MAX_GAP: u32 = 1_000;
 /// independent of the shard count.
 ///
 /// The shard count is chosen at rebuild time so the per-shard spent set fits the configured
-/// [`zaino_common::DatabaseConfig::sync_write_batch_size`] budget (see
+/// [`zaino_common::DatabaseConfig::accumulator_rebuild_memory_size`] budget (see
 /// [`DbV1::rebuild_tx_out_set_accumulator`]): a single optimal pass on hosts with enough RAM for
 /// the full spent set, scaling up on memory-constrained deployments. Sharding partitions on the
 /// creating-txid's first byte (256 distinct values), so the count is capped here.

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
@@ -184,9 +184,14 @@ pub(crate) const ACCUMULATOR_INCREMENTAL_MAX_GAP: u32 = 1_000;
 pub(crate) const ACCUMULATOR_BUILD_MAX_SHARDS: u16 = 256;
 
 /// Conservative per-entry RAM estimate for the rebuild's in-memory spent set, used only to size the
-/// shard count. Each entry is a boxed `spent` key (~37 bytes) plus `HashSet` bucket overhead; an
-/// over-estimate just adds shards (less memory), never under-bounds.
-pub(crate) const SPENT_SET_ENTRY_BYTES_ESTIMATE: u64 = 128;
+/// shard count.
+///
+/// Each entry is a 37-byte `spent` key heap-allocated as a `Box<[u8]>` (rounded up by the
+/// allocator), a 16-byte fat pointer stored in the `HashSet` table, plus hashbrown control bytes and
+/// load-factor slack — realistically ~120 bytes, but allocator behaviour varies. Set deliberately
+/// *above* that so the chosen shard count over-provisions: the per-shard set then stays within the
+/// budget, and over-counting only adds shards (less memory per shard), it never under-bounds.
+pub(crate) const SPENT_SET_ENTRY_BYTES_ESTIMATE: u64 = 256;
 
 /// Number of committed block writes / migration heights between explicit
 /// `env.sync(true)` durability checkpoints.

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
@@ -196,15 +196,54 @@ pub(crate) const SPENT_SET_ENTRY_BYTES_ESTIMATE: u64 = 256;
 /// Number of committed block writes / migration heights between explicit
 /// `env.sync(true)` durability checkpoints.
 ///
+/// This governs the durability-sync cadence of the **per-block steady-state append**
+/// ([`DbWrite::write_block`]) and the **migration backfill scan**: both commit frequently but, under
+/// `MDB_NOSYNC`, force an `env.sync(true)` only every `SYNC_CHECKPOINT_INTERVAL` committed
+/// writes/heights. (The separate **bulk catch-up** path batches differently — by the
+/// `sync_write_batch_size` byte budget, a block-count cap, and the wall-clock
+/// `DatabaseConfig::sync_checkpoint_interval` — and fsyncs once per committed batch, so it does not
+/// use this constant.)
+///
 /// The LMDB environment is opened with `MDB_NOSYNC` (see [`DbV1::spawn`]), so an individual
-/// `txn.commit()` is *not* flushed to disk. Because the environment does not use `WRITE_MAP`,
-/// LMDB still guarantees ACI on crash — only durability (D) is lost: a crash rolls the database
-/// back to the last on-disk-consistent transaction, it never corrupts it (copy-on-write + dual
-/// meta pages always leave a recoverable committed snapshot). Forcing a sync every
-/// `SYNC_CHECKPOINT_INTERVAL` writes bounds how much committed-but-unflushed tail a crash can
-/// discard. The tail is always safe to re-do: clean sync resumes from the on-disk tip and
-/// re-fetches the missing blocks, and migrations resume idempotently from their progress keys.
+/// `txn.commit()` is *not* flushed to disk. On a **write-order-preserving local filesystem** this
+/// only costs durability (D): LMDB's copy-on-write + dual meta pages mean a crash rolls back to the
+/// last fully-flushed transaction without corrupting the database, and the checkpoint cadence bounds
+/// how much committed-but-unflushed tail a crash can discard. The tail is always safe to re-do:
+/// clean sync resumes from the on-disk tip and re-fetches the missing blocks, and migrations resume
+/// idempotently from their progress keys.
+///
+/// CAVEAT: that integrity guarantee relies on the filesystem preserving write order. On networked
+/// storage (NFS), overlay filesystems, or a container/pod hard-eviction that drops the unflushed
+/// page cache, write order is *not* guaranteed and a crash under `MDB_NOSYNC` **can** leave torn
+/// pages — surfacing later as an LMDB cursor assertion or a checksum/decode failure on the affected
+/// table. The recovery is to wipe the finalised-state DB and re-index (its tables are all
+/// re-derivable from the validator). A shorter checkpoint interval shrinks, but does not eliminate,
+/// this window.
 pub(crate) const SYNC_CHECKPOINT_INTERVAL: u32 = 1000;
+
+/// Formats a one-line corruption report for a malformed `spent` entry: its position in the table,
+/// the key (hex), the value length, and the value's leading bytes (hex), plus the re-index hint.
+///
+/// The leading bytes are the diagnostic that distinguishes failure modes: a value that should begin
+/// with the `StoredEntryFixed` version tag but starts with arbitrary bytes (e.g. `0xfd`) is a torn
+/// write, whereas a recognisable-but-old structure would indicate a format problem.
+fn spent_corruption_detail(
+    entry_index: u64,
+    key_bytes: &[u8],
+    val_bytes: &[u8],
+    reason: &str,
+) -> String {
+    /// Cap on value bytes included in the report — enough to identify the framing, not the whole row.
+    const VALUE_HEAD_BYTES: usize = 16;
+    let value_head = hex::encode(&val_bytes[..val_bytes.len().min(VALUE_HEAD_BYTES)]);
+    format!(
+        "corrupt spent entry #{entry_index} ({reason}): key=0x{key}, value_len={value_len}, \
+         value_head=0x{value_head}; the finalised-state spent table is damaged — wipe the database \
+         and re-index",
+        key = hex::encode(key_bytes),
+        value_len = val_bytes.len(),
+    )
+}
 
 /// [`DbCore`] capability implementation for [`DbV1`].
 ///
@@ -399,8 +438,11 @@ impl DbV1 {
         // hashes), which made per-commit fsync the dominant sync cost once those trees outgrew
         // the page cache. Under `NO_SYNC` the OS batches that write-back; we force durability at
         // explicit checkpoints (`SYNC_CHECKPOINT_INTERVAL`) and on graceful shutdown instead.
-        // `WRITE_MAP` is unset, so a crash never corrupts the database — it only discards the
-        // unflushed tail of recent commits, which clean sync and migrations safely re-do.
+        // `WRITE_MAP` is unset, so on a write-order-preserving local filesystem a crash does not
+        // corrupt the database — it only discards the unflushed tail of recent commits, which clean
+        // sync and migrations safely re-do. (On NFS / overlay filesystems or a hard pod eviction that
+        // drops the unflushed page cache, write order is not guaranteed and a crash *can* leave torn
+        // pages; the recovery there is to wipe and re-index. See `SYNC_CHECKPOINT_INTERVAL`.)
         let env = Environment::new()
             .set_max_dbs(15)
             .set_map_size(db_size_bytes)
@@ -651,26 +693,62 @@ impl DbV1 {
     }
 
     /// Validates every stored spent-outpoint entry (`Outpoint` -> `TxLocation`) by checksum.
+    ///
+    /// On the first malformed entry the error dumps the offending key, the value length, and the
+    /// value's leading bytes (hex). This is deliberately specific: a "version tag 253"-style failure
+    /// here means the on-disk `spent` table is damaged (almost always a torn write from an unclean
+    /// exit under `NO_SYNC` on networked/evicted storage — see [`SYNC_CHECKPOINT_INTERVAL`]), and the
+    /// dumped bytes let an operator confirm torn-page corruption vs. a genuine format problem. The
+    /// recovery is to wipe the finalised-state database and re-index.
     async fn initial_spent_scan(&self) -> Result<(), FinalisedStateError> {
         let env = self.env.clone();
         let spent = self.spent;
 
         tokio::task::spawn_blocking(move || {
+            // Logged before the scan so that a native LMDB abort while walking a torn `spent` B-tree
+            // (which bypasses Rust error handling) is still attributable to this startup phase.
+            info!("validating finalised-state spent table integrity");
             let ro = env.begin_ro_txn()?;
-            let mut cursor = ro.open_ro_cursor(spent)?;
+            let cursor = ro.open_ro_cursor(spent)?;
 
-            for (key_bytes, val_bytes) in cursor.iter() {
-                let entry = StoredEntryFixed::<TxLocation>::from_bytes(val_bytes).map_err(|e| {
-                    FinalisedStateError::Custom(format!("corrupt spent entry: {e}"))
-                })?;
+            // Explicit cursor walk rather than `Cursor::iter` (which `debug_assert!`-panics on a
+            // non-`NotFound` LMDB error in debug and silently ends the scan in release): a real LMDB
+            // error propagates cleanly and the scan only ends on a genuine end-of-table `NotFound`.
+            let mut entry_index: u64 = 0;
+            let mut op = lmdb_sys::MDB_FIRST;
+            loop {
+                let (key_bytes, val_bytes) = match cursor.get(None, None, op) {
+                    Ok((Some(key), value)) => (key, value),
+                    // `MDB_FIRST`/`MDB_NEXT` always report the key; treat a missing key as end-of-data.
+                    Ok((None, _)) => break,
+                    Err(lmdb::Error::NotFound) => break,
+                    Err(error) => return Err(FinalisedStateError::LmdbError(error)),
+                };
+                op = lmdb_sys::MDB_NEXT;
+
+                let entry =
+                    StoredEntryFixed::<TxLocation>::from_bytes(val_bytes).map_err(|error| {
+                        FinalisedStateError::Custom(spent_corruption_detail(
+                            entry_index,
+                            key_bytes,
+                            val_bytes,
+                            &error.to_string(),
+                        ))
+                    })?;
 
                 if !entry.verify(key_bytes) {
-                    return Err(FinalisedStateError::Custom(
-                        "spent record checksum mismatch".into(),
-                    ));
+                    return Err(FinalisedStateError::Custom(spent_corruption_detail(
+                        entry_index,
+                        key_bytes,
+                        val_bytes,
+                        "checksum mismatch",
+                    )));
                 }
+
+                entry_index += 1;
             }
 
+            info!("finalised-state spent table integrity check passed ({entry_index} entries)");
             Ok(())
         })
         .await
@@ -967,8 +1045,11 @@ impl DbV1 {
         // hashes), which made per-commit fsync the dominant sync cost once those trees outgrew
         // the page cache. Under `NO_SYNC` the OS batches that write-back; we force durability at
         // explicit checkpoints (`SYNC_CHECKPOINT_INTERVAL`) and on graceful shutdown instead.
-        // `WRITE_MAP` is unset, so a crash never corrupts the database — it only discards the
-        // unflushed tail of recent commits, which clean sync and migrations safely re-do.
+        // `WRITE_MAP` is unset, so on a write-order-preserving local filesystem a crash does not
+        // corrupt the database — it only discards the unflushed tail of recent commits, which clean
+        // sync and migrations safely re-do. (On NFS / overlay filesystems or a hard pod eviction that
+        // drops the unflushed page cache, write order is not guaranteed and a crash *can* leave torn
+        // pages; the recovery there is to wipe and re-index. See `SYNC_CHECKPOINT_INTERVAL`.)
         let env = Environment::new()
             .set_max_dbs(15)
             .set_map_size(db_size_bytes)
@@ -1097,5 +1178,106 @@ impl DbV1 {
         zaino_db.spawn_handler().await?;
 
         Ok(zaino_db)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn spent_corruption_detail_reports_key_length_and_value_head() {
+        // A torn `spent` value whose framing byte is 0xfd (the "version tag 253" report) plus extra
+        // padding so the value length is clearly wrong for a `StoredEntryFixed<TxLocation>` (40 B).
+        let key = [0xab_u8; 37];
+        let value = [0xfd_u8; 50];
+
+        let detail = spent_corruption_detail(7, &key, &value, "unsupported Zaino version tag 253");
+
+        assert!(detail.contains("corrupt spent entry #7"), "{detail}");
+        assert!(
+            detail.contains("unsupported Zaino version tag 253"),
+            "{detail}"
+        );
+        assert!(
+            detail.contains(&format!("key=0x{}", hex::encode(key))),
+            "{detail}"
+        );
+        assert!(detail.contains("value_len=50"), "{detail}");
+        // Only the leading 16 bytes of the value are dumped.
+        assert!(
+            detail.contains(&format!("value_head=0x{}", "fd".repeat(16))),
+            "{detail}"
+        );
+        assert!(
+            detail.contains("wipe the database and re-index"),
+            "{detail}"
+        );
+    }
+
+    #[test]
+    fn spent_corruption_detail_handles_short_values() {
+        // A value shorter than the dump cap must not panic on the slice.
+        let detail = spent_corruption_detail(0, &[0x01, 0x02], &[0x09], "checksum mismatch");
+
+        assert!(detail.contains("value_len=1"), "{detail}");
+        assert!(detail.contains("value_head=0x09"), "{detail}");
+    }
+
+    /// End-to-end: a malformed value in the `spent` table makes the startup integrity scan return
+    /// the actionable diagnostic (key / length / value bytes + re-index hint), not a bare error or a
+    /// silent pass.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn initial_spent_scan_reports_corrupt_value() {
+        use lmdb::{Transaction as _, WriteFlags};
+        use zaino_common::network::ActivationHeights;
+        use zaino_common::{DatabaseConfig, Network, StorageConfig};
+
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let config = ChainIndexConfig {
+            storage: StorageConfig {
+                database: DatabaseConfig {
+                    path: temp_dir.path().to_path_buf(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ephemeral: false,
+            db_version: 1,
+            network: Network::Regtest(ActivationHeights::default()),
+        };
+
+        let db = DbV1::spawn(&config).await.expect("spawn empty v1 db");
+
+        // Inject a malformed value under a valid outpoint key: a `StoredEntryFixed<TxLocation>` is 40
+        // bytes beginning with a version tag of 1; this is 50 bytes of 0xfd (the "version tag 253"
+        // torn-write shape).
+        let key = Outpoint::new([0x11; 32], 0)
+            .to_bytes()
+            .expect("encode outpoint");
+        let garbage = [0xfd_u8; 50];
+        {
+            let mut txn = db.env.begin_rw_txn().expect("rw txn");
+            txn.put(db.spent, &key, &garbage, WriteFlags::empty())
+                .expect("put garbage spent value");
+            txn.commit().expect("commit");
+        }
+
+        let error = db
+            .initial_spent_scan()
+            .await
+            .expect_err("a malformed spent value must be rejected");
+        let message = error.to_string();
+
+        assert!(message.contains("corrupt spent entry"), "{message}");
+        assert!(message.contains("value_len=50"), "{message}");
+        assert!(
+            message.contains(&format!("key=0x{}", hex::encode(&key))),
+            "{message}"
+        );
+        assert!(
+            message.contains("wipe the database and re-index"),
+            "{message}"
+        );
     }
 }

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
@@ -168,15 +168,25 @@ pub(crate) const TX_OUT_SET_ACCUMULATOR_BUILT_HEIGHT_KEY: &[u8] =
 /// both paths produce the identical accumulator at the tip.
 pub(crate) const ACCUMULATOR_INCREMENTAL_MAX_GAP: u32 = 1_000;
 
-/// Number of txid-prefix shards used by the bulk txout-set accumulator builder.
+/// Maximum number of txid-prefix shards used by the bulk txout-set accumulator builder.
 ///
 /// The builder holds the set of spent outpoints in memory while scanning the block data. Sharding
 /// on the creating-txid's first byte bounds that working set to roughly `1 / shards` of the total
 /// spent index, at the cost of one extra sequential pass over the block data per shard. The
 /// per-shard partials recombine exactly (XOR commitment + additive counters), so the result is
-/// independent of the shard count. `1` is a single optimal pass and is correct on any host with
-/// enough RAM for the full spent set; raise it on memory-constrained deployments.
-pub(crate) const ACCUMULATOR_BUILD_SHARDS: u16 = 1;
+/// independent of the shard count.
+///
+/// The shard count is chosen at rebuild time so the per-shard spent set fits the configured
+/// [`zaino_common::DatabaseConfig::sync_write_batch_size`] budget (see
+/// [`DbV1::rebuild_tx_out_set_accumulator`]): a single optimal pass on hosts with enough RAM for
+/// the full spent set, scaling up on memory-constrained deployments. Sharding partitions on the
+/// creating-txid's first byte (256 distinct values), so the count is capped here.
+pub(crate) const ACCUMULATOR_BUILD_MAX_SHARDS: u16 = 256;
+
+/// Conservative per-entry RAM estimate for the rebuild's in-memory spent set, used only to size the
+/// shard count. Each entry is a boxed `spent` key (~37 bytes) plus `HashSet` bucket overhead; an
+/// over-estimate just adds shards (less memory), never under-bounds.
+pub(crate) const SPENT_SET_ENTRY_BYTES_ESTIMATE: u64 = 128;
 
 /// Number of committed block writes / migration heights between explicit
 /// `env.sync(true)` durability checkpoints.

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/transparent_address_history.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/transparent_address_history.rs
@@ -1726,14 +1726,27 @@ impl DbV1 {
             .accumulator_rebuild_memory_size
             .to_byte_count() as u64)
             .max(1);
-        let shards = self.accumulator_build_shards(budget)?;
+        // Logged before any cursor work: choosing the initial shard count scans the `spent` table,
+        // and a native LMDB abort there (a torn DB) is otherwise an unattributable stderr-only crash.
         info!(
-            "rebuilding txout-set accumulator to height {} ({shards} shard(s), ~{budget} byte budget)",
+            "txout-set accumulator rebuild to height {}: sizing shards (~{budget} byte budget)",
+            db_tip.0
+        );
+        // `shards` is the *initial* partition (a good first guess from the memory estimate);
+        // `max_spent_entries` is the *hard* per-shard cap the builder enforces during the spent
+        // load, bisecting any shard that would exceed it. So the estimate only affects how many
+        // passes we make, never whether we stay within budget.
+        let shards = self.accumulator_build_shards(budget)?;
+        let max_spent_entries = (budget / SPENT_SET_ENTRY_BYTES_ESTIMATE).max(1);
+        info!(
+            "txout-set accumulator rebuild to height {}: {shards} initial shard(s), \
+             ≤{max_spent_entries} spent outpoints/shard, ~{budget} byte budget",
             db_tip.0
         );
 
         tokio::task::block_in_place(|| {
-            let accumulator = self.build_tx_out_set_accumulator_blocking(db_tip, shards)?;
+            let accumulator =
+                self.build_tx_out_set_accumulator_blocking(db_tip, shards, max_spent_entries)?;
 
             let mut txn = self.env.begin_rw_txn()?;
 
@@ -1766,8 +1779,13 @@ impl DbV1 {
     ///
     /// `shards = ceil(estimated_spent_set_bytes / budget)`, clamped to
     /// `1..=ACCUMULATOR_BUILD_MAX_SHARDS`. Hosts with enough RAM for the whole spent set get a
-    /// single optimal pass; constrained hosts scale up. The estimate over-counting only adds shards
-    /// (less memory), never under-bounds, so the rebuild cannot OOM within the budget.
+    /// single optimal pass; constrained hosts scale up.
+    ///
+    /// This is only the *initial* partition handed to
+    /// [`DbV1::build_tx_out_set_accumulator_blocking`] — a good first guess that minimises passes.
+    /// The actual memory bound is enforced separately and strictly by that builder (it bisects any
+    /// shard whose spent set would exceed the cap), so an inaccurate estimate here only changes how
+    /// many passes are made, never whether the rebuild stays within budget.
     pub(crate) fn accumulator_build_shards(
         &self,
         budget_bytes: u64,
@@ -1788,33 +1806,56 @@ impl DbV1 {
     /// table's entry count times [`SPENT_SET_ENTRY_BYTES_ESTIMATE`].
     ///
     /// Counts via a sequential cursor scan (the safe `lmdb` API exposes no per-sub-DB stat), stopping
-    /// early once `max_useful_entries` is reached. The rebuild already scans `spent` once per shard,
-    /// so this extra bounded pass is marginal.
+    /// early once `max_useful_entries` is reached. The builder's per-shard loads are range-seeks that
+    /// together touch `spent` once in total, so this single extra count pass roughly doubles the
+    /// spent-table reads — bounded, and dwarfed by the chain-length block scans.
     fn estimate_spent_set_bytes(
         &self,
         max_useful_entries: u64,
     ) -> Result<u64, FinalisedStateError> {
         tokio::task::block_in_place(|| {
             let txn = self.env.begin_ro_txn()?;
-            let mut cursor = txn.open_ro_cursor(self.spent)?;
+            let cursor = txn.open_ro_cursor(self.spent)?;
+
+            // Explicit cursor walk rather than `Cursor::iter`: that iterator `debug_assert!`-panics
+            // on any non-`NotFound` LMDB error in debug builds and silently ends the scan in release
+            // (truncating the count). Here a real LMDB error propagates cleanly and the count is only
+            // ever ended by a genuine end-of-table `NotFound`. Counting allocates nothing (the cursor
+            // yields references into the mmap), so this is O(1) heap regardless of table size.
             let mut count: u64 = 0;
-            for _ in cursor.iter() {
-                count += 1;
-                if count >= max_useful_entries {
-                    break;
+            let mut op = lmdb_sys::MDB_FIRST;
+            loop {
+                match cursor.get(None, None, op) {
+                    Ok(_) => {
+                        count += 1;
+                        if count >= max_useful_entries {
+                            break;
+                        }
+                    }
+                    Err(lmdb::Error::NotFound) => break,
+                    Err(error) => return Err(FinalisedStateError::LmdbError(error)),
                 }
+                op = lmdb_sys::MDB_NEXT;
             }
+
             Ok(count.saturating_mul(SPENT_SET_ENTRY_BYTES_ESTIMATE))
         })
     }
 
     /// Computes the finalised txout-set accumulator over the UTXO set at `db_tip`.
     ///
-    /// Strategy (per shard): scan the `spent` table once to collect the spent outpoints whose
-    /// creating txid falls in the shard, then scan the block `transparent` + `txids` tables in
-    /// ascending height order, adding every spendable output that is not in that spent set. The
-    /// `transactions` count is derived locally per transaction (all of a tx's outputs live in one
-    /// height entry). Sharding bounds the in-memory spent set; partials recombine exactly.
+    /// Strategy (per shard): **range-seek** the `spent` table over the shard's contiguous key range
+    /// to collect the spent outpoints whose creating txid falls in the shard, then scan the block
+    /// `transparent` + `txids` tables in ascending height order, adding every spendable output that
+    /// is not in that spent set. The `transactions` count is derived locally per transaction (all of
+    /// a tx's outputs live in one height entry). Sharding bounds the in-memory spent set; partials
+    /// recombine exactly.
+    ///
+    /// The range-seek matters: `spent` keys are sorted and the version tag is constant, so a shard's
+    /// first-byte range `[lo, hi)` is one contiguous key range. Seeking to it (rather than scanning
+    /// the whole table and filtering) makes the total spent-table work O(N) across all shards instead
+    /// of O(shards·N) — at maximal sharding (256) that is the difference between one sweep and 256
+    /// full-table sweeps, which on a cgroup-limited host is also a page-cache pressure / OOM risk.
     ///
     /// WARNING: blocking — call from a blocking context. Builds to `db_tip` only (the spent table
     /// is assumed to cover spends up to the same tip).
@@ -1822,170 +1863,217 @@ impl DbV1 {
         &self,
         db_tip: Height,
         shards: u16,
+        max_spent_entries: u64,
     ) -> Result<FinalisedTxOutSetInfoAccumulator, FinalisedStateError> {
         let shards = shards.max(1) as usize;
+        let max_spent_entries = max_spent_entries.max(1);
         let mut total = FinalisedTxOutSetInfoAccumulator::empty();
 
-        for shard in 0..shards {
-            // First-byte range [lo, hi) of the creating-txid assigned to this shard.
-            let lo = (shard * 256 / shards) as u16;
-            let hi = ((shard + 1) * 256 / shards) as u16;
-            let in_shard = |first_byte: u8| -> bool {
-                let b = first_byte as u16;
-                b >= lo && b < hi
-            };
+        // Work-list of creating-txid first-byte ranges `[lo, hi)` still to process, seeded with
+        // `shards` equal ranges (the memory estimate's initial partition — a good first guess that
+        // avoids splitting down from the whole space). A range whose spent set would exceed
+        // `max_spent_entries` is bisected and retried, so every shard actually loaded holds a *hard*
+        // ≤ `max_spent_entries` outpoints — the bound holds regardless of the estimate's accuracy or
+        // the txid distribution. The ranges stay a disjoint cover of `[0, 256)`, and XOR/sum
+        // recombination is order-independent, so the result is identical for any partition.
+        let mut pending: Vec<(u16, u16)> = (0..shards)
+            .map(|shard| {
+                (
+                    (shard * 256 / shards) as u16,
+                    ((shard + 1) * 256 / shards) as u16,
+                )
+            })
+            .collect();
 
-            // One read snapshot for the whole shard pass (subsumes the per-lookup RO-txn churn the
-            // old per-block path incurred).
-            let txn = self.env.begin_ro_txn()?;
-
-            // (1) Spent outpoints in this shard. The `spent` key is `Outpoint::to_bytes()` =
-            //     `[version tag][32-byte prev_txid][4-byte index]`, so the prev-txid's first byte
-            //     (which equals the creating txid's first byte) is at index 1.
-            let mut spent_set: HashSet<Box<[u8]>> = HashSet::new();
-            {
-                let mut cursor = txn.open_ro_cursor(self.spent)?;
-                for (key_bytes, _value) in cursor.iter() {
-                    if key_bytes.len() < 2 || !in_shard(key_bytes[1]) {
-                        continue;
+        while let Some((lo, hi)) = pending.pop() {
+            match self.accumulate_tx_out_set_shard_blocking(db_tip, lo, hi, max_spent_entries)? {
+                Some(shard_acc) => total
+                    .combine(&shard_acc)
+                    .map_err(|error| FinalisedStateError::Custom(error.to_string()))?,
+                None => {
+                    if hi - lo <= 1 {
+                        // A single creating-txid first-byte value cannot be split further. Fail with
+                        // an actionable error rather than OOM-ing: the spent outpoints sharing this
+                        // first byte do not fit the configured budget.
+                        return Err(FinalisedStateError::Custom(format!(
+                            "txout-set accumulator: spent shard for creating-txid first-byte {lo} \
+                             exceeds the per-shard budget ({max_spent_entries} outpoints) and cannot \
+                             be split further; raise accumulator_rebuild_memory_size"
+                        )));
                     }
-                    spent_set.insert(Box::from(key_bytes));
+                    let mid = lo + (hi - lo) / 2;
+                    pending.push((lo, mid));
+                    pending.push((mid, hi));
                 }
             }
-
-            // (2) Sequential pass over block transparent data, height-ascending.
-            let mut shard_acc = FinalisedTxOutSetInfoAccumulator::empty();
-            let mut height = GENESIS_HEIGHT.0;
-            while height <= db_tip.0 {
-                let block_height = Height::try_from(height)
-                    .map_err(|error| FinalisedStateError::Custom(error.to_string()))?;
-                let height_bytes = block_height.to_bytes()?;
-
-                let transparent_tx_list = {
-                    let raw = txn
-                        .get(self.transparent, &height_bytes)
-                        .map_err(FinalisedStateError::LmdbError)?;
-                    let entry =
-                        StoredEntryVar::<TransparentTxList>::from_bytes(raw).map_err(|error| {
-                            FinalisedStateError::Custom(format!(
-                                "transparent corrupt data: {error}"
-                            ))
-                        })?;
-                    if !entry.verify(&height_bytes) {
-                        return Err(FinalisedStateError::Custom(
-                            "transparent checksum mismatch".to_string(),
-                        ));
-                    }
-                    entry.inner().clone()
-                };
-
-                let txids = {
-                    let raw = txn
-                        .get(self.txids, &height_bytes)
-                        .map_err(FinalisedStateError::LmdbError)?;
-                    let entry = StoredEntryVar::<TxidList>::from_bytes(raw).map_err(|error| {
-                        FinalisedStateError::Custom(format!("txids corrupt data: {error}"))
-                    })?;
-                    if !entry.verify(&height_bytes) {
-                        return Err(FinalisedStateError::Custom(
-                            "txids checksum mismatch".to_string(),
-                        ));
-                    }
-                    entry.inner().txids().to_vec()
-                };
-
-                for (tx_index, tx_opt) in transparent_tx_list.tx().iter().enumerate() {
-                    let txid = txids.get(tx_index).ok_or_else(|| {
-                        FinalisedStateError::Custom(format!(
-                            "txid/transparent length mismatch at height {height}"
-                        ))
-                    })?;
-
-                    // A tx's outputs are removed by spends keyed under the same txid, so the whole
-                    // tx belongs to exactly one shard.
-                    if !in_shard(txid.0[0]) {
-                        continue;
-                    }
-
-                    let Some(transparent_tx) = tx_opt else {
-                        continue;
-                    };
-
-                    let mut tx_has_unspent = false;
-                    for (out_index, output) in transparent_tx.outputs().iter().enumerate() {
-                        if is_unspendable_tx_out(output) {
-                            continue;
-                        }
-
-                        let outpoint = Outpoint::new(txid.0, out_index as u32);
-                        let outpoint_key = outpoint.to_bytes()?;
-                        if spent_set.contains(outpoint_key.as_slice()) {
-                            // Created then spent at/below the tip: cancels out of the live set.
-                            continue;
-                        }
-
-                        shard_acc
-                            .apply_added_output(&outpoint, output)
-                            .map_err(|error| FinalisedStateError::Custom(error.to_string()))?;
-                        tx_has_unspent = true;
-                    }
-
-                    if tx_has_unspent {
-                        shard_acc.transactions =
-                            shard_acc.transactions.checked_add(1).ok_or_else(|| {
-                                FinalisedStateError::Custom(
-                                    "txout-set accumulator transactions overflow".to_string(),
-                                )
-                            })?;
-                    }
-                }
-
-                height += 1;
-            }
-
-            // Recombine: XOR the multiset commitments, sum the additive counters.
-            for (dst, src) in total
-                .hash_serialized
-                .iter_mut()
-                .zip(shard_acc.hash_serialized.iter())
-            {
-                *dst ^= *src;
-            }
-            total.transactions = total
-                .transactions
-                .checked_add(shard_acc.transactions)
-                .ok_or_else(|| {
-                    FinalisedStateError::Custom(
-                        "txout-set accumulator transactions overflow".to_string(),
-                    )
-                })?;
-            total.transaction_outputs = total
-                .transaction_outputs
-                .checked_add(shard_acc.transaction_outputs)
-                .ok_or_else(|| {
-                    FinalisedStateError::Custom(
-                        "txout-set accumulator transaction_outputs overflow".to_string(),
-                    )
-                })?;
-            total.bytes_serialized = total
-                .bytes_serialized
-                .checked_add(shard_acc.bytes_serialized)
-                .ok_or_else(|| {
-                    FinalisedStateError::Custom(
-                        "txout-set accumulator bytes_serialized overflow".to_string(),
-                    )
-                })?;
-            total.total_zatoshis = total
-                .total_zatoshis
-                .checked_add(shard_acc.total_zatoshis)
-                .ok_or_else(|| {
-                    FinalisedStateError::Custom(
-                        "txout-set accumulator total_zatoshis overflow".to_string(),
-                    )
-                })?;
         }
 
         Ok(total)
+    }
+
+    /// Builds the accumulator partial for the creating-txid first-byte range `[lo, hi)`, or returns
+    /// `Ok(None)` if the shard's in-memory spent set would exceed `max_spent_entries` outpoints —
+    /// the signal for the caller to bisect the range and retry.
+    ///
+    /// Aborting *during* the spent load (before the limit is exceeded, dropping the partial set) is
+    /// what makes the per-shard memory a hard cap rather than an estimate. An aborted shard does no
+    /// block-table work, so a split wastes only a bounded partial spent scan.
+    fn accumulate_tx_out_set_shard_blocking(
+        &self,
+        db_tip: Height,
+        lo: u16,
+        hi: u16,
+        max_spent_entries: u64,
+    ) -> Result<Option<FinalisedTxOutSetInfoAccumulator>, FinalisedStateError> {
+        let in_shard = |first_byte: u8| -> bool {
+            let b = first_byte as u16;
+            b >= lo && b < hi
+        };
+
+        // One read snapshot for the whole shard pass (subsumes the per-lookup RO-txn churn the old
+        // per-block path incurred).
+        let txn = self.env.begin_ro_txn()?;
+
+        // (1) Spent outpoints in this shard. The `spent` key is `Outpoint::to_bytes()` =
+        //     `[version tag][32-byte prev_txid][4-byte index]`, so the prev-txid's first byte
+        //     (which equals the creating txid's first byte) is at index 1. Because the keys are
+        //     sorted and the version tag is constant, the shard's keys form one contiguous range;
+        //     seek to its start and stop once we pass `hi` rather than scanning the whole table.
+        let mut spent_set: HashSet<Box<[u8]>> = HashSet::new();
+        {
+            let mut shard_start_outpoint = [0u8; 32];
+            shard_start_outpoint[0] = lo as u8;
+            let shard_lower_bound = Outpoint::new(shard_start_outpoint, 0).to_bytes()?;
+
+            // Seek to the first spent key >= the shard's lower bound, then walk forward with
+            // `MDB_NEXT` until the first byte leaves `[lo, hi)`. `MDB_SET_RANGE` returns `NotFound`
+            // when no key is at/after the bound (empty table, or a shard past the largest key) —
+            // that is simply an empty shard. (`Cursor::iter_from` is unusable here: it `unwrap()`s
+            // that `NotFound` and would panic.)
+            let cursor = txn.open_ro_cursor(self.spent)?;
+            let mut next = match cursor.get(
+                Some(shard_lower_bound.as_slice()),
+                None,
+                lmdb_sys::MDB_SET_RANGE,
+            ) {
+                Ok((key, _value)) => key,
+                Err(lmdb::Error::NotFound) => None,
+                Err(error) => return Err(FinalisedStateError::LmdbError(error)),
+            };
+            while let Some(key_bytes) = next {
+                if key_bytes.len() >= 2 {
+                    // Sorted keys: once the first byte reaches `hi` we are past this shard.
+                    if key_bytes[1] as u16 >= hi {
+                        break;
+                    }
+                    // The seek guarantees `>= lo` for well-formed keys; re-check defensively so a
+                    // stray shorter/foreign key can never leak into the wrong shard.
+                    if in_shard(key_bytes[1]) {
+                        // Hard cap: bail out before the set can exceed the budget; the caller splits
+                        // this range and retries the (smaller) halves.
+                        if spent_set.len() as u64 >= max_spent_entries {
+                            return Ok(None);
+                        }
+                        spent_set.insert(Box::from(key_bytes));
+                    }
+                }
+                next = match cursor.get(None, None, lmdb_sys::MDB_NEXT) {
+                    Ok((key, _value)) => key,
+                    Err(lmdb::Error::NotFound) => None,
+                    Err(error) => return Err(FinalisedStateError::LmdbError(error)),
+                };
+            }
+        }
+
+        // (2) Sequential pass over block transparent data, height-ascending.
+        let mut shard_acc = FinalisedTxOutSetInfoAccumulator::empty();
+        let mut height = GENESIS_HEIGHT.0;
+        while height <= db_tip.0 {
+            let block_height = Height::try_from(height)
+                .map_err(|error| FinalisedStateError::Custom(error.to_string()))?;
+            let height_bytes = block_height.to_bytes()?;
+
+            let transparent_tx_list = {
+                let raw = txn
+                    .get(self.transparent, &height_bytes)
+                    .map_err(FinalisedStateError::LmdbError)?;
+                let entry =
+                    StoredEntryVar::<TransparentTxList>::from_bytes(raw).map_err(|error| {
+                        FinalisedStateError::Custom(format!("transparent corrupt data: {error}"))
+                    })?;
+                if !entry.verify(&height_bytes) {
+                    return Err(FinalisedStateError::Custom(
+                        "transparent checksum mismatch".to_string(),
+                    ));
+                }
+                entry.inner().clone()
+            };
+
+            let txids = {
+                let raw = txn
+                    .get(self.txids, &height_bytes)
+                    .map_err(FinalisedStateError::LmdbError)?;
+                let entry = StoredEntryVar::<TxidList>::from_bytes(raw).map_err(|error| {
+                    FinalisedStateError::Custom(format!("txids corrupt data: {error}"))
+                })?;
+                if !entry.verify(&height_bytes) {
+                    return Err(FinalisedStateError::Custom(
+                        "txids checksum mismatch".to_string(),
+                    ));
+                }
+                entry.inner().txids().to_vec()
+            };
+
+            for (tx_index, tx_opt) in transparent_tx_list.tx().iter().enumerate() {
+                let txid = txids.get(tx_index).ok_or_else(|| {
+                    FinalisedStateError::Custom(format!(
+                        "txid/transparent length mismatch at height {height}"
+                    ))
+                })?;
+
+                // A tx's outputs are removed by spends keyed under the same txid, so the whole
+                // tx belongs to exactly one shard.
+                if !in_shard(txid.0[0]) {
+                    continue;
+                }
+
+                let Some(transparent_tx) = tx_opt else {
+                    continue;
+                };
+
+                let mut tx_has_unspent = false;
+                for (out_index, output) in transparent_tx.outputs().iter().enumerate() {
+                    if is_unspendable_tx_out(output) {
+                        continue;
+                    }
+
+                    let outpoint = Outpoint::new(txid.0, out_index as u32);
+                    let outpoint_key = outpoint.to_bytes()?;
+                    if spent_set.contains(outpoint_key.as_slice()) {
+                        // Created then spent at/below the tip: cancels out of the live set.
+                        continue;
+                    }
+
+                    shard_acc
+                        .apply_added_output(&outpoint, output)
+                        .map_err(|error| FinalisedStateError::Custom(error.to_string()))?;
+                    tx_has_unspent = true;
+                }
+
+                if tx_has_unspent {
+                    shard_acc.transactions =
+                        shard_acc.transactions.checked_add(1).ok_or_else(|| {
+                            FinalisedStateError::Custom(
+                                "txout-set accumulator transactions overflow".to_string(),
+                            )
+                        })?;
+                }
+            }
+
+            height += 1;
+        }
+
+        Ok(Some(shard_acc))
     }
 
     /// Reads the height the persisted txout-set accumulator currently reflects, or `None` if it has

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/transparent_address_history.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/transparent_address_history.rs
@@ -1715,10 +1715,17 @@ impl DbV1 {
             return Ok(());
         };
 
-        // Bound the rebuild's peak RAM to the configured sync batch budget by sharding the in-memory
-        // spent set; on hosts where the whole set fits this resolves to a single optimal pass.
-        let budget =
-            (self.config.storage.database.sync_write_batch_size.to_byte_count() as u64).max(1);
+        // Bound the rebuild's peak RAM to the dedicated accumulator-rebuild budget by sharding the
+        // in-memory spent set; on hosts where the whole set fits this resolves to a single optimal
+        // pass. This budget is intentionally *separate* from the bulk-sync write-batch budget so the
+        // two operations cannot inflate each other's peak memory.
+        let budget = (self
+            .config
+            .storage
+            .database
+            .accumulator_rebuild_memory_size
+            .to_byte_count() as u64)
+            .max(1);
         let shards = self.accumulator_build_shards(budget)?;
         info!(
             "rebuilding txout-set accumulator to height {} ({shards} shard(s), ~{budget} byte budget)",

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/transparent_address_history.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/transparent_address_history.rs
@@ -1793,8 +1793,7 @@ impl DbV1 {
         let budget = budget_bytes.max(1);
         // Only count the spent set up to the point where we'd hit the shard cap anyway — past it
         // the exact size cannot change the decision, so the count pass is itself bounded.
-        let max_useful_entries = (ACCUMULATOR_BUILD_MAX_SHARDS as u64)
-            .saturating_mul(budget)
+        let max_useful_entries = (ACCUMULATOR_BUILD_MAX_SHARDS as u64).saturating_mul(budget)
             / SPENT_SET_ENTRY_BYTES_ESTIMATE.max(1);
         let needed = self
             .estimate_spent_set_bytes(max_useful_entries)?

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/transparent_address_history.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/transparent_address_history.rs
@@ -1,8 +1,8 @@
 //! FinalisedState::V1 transparent address history indexing functionality.
 
 use crate::chain_index::finalised_state::finalised_source::v1::{
-    ACCUMULATOR_BUILD_SHARDS, TX_OUT_SET_ACCUMULATOR_BUILT_HEIGHT_KEY,
-    TX_OUT_SET_INFO_ACCUMULATOR_KEY,
+    ACCUMULATOR_BUILD_MAX_SHARDS, SPENT_SET_ENTRY_BYTES_ESTIMATE,
+    TX_OUT_SET_ACCUMULATOR_BUILT_HEIGHT_KEY, TX_OUT_SET_INFO_ACCUMULATOR_KEY,
 };
 use crate::chain_index::types::db::metadata::{
     is_unspendable_tx_out, tx_out_set_entry_digest, FinalisedTxOutSetInfoAccumulator,
@@ -1715,9 +1715,18 @@ impl DbV1 {
             return Ok(());
         };
 
+        // Bound the rebuild's peak RAM to the configured sync batch budget by sharding the in-memory
+        // spent set; on hosts where the whole set fits this resolves to a single optimal pass.
+        let budget =
+            (self.config.storage.database.sync_write_batch_size.to_byte_count() as u64).max(1);
+        let shards = self.accumulator_build_shards(budget)?;
+        info!(
+            "rebuilding txout-set accumulator to height {} ({shards} shard(s), ~{budget} byte budget)",
+            db_tip.0
+        );
+
         tokio::task::block_in_place(|| {
-            let accumulator =
-                self.build_tx_out_set_accumulator_blocking(db_tip, ACCUMULATOR_BUILD_SHARDS)?;
+            let accumulator = self.build_tx_out_set_accumulator_blocking(db_tip, shards)?;
 
             let mut txn = self.env.begin_rw_txn()?;
 
@@ -1742,6 +1751,53 @@ impl DbV1 {
             self.env.sync(true)?;
 
             Ok::<_, FinalisedStateError>(())
+        })
+    }
+
+    /// Chooses the number of [`DbV1::build_tx_out_set_accumulator_blocking`] shards so the per-shard
+    /// in-memory spent set stays within `budget_bytes`.
+    ///
+    /// `shards = ceil(estimated_spent_set_bytes / budget)`, clamped to
+    /// `1..=ACCUMULATOR_BUILD_MAX_SHARDS`. Hosts with enough RAM for the whole spent set get a
+    /// single optimal pass; constrained hosts scale up. The estimate over-counting only adds shards
+    /// (less memory), never under-bounds, so the rebuild cannot OOM within the budget.
+    pub(crate) fn accumulator_build_shards(
+        &self,
+        budget_bytes: u64,
+    ) -> Result<u16, FinalisedStateError> {
+        let budget = budget_bytes.max(1);
+        // Only count the spent set up to the point where we'd hit the shard cap anyway — past it
+        // the exact size cannot change the decision, so the count pass is itself bounded.
+        let max_useful_entries = (ACCUMULATOR_BUILD_MAX_SHARDS as u64)
+            .saturating_mul(budget)
+            / SPENT_SET_ENTRY_BYTES_ESTIMATE.max(1);
+        let needed = self
+            .estimate_spent_set_bytes(max_useful_entries)?
+            .div_ceil(budget);
+        Ok(needed.clamp(1, ACCUMULATOR_BUILD_MAX_SHARDS as u64) as u16)
+    }
+
+    /// Estimates the in-RAM bytes the rebuild's single-shard spent set would occupy: the `spent`
+    /// table's entry count times [`SPENT_SET_ENTRY_BYTES_ESTIMATE`].
+    ///
+    /// Counts via a sequential cursor scan (the safe `lmdb` API exposes no per-sub-DB stat), stopping
+    /// early once `max_useful_entries` is reached. The rebuild already scans `spent` once per shard,
+    /// so this extra bounded pass is marginal.
+    fn estimate_spent_set_bytes(
+        &self,
+        max_useful_entries: u64,
+    ) -> Result<u64, FinalisedStateError> {
+        tokio::task::block_in_place(|| {
+            let txn = self.env.begin_ro_txn()?;
+            let mut cursor = txn.open_ro_cursor(self.spent)?;
+            let mut count: u64 = 0;
+            for _ in cursor.iter() {
+                count += 1;
+                if count >= max_useful_entries {
+                    break;
+                }
+            }
+            Ok(count.saturating_mul(SPENT_SET_ENTRY_BYTES_ESTIMATE))
         })
     }
 

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
@@ -117,10 +117,16 @@ impl DbWrite for DbV1 {
             // the `batch_bytes < batch_budget` check on the first iteration (`0 < 0`), buffer no
             // blocks, and stall the sync. A 1-byte floor still guarantees forward progress
             // (worst case, one block per batch).
-            let batch_budget =
-                (self.config.storage.database.sync_write_batch_size.to_byte_count() as u64).max(1);
-            let batch_interval =
-                std::time::Duration::from_secs(self.config.storage.database.sync_checkpoint_interval);
+            let batch_budget = (self
+                .config
+                .storage
+                .database
+                .sync_write_batch_size
+                .to_byte_count() as u64)
+                .max(1);
+            let batch_interval = std::time::Duration::from_secs(
+                self.config.storage.database.sync_checkpoint_interval,
+            );
             let mut next = start_height;
             let mut last_progress_log = std::time::Instant::now();
             while next <= height.0 {

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
@@ -29,11 +29,6 @@ fn approx_indexed_block_bytes(block: &IndexedBlock) -> u64 {
 #[cfg(not(feature = "transparent_address_history_experimental"))]
 const SYNC_WRITE_BATCH_MAX_BLOCKS: usize = 100_000;
 
-/// Maximum wall-clock time spent buffering a single bulk-sync write batch before flushing, so
-/// commits (and progress) happen regularly even when block fetches are slow.
-#[cfg(not(feature = "transparent_address_history_experimental"))]
-const SYNC_WRITE_BATCH_MAX_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
-
 /// Interval between in-flight "syncing height" progress logs during bulk sync.
 #[cfg(not(feature = "transparent_address_history_experimental"))]
 const SYNC_PROGRESS_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
@@ -118,7 +113,14 @@ impl DbWrite for DbV1 {
         // earlier-in-batch uncommitted blocks), so it keeps the per-block path.
         #[cfg(not(feature = "transparent_address_history_experimental"))]
         {
-            let batch_budget = self.config.storage.database.sync_write_batch_bytes.max(1);
+            // `.max(1)` guards a misconfigured `sync_write_batch_size = 0`: a 0 budget would fail
+            // the `batch_bytes < batch_budget` check on the first iteration (`0 < 0`), buffer no
+            // blocks, and stall the sync. A 1-byte floor still guarantees forward progress
+            // (worst case, one block per batch).
+            let batch_budget =
+                (self.config.storage.database.sync_write_batch_size.to_byte_count() as u64).max(1);
+            let batch_interval =
+                std::time::Duration::from_secs(self.config.storage.database.sync_checkpoint_interval);
             let mut next = start_height;
             let mut last_progress_log = std::time::Instant::now();
             while next <= height.0 {
@@ -133,7 +135,7 @@ impl DbWrite for DbV1 {
                 while next <= height.0
                     && batch_bytes < batch_budget
                     && batch.len() < SYNC_WRITE_BATCH_MAX_BLOCKS
-                    && batch_started.elapsed() < SYNC_WRITE_BATCH_MAX_INTERVAL
+                    && batch_started.elapsed() < batch_interval
                 {
                     let block = build_indexed_block_from_source(
                         source,

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -1017,7 +1017,8 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
             // Buffer spent entries across heights, then flush them in sorted key order so the
             // random-keyed `spent` B-tree fills via a sequential sweep instead of a random fault per
             // insert. Each flush commits the entries together with the progress watermark.
-            let batch_budget = cfg.storage.database.sync_write_batch_bytes.max(1);
+            let batch_budget =
+                (cfg.storage.database.sync_write_batch_size.to_byte_count() as u64).max(1);
             let mut spent_buffer: Vec<(Vec<u8>, TxLocation)> = Vec::new();
             let mut spent_buffer_bytes: u64 = 0;
 

--- a/packages/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/non_finalised_state.rs
@@ -1,4 +1,8 @@
-use super::{finalised_state::FinalisedState, source::BlockchainSource, NON_FINALIZED_DEPTH};
+use super::{
+    finalised_state::{reader::DbReader, FinalisedState},
+    source::BlockchainSource,
+    NON_FINALIZED_DEPTH,
+};
 use crate::{
     chain_index::types::{
         self, BlockHash, BlockIndex, BlockMetadata, BlockWithMetadata, Height, TreeRootData,
@@ -354,6 +358,50 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
         }
     }
 
+    /// Resolve the non-finalised state's anchor (root) block at `anchor_height`.
+    ///
+    /// Prefers the finalised reader, which serves the block from the persistent DB when the height
+    /// is in range, or from the validator via the ReadOnly ephemeral passthrough while the finalised
+    /// DB is catching up in the background. Falls back to building the block directly from the
+    /// validator source when the reader cannot serve it yet — e.g. the first worker iteration, before
+    /// any passthrough is installed — so the anchor never silently drops to genesis (issue #1261).
+    ///
+    /// The anchor sits below the reorg-possible range, so its chainwork is irrelevant to best-chain
+    /// selection; it is set to zero, matching the ephemeral passthrough's own anchor build.
+    pub(super) async fn resolve_anchor_block(
+        source: &Source,
+        reader: &DbReader<Source>,
+        network: &Network,
+        anchor_height: Height,
+    ) -> Result<IndexedBlock, FinalisedStateError> {
+        if let Some(block) = reader.get_chain_block_by_height(anchor_height).await? {
+            return Ok(block);
+        }
+
+        let block = source
+            .get_block(HashOrHeight::Height(zebra_chain::block::Height(
+                anchor_height.0,
+            )))
+            .await?
+            .ok_or_else(|| {
+                FinalisedStateError::DataUnavailable(format!(
+                    "anchor block {} unavailable from validator",
+                    anchor_height.0
+                ))
+            })?;
+
+        let (sapling, orchard) = source.get_commitment_tree_roots(block.hash().into()).await?;
+        let tree_roots = TreeRootData { sapling, orchard };
+
+        Self::create_indexed_block_with_optional_roots(
+            block.as_ref(),
+            &tree_roots,
+            ChainWork::from(U256::zero()),
+            network.clone(),
+        )
+        .map_err(FinalisedStateError::Custom)
+    }
+
     /// Set up the optional non-finalized change listener
     async fn setup_listener(
         source: &Source,
@@ -388,20 +436,29 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
     ) -> Result<(), SyncError> {
         let mut initial_state = self.get_snapshot();
         let local_finalized_tip = finalized_db.to_reader().db_height().await?;
-        if Some(initial_state.best_tip.height) < local_finalized_tip {
+        // Anchor floor: the non-finalised state must never start more than `NON_FINALIZED_DEPTH`
+        // blocks below the chain tip, even when the finalised DB tip lags far behind during
+        // background catch-up. Without this floor a freshly-initialised (or genesis-fallback)
+        // snapshot would try to bridge the entire gap from the finalised tip up to the chain tip one
+        // block at a time — millions of sequential validator fetches that never converge (#1261).
+        // When the floor sits above the finalised tip the anchor block isn't in the persistent DB;
+        // `resolve_anchor_block` serves it via the passthrough or builds it from the validator.
+        let anchor_height = Height(
+            local_finalized_tip
+                .map(|height| height.0)
+                .unwrap_or(0)
+                .max(u32::from(chain_height).saturating_sub(NON_FINALIZED_DEPTH)),
+        );
+        if initial_state.best_tip.height.0 < anchor_height.0 {
+            let anchor_block = Self::resolve_anchor_block(
+                &self.source,
+                &finalized_db.to_reader(),
+                &self.network,
+                anchor_height,
+            )
+            .await?;
             self.current.swap(Arc::new(
-                NonfinalizedBlockCacheSnapshot::from_initial_block(
-                    finalized_db
-                        .to_reader()
-                        .get_chain_block_by_height(
-                            local_finalized_tip.expect("known to be some due to above if"),
-                        )
-                        .await?
-                        .ok_or(FinalisedStateError::DataUnavailable(format!(
-                            "Missing block {}",
-                            local_finalized_tip.unwrap().0
-                        )))?,
-                ),
+                NonfinalizedBlockCacheSnapshot::from_initial_block(anchor_block),
             ));
             initial_state = self.get_snapshot()
         }

--- a/packages/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/non_finalised_state.rs
@@ -390,7 +390,9 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
                 ))
             })?;
 
-        let (sapling, orchard) = source.get_commitment_tree_roots(block.hash().into()).await?;
+        let (sapling, orchard) = source
+            .get_commitment_tree_roots(block.hash().into())
+            .await?;
         let tree_roots = TreeRootData { sapling, orchard };
 
         Self::create_indexed_block_with_optional_roots(

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tempfile::TempDir;
 use zaino_common::network::ActivationHeights;
-use zaino_common::{DatabaseConfig, Network, StorageConfig};
+use zaino_common::{DatabaseConfig, Network, StorageConfig, SyncWriteBatchSize};
 use zaino_proto::proto::utils::{compact_block_with_pool_types, PoolTypeFilter};
 
 use crate::chain_index::finalised_state::capability::IndexedBlockExt;
@@ -1070,6 +1070,36 @@ async fn bulk_tx_out_set_accumulator_builder_matches_incremental() {
     }
 }
 
+/// The accumulator rebuild auto-shards to keep the per-shard in-memory spent set within the
+/// configured memory budget: a generous budget yields a single optimal pass, while a budget smaller
+/// than the spent set forces multiple shards (capped at 256). This is the OOM guard for
+/// memory-constrained hosts.
+#[tokio::test(flavor = "multi_thread")]
+async fn accumulator_build_shards_scale_to_memory_budget() {
+    init_tracing();
+
+    let (_data, _db_dir, zaino_db) = load_vectors_and_spawn_and_sync_v1_zaino_db().await;
+    zaino_db.wait_until_ready().await;
+
+    let backend = zaino_db
+        .backend_for_cap(crate::chain_index::finalised_state::capability::CapabilityRequest::WriteCore)
+        .unwrap();
+
+    // A budget far larger than the (tiny regtest) spent set => the whole set fits in one shard.
+    assert_eq!(
+        backend.accumulator_build_shards(u64::MAX).unwrap(),
+        1,
+        "a budget exceeding the spent set must use a single pass"
+    );
+
+    // A 1-byte budget => the spent set far exceeds it => more than one shard, never above the cap.
+    let constrained = backend.accumulator_build_shards(1).unwrap();
+    assert!(
+        constrained > 1 && constrained <= 256,
+        "a 1-byte budget must force multiple shards (capped at 256), got {constrained}"
+    );
+}
+
 /// The write path must advance the validated tip itself (via the cheap in-memory parent + merkle
 /// checks), so reads never fall back to the expensive read-back validation. This must hold right
 /// after a sync completes, independent of the background validator.
@@ -1102,7 +1132,7 @@ async fn write_path_advances_validated_tip() {
 /// resulting `(db tip, validated tip, txout-set accumulator)`.
 async fn sync_with_batch_budget(
     blocks: Vec<TestVectorBlockData>,
-    sync_write_batch_bytes: u64,
+    sync_write_batch_size: SyncWriteBatchSize,
 ) -> (Height, u32, FinalisedTxOutSetInfoAccumulator) {
     use crate::chain_index::finalised_state::capability::{
         CapabilityRequest, DbRead, TransparentHistExt,
@@ -1114,7 +1144,7 @@ async fn sync_with_batch_budget(
         storage: StorageConfig {
             database: DatabaseConfig {
                 path: temp_dir.path().to_path_buf(),
-                sync_write_batch_bytes,
+                sync_write_batch_size,
                 ..Default::default()
             },
             ..Default::default()
@@ -1150,10 +1180,11 @@ async fn batched_sync_is_batch_size_independent() {
 
     let blocks = load_test_vectors().unwrap().blocks;
 
-    // u64::MAX => the whole sync is one batch; 1 => every block exceeds the budget => one block per
-    // batch (a flush + commit + fsync after each block).
-    let single_batch = sync_with_batch_budget(blocks.clone(), u64::MAX).await;
-    let per_block_batches = sync_with_batch_budget(blocks, 1).await;
+    // 1 GiB ≫ the tiny regtest test chain => the whole sync is one batch; 0 GiB => the `.max(1)`
+    // floor makes the effective budget 1 byte, so every block exceeds it => one block per batch (a
+    // flush + commit + fsync after each block).
+    let single_batch = sync_with_batch_budget(blocks.clone(), SyncWriteBatchSize(1)).await;
+    let per_block_batches = sync_with_batch_budget(blocks, SyncWriteBatchSize(0)).await;
 
     assert_eq!(single_batch.0, per_block_batches.0, "db tip must match");
     assert_eq!(

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -1058,8 +1058,9 @@ async fn bulk_tx_out_set_accumulator_builder_matches_incremental() {
     // 1 = single optimal pass; >1 exercises the sharded multi-pass recombination; 256 = one
     // first-byte value per shard (maximal sharding).
     for shards in [1u16, 2, 4, 256] {
+        // Cap = u64::MAX: the initial partition is used verbatim (no bisection).
         let built = tokio::task::block_in_place(|| {
-            backend.build_tx_out_set_accumulator_blocking(db_tip, shards)
+            backend.build_tx_out_set_accumulator_blocking(db_tip, shards, u64::MAX)
         })
         .unwrap();
 
@@ -1067,6 +1068,23 @@ async fn bulk_tx_out_set_accumulator_builder_matches_incremental() {
             built, incremental,
             "bulk builder (shards={shards}) must equal the incrementally-maintained accumulator"
         );
+
+        // Tiny per-shard caps force the strict memory bound to bisect the initial ranges to varying
+        // depths. Whenever the build succeeds it must still equal the incremental accumulator (the
+        // bisected ranges remain a disjoint cover of the first-byte space, and recombination is
+        // order-independent); if a single first-byte bucket genuinely exceeds the cap the builder
+        // fails fast by design (the strict bound), which is also acceptable here.
+        for max_spent_entries in [16u64, 8, 4, 2, 1] {
+            if let Ok(built_capped) = tokio::task::block_in_place(|| {
+                backend.build_tx_out_set_accumulator_blocking(db_tip, shards, max_spent_entries)
+            }) {
+                assert_eq!(
+                    built_capped, incremental,
+                    "strict-capped bulk builder (shards={shards}, cap={max_spent_entries}) must \
+                     equal the incremental accumulator"
+                );
+            }
+        }
     }
 }
 
@@ -1268,9 +1286,10 @@ async fn incremental_accumulator_update_matches_full_rebuild() {
     );
 
     let incremental = backend.get_tx_out_set_info_accumulator().await.unwrap();
-    let from_genesis =
-        tokio::task::block_in_place(|| backend.build_tx_out_set_accumulator_blocking(db_tip, 1))
-            .unwrap();
+    let from_genesis = tokio::task::block_in_place(|| {
+        backend.build_tx_out_set_accumulator_blocking(db_tip, 1, u64::MAX)
+    })
+    .unwrap();
 
     assert_eq!(
         incremental, from_genesis,

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -1100,7 +1100,9 @@ async fn accumulator_build_shards_scale_to_memory_budget() {
     zaino_db.wait_until_ready().await;
 
     let backend = zaino_db
-        .backend_for_cap(crate::chain_index::finalised_state::capability::CapabilityRequest::WriteCore)
+        .backend_for_cap(
+            crate::chain_index::finalised_state::capability::CapabilityRequest::WriteCore,
+        )
         .unwrap();
 
     // A budget far larger than the (tiny regtest) spent set => the whole set fits in one shard.

--- a/packages/zaino-state/src/chain_index/types/db/metadata.rs
+++ b/packages/zaino-state/src/chain_index/types/db/metadata.rs
@@ -226,7 +226,11 @@ impl FinalisedTxOutSetInfoAccumulator {
     /// both commutative and associative, the recombined result is independent of the shard count and
     /// of the order shards are folded in.
     pub fn combine(&mut self, other: &Self) -> Result<(), AccumulatorDeltaError> {
-        for (dst, src) in self.hash_serialized.iter_mut().zip(other.hash_serialized.iter()) {
+        for (dst, src) in self
+            .hash_serialized
+            .iter_mut()
+            .zip(other.hash_serialized.iter())
+        {
             *dst ^= *src;
         }
         self.transactions = self
@@ -395,7 +399,10 @@ mod tests {
         let mut ba = b;
         ba.combine(&a).expect("no overflow");
 
-        assert_eq!(ab, ba, "XOR + addition are commutative, so combine must be order-independent");
+        assert_eq!(
+            ab, ba,
+            "XOR + addition are commutative, so combine must be order-independent"
+        );
     }
 
     #[test]
@@ -426,17 +433,23 @@ mod tests {
 
         let mut whole = FinalisedTxOutSetInfoAccumulator::empty();
         for (outpoint, out) in &outputs {
-            whole.apply_added_output(outpoint, out).expect("no overflow");
+            whole
+                .apply_added_output(outpoint, out)
+                .expect("no overflow");
         }
 
         // Split into two arbitrary disjoint groups, accumulate each, and recombine.
         let mut part_a = FinalisedTxOutSetInfoAccumulator::empty();
         for (outpoint, out) in &outputs[..2] {
-            part_a.apply_added_output(outpoint, out).expect("no overflow");
+            part_a
+                .apply_added_output(outpoint, out)
+                .expect("no overflow");
         }
         let mut part_b = FinalisedTxOutSetInfoAccumulator::empty();
         for (outpoint, out) in &outputs[2..] {
-            part_b.apply_added_output(outpoint, out).expect("no overflow");
+            part_b
+                .apply_added_output(outpoint, out)
+                .expect("no overflow");
         }
 
         let mut combined = part_a;

--- a/packages/zaino-state/src/chain_index/types/db/metadata.rs
+++ b/packages/zaino-state/src/chain_index/types/db/metadata.rs
@@ -219,6 +219,35 @@ impl FinalisedTxOutSetInfoAccumulator {
         Ok(())
     }
 
+    /// Folds another accumulator into this one: XOR the multiset commitments (self-inverse and
+    /// order-independent) and checked-sum the additive counters.
+    ///
+    /// Used to recombine the per-shard partials of a sharded rebuild. Because XOR and addition are
+    /// both commutative and associative, the recombined result is independent of the shard count and
+    /// of the order shards are folded in.
+    pub fn combine(&mut self, other: &Self) -> Result<(), AccumulatorDeltaError> {
+        for (dst, src) in self.hash_serialized.iter_mut().zip(other.hash_serialized.iter()) {
+            *dst ^= *src;
+        }
+        self.transactions = self
+            .transactions
+            .checked_add(other.transactions)
+            .ok_or(AccumulatorDeltaError::Overflow("transactions"))?;
+        self.transaction_outputs = self
+            .transaction_outputs
+            .checked_add(other.transaction_outputs)
+            .ok_or(AccumulatorDeltaError::Overflow("transaction_outputs"))?;
+        self.bytes_serialized = self
+            .bytes_serialized
+            .checked_add(other.bytes_serialized)
+            .ok_or(AccumulatorDeltaError::Overflow("bytes_serialized"))?;
+        self.total_zatoshis = self
+            .total_zatoshis
+            .checked_add(other.total_zatoshis)
+            .ok_or(AccumulatorDeltaError::Overflow("total_zatoshis"))?;
+        Ok(())
+    }
+
     /// Applies a single UTXO leaving the set to all per-output fields. Inverse of
     /// [`Self::apply_added_output`].
     pub fn apply_removed_output(
@@ -339,6 +368,84 @@ mod tests {
         assert_eq!(accumulator.bytes_serialized, 0);
         assert_eq!(accumulator.hash_serialized, [0u8; 32]);
         assert_eq!(accumulator.total_zatoshis, 0);
+    }
+
+    #[test]
+    fn combine_xors_commitments_and_sums_counters() {
+        let a = FinalisedTxOutSetInfoAccumulator::new(2, 10, 100, [0xaa; 32], 500);
+        let b = FinalisedTxOutSetInfoAccumulator::new(3, 7, 70, [0x0f; 32], 250);
+
+        let mut combined = a;
+        combined.combine(&b).expect("no overflow");
+
+        assert_eq!(combined.transactions, 5);
+        assert_eq!(combined.transaction_outputs, 17);
+        assert_eq!(combined.bytes_serialized, 170);
+        assert_eq!(combined.total_zatoshis, 750);
+        assert_eq!(combined.hash_serialized, [0xaa ^ 0x0f; 32]);
+    }
+
+    #[test]
+    fn combine_is_order_independent() {
+        let a = FinalisedTxOutSetInfoAccumulator::new(2, 10, 100, [0xaa; 32], 500);
+        let b = FinalisedTxOutSetInfoAccumulator::new(3, 7, 70, [0x0f; 32], 250);
+
+        let mut ab = a;
+        ab.combine(&b).expect("no overflow");
+        let mut ba = b;
+        ba.combine(&a).expect("no overflow");
+
+        assert_eq!(ab, ba, "XOR + addition are commutative, so combine must be order-independent");
+    }
+
+    #[test]
+    fn combine_detects_counter_overflow() {
+        let mut a = FinalisedTxOutSetInfoAccumulator::new(u64::MAX, 0, 0, [0; 32], 0);
+        let b = FinalisedTxOutSetInfoAccumulator::new(1, 0, 0, [0; 32], 0);
+
+        assert!(
+            a.combine(&b).is_err(),
+            "a counter overflow must surface as an error, never silently wrap"
+        );
+    }
+
+    #[test]
+    fn combine_recombines_partitioned_outputs() {
+        // This is the property the sharded rebuild relies on: accumulating disjoint groups of the
+        // UTXO set and folding the partials with `combine` must equal accumulating the whole set in
+        // one pass. (`apply_added_output` does not touch `transactions`, so this exercises the XOR
+        // commitment and the per-output additive counters; the `transactions` sum is covered above.)
+        let outputs: Vec<(Outpoint, TxOutCompact)> = (0..6u32)
+            .map(|i| {
+                let outpoint = Outpoint::new([i as u8; 32], i);
+                let out = TxOutCompact::new(1_000 + u64::from(i), [i as u8; 20], (i % 2) as u8)
+                    .expect("script_type 0/1 is valid");
+                (outpoint, out)
+            })
+            .collect();
+
+        let mut whole = FinalisedTxOutSetInfoAccumulator::empty();
+        for (outpoint, out) in &outputs {
+            whole.apply_added_output(outpoint, out).expect("no overflow");
+        }
+
+        // Split into two arbitrary disjoint groups, accumulate each, and recombine.
+        let mut part_a = FinalisedTxOutSetInfoAccumulator::empty();
+        for (outpoint, out) in &outputs[..2] {
+            part_a.apply_added_output(outpoint, out).expect("no overflow");
+        }
+        let mut part_b = FinalisedTxOutSetInfoAccumulator::empty();
+        for (outpoint, out) in &outputs[2..] {
+            part_b.apply_added_output(outpoint, out).expect("no overflow");
+        }
+
+        let mut combined = part_a;
+        combined.combine(&part_b).expect("no overflow");
+
+        assert_eq!(
+            combined, whole,
+            "combining partials of a partition must equal accumulating the whole set"
+        );
     }
 
     #[test]

--- a/packages/zainod/CHANGELOG.md
+++ b/packages/zainod/CHANGELOG.md
@@ -10,19 +10,26 @@ and this crate adheres to Rust's notion of
 
 ### Added
 - `[storage.database]` config gains `sync_checkpoint_interval` (seconds, default
-  300) — the bulk-sync write-batch flush interval.
+  120) — the bulk-sync write-batch flush interval, which also bounds the window of
+  unflushed (`NO_SYNC`) writes at risk on a hard kill / eviction.
+- `[storage.database]` config gains `accumulator_rebuild_memory_size` (GiB,
+  default 8) — a dedicated heap budget for the txout-set accumulator rebuild,
+  separate from `sync_write_batch_size`.
 ### Changed
 - **Breaking** — `[storage.database] sync_write_batch_bytes` (bytes) is renamed
-  to `sync_write_batch_size` and is now given in **GiB** (default raised from
-  4 GiB to 32 GiB). Lowering it bounds peak sync RAM and the txout-set
-  accumulator rebuild's per-shard memory on memory-constrained hosts. See the
-  `zaino-common` changelog.
+  to `sync_write_batch_size` and is now given in **GiB** (default 8). It now
+  budgets only the bulk-sync block buffer; the accumulator rebuild uses the new
+  `accumulator_rebuild_memory_size`. See the `zaino-common` changelog.
+- **Breaking** — unknown keys under `[storage.database]` now fail config parsing
+  loudly (e.g. a stale `sync_write_batch_bytes`) instead of being silently ignored
+  and falling back to the default budget.
 ### Deprecated
 ### Removed
 ### Fixed
-- Zaino no longer OOM-crashes during the txout-set accumulator rebuild when it
-  reaches mainnet chain tip on memory-constrained hosts (e.g. a 16 GiB pod); the
-  rebuild auto-shards to fit the configured `sync_write_batch_size` budget.
+- Zaino no longer silently falls back to a large default write/rebuild budget when
+  an old `[storage.database]` key is present — the silent fallback to the (former
+  32 GiB) default is what OOM-killed nodes at mainnet chain tip (e.g. a 16 GiB
+  pod), and the kill, under `NO_SYNC`, then corrupted the on-disk database.
 
 ## [0.4.1] - 2026-06-18
 

--- a/packages/zainod/CHANGELOG.md
+++ b/packages/zainod/CHANGELOG.md
@@ -9,10 +9,20 @@ and this crate adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+- `[storage.database]` config gains `sync_checkpoint_interval` (seconds, default
+  300) — the bulk-sync write-batch flush interval.
 ### Changed
+- **Breaking** — `[storage.database] sync_write_batch_bytes` (bytes) is renamed
+  to `sync_write_batch_size` and is now given in **GiB** (default raised from
+  4 GiB to 32 GiB). Lowering it bounds peak sync RAM and the txout-set
+  accumulator rebuild's per-shard memory on memory-constrained hosts. See the
+  `zaino-common` changelog.
 ### Deprecated
 ### Removed
 ### Fixed
+- Zaino no longer OOM-crashes during the txout-set accumulator rebuild when it
+  reaches mainnet chain tip on memory-constrained hosts (e.g. a 16 GiB pod); the
+  rebuild auto-shards to fit the configured `sync_write_batch_size` budget.
 
 ## [0.4.1] - 2026-06-18
 

--- a/packages/zainod/src/config.rs
+++ b/packages/zainod/src/config.rs
@@ -1024,8 +1024,7 @@ sync_write_batch_bytes = 2147483648
 listen_address = "127.0.0.1:8137"
 "#;
 
-        let config_path =
-            create_test_config_file(&temp_dir, toml_content, "stale_batch_key.toml");
+        let config_path = create_test_config_file(&temp_dir, toml_content, "stale_batch_key.toml");
         assert!(
             load_config(&config_path).is_err(),
             "stale `sync_write_batch_bytes` key must be rejected by deny_unknown_fields"

--- a/packages/zainod/src/config.rs
+++ b/packages/zainod/src/config.rs
@@ -1004,6 +1004,62 @@ listen_address = "127.0.0.1:8137"
         assert!(result.is_err());
     }
 
+    /// Regression guard: the old `[storage.database] sync_write_batch_bytes` key (renamed to
+    /// `sync_write_batch_size` and re-unitised to GiB) must now fail loudly. Silently ignoring it
+    /// and falling back to the default budget is what OOM-killed nodes at mainnet chain tip.
+    #[test]
+    fn stale_sync_write_batch_bytes_key_is_rejected() {
+        let _guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
+
+        let toml_content = r#"
+[validator_settings]
+validator_jsonrpc_listen_address = "127.0.0.1:18232"
+
+[storage.database]
+path = "/zaino/db"
+sync_write_batch_bytes = 2147483648
+
+[grpc_settings]
+listen_address = "127.0.0.1:8137"
+"#;
+
+        let config_path =
+            create_test_config_file(&temp_dir, toml_content, "stale_batch_key.toml");
+        assert!(
+            load_config(&config_path).is_err(),
+            "stale `sync_write_batch_bytes` key must be rejected by deny_unknown_fields"
+        );
+    }
+
+    /// The current `[storage.database]` budget keys parse and bind as expected.
+    #[test]
+    fn current_database_budget_keys_parse() {
+        let _guard = EnvGuard::new();
+        let temp_dir = TempDir::new().unwrap();
+
+        let toml_content = r#"
+[validator_settings]
+validator_jsonrpc_listen_address = "127.0.0.1:18232"
+
+[storage.database]
+path = "/zaino/db"
+sync_write_batch_size = 2
+accumulator_rebuild_memory_size = 1
+sync_checkpoint_interval = 30
+
+[grpc_settings]
+listen_address = "127.0.0.1:8137"
+"#;
+
+        let config_path =
+            create_test_config_file(&temp_dir, toml_content, "current_budget_keys.toml");
+        let config = load_config(&config_path).expect("current budget keys must parse");
+        assert_eq!(config.storage.database.sync_write_batch_size.0, 2);
+        assert_eq!(config.storage.database.accumulator_rebuild_memory_size.0, 1);
+        assert_eq!(config.storage.database.sync_checkpoint_interval, 30);
+    }
+
     /// Verifies that `generate_default_config()` produces valid TOML.
     ///
     /// TOML requires simple values before table sections. If ZainodConfig field


### PR DESCRIPTION
Contains fixes for bugs/issues found in release testing of the v0.5.0 release candidate, detailed by commit / issue:
---
**Sync progress lost on restart - #1261**:

- 82aa6d03 — Restrict the finalised-state sync to a single running task

The ChainIndex worker calls sync_to_height on every poll (~500 ms), and for long ranges that method spawns the sync as a detached task and returns immediately. With no in-flight guard, each poll re-spawned another background sync, piling up concurrent write_blocks_to_height runs that contended on the single LMDB writer and multiplied memory (concurrent block buffering plus repeated full accumulator rebuilds) — driving the process to OOM before any batch committed, so on restart the persistent tip was still at the old snapshot baseline and sync started over. The fix adds a single-flight check at the top of sync_to_height using the existing Router::has_background_ops() tracker (incremented synchronously before the spawn, held for the task's whole lifetime): if a sync is already in progress, the poll is a no-op. The worker being the sole sequential caller makes the check race-free.

- 7e78a6f9 — Seed the non-finalised state no deeper than chain_height − NON_FINALIZED_DEPTH

While the finalised DB was still catching up, seeding the non-finalised state (NFS) called get_chain_block_by_height(tip − NON_FINALIZED_DEPTH), which returned Ok(None) and was .expect("todo") unwrapped down to genesis. sync() then re-anchored to the lagging finalised tip and walked every block up to the chain tip one at a time, never converging. The fix adds resolve_anchor_block, which fetches the seed block reader-first (finalised DB, or the validator via the ReadOnly passthrough during catch-up) with a direct-from-validator fallback, so the anchor never drops to genesis. Both the init and re-anchor paths now floor the anchor at max(finalised_tip, chain_height − NON_FINALIZED_DEPTH), keeping the NFS to the reorg window (~101 blocks). The two .expect("todo") calls were replaced with proper error propagation.

  ---
**OOM on TxOutSetInfo accumulator build - #1260**:

- 8f4c2348 — Add sharding to the txout-set accumulator build for low-memory systems

At chain tip the from-genesis accumulator rebuild was pinned to ACCUMULATOR_BUILD_SHARDS = 1, loading the entire spent table into one in-memory HashSet — which exceeds 16 GiB at mainnet tip and OOM-crashed (exit 137). The fix enables the builder's existing sequential, zero-random-read sharding: the spent set is partitioned by the creating-txid's first byte into shards contiguous key ranges, each range is accumulated independently, and the results are recombined. Because the accumulator is an XOR multiset plus additive counters, partitioning is order-independent and result-identical, and the accumulator struct is fixed-size — so only the per-shard spent set scales with shard count, and capping it caps RSS. (Batching via the incremental path was rejected: its O(range) random lookups reintroduce the sandblast-era sync slowdown.)

- f56ee9a8 — Separate the block-batch budget from the accumulator-build budget

A single sync_write_batch_size config sized both the bulk-sync block buffer and the accumulator spent set, so they couldn't be tuned independently — and because DatabaseConfig was #[serde(default)] with no deny_unknown_fields, a config still using the old sync_write_batch_bytes key was silently ignored and fell back to the large default, defeating the budget on exactly the hosts that needed it. The fix adds a dedicated accumulator_rebuild_memory_size config (the rebuild uses this, never the block-batch budget) and adds #[serde(deny_unknown_fields)] so any stale or unknown key now fails loud at startup instead of silently reverting to defaults. Both budgets default to 8 GiB and sync_checkpoint_interval defaults to 120 s, with saturating byte-count conversion. The example config and changelogs are updated; new tests confirm the old key is rejected and the new keys parse.

- baf9a6a6 — Make accumulator sharding a hard memory cap

Shard count was derived from an estimate of spent-set bytes, so if the estimate was low (or one first-byte bucket was unusually dense) a shard could still exceed the budget and OOM — the cap wasn't actually guaranteed. The fix replaces the estimate with a strict hard cap: each shard loads spent entries via a range-seek and aborts the moment it hits max_spent_entries (returning None), and the work-list then bisects that range and retries, so no shard ever exceeds the budget regardless of key distribution. If a single first-byte bucket can't be split below the cap it fails with an actionable error instead of OOMing. A new combine method on the accumulator (with overflow-checked counter sums) plus unit tests prove combine is order-independent and correctly recombines partitioned outputs.

- 26c20744 — Diagnostics, durability docs, and tests for the spent scan

On a torn or corrupt spent page the startup scan aborted with a cryptic "unsupported Zaino version tag 253" and no context, several scans used LMDB cursor iterators that can panic or silently truncate on edge cases, and doc comments wrongly claimed the NO_SYNC env "never corrupts" on a crash (false on NFS / evicted containers where write ordering isn't preserved). The fix rewrites initial_spent_scan (and the estimator and per-shard loads) as explicit, panic-safe cursor walks that propagate every LMDB error, and on a decode failure reports the key (hex), value length, and value head plus a "wipe and re-index" instruction — turning "tag 253" into a definitive torn-page diagnosis. It also adds phase logging around the full-table scans so a native abort in stderr is attributable, corrects the misleading durability comments, and adds unit and end-to-end tests (including one that injects a corrupt spent value and asserts the diagnostic error).

  ---