### PR TITLE
Fix integration-test container build and macOS portability

### DIFF
--- a/integration-tests/test_environment/Containerfile
+++ b/integration-tests/test_environment/Containerfile
@@ -103,17 +103,21 @@ LABEL org.zaino.test-artifacts.versions.rust="${RUST_VERSION}"
 # Versions pinned (DL3008) to the candidates in rust:1.95.0-trixie; bump
 # together with the base image (query with `apt-cache policy <pkg>`).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libssl-dev=3.5.6-1~deb13u1 \
+    libssl-dev=3.5.6-1~deb13u2 \
     curl=8.14.1-2+deb13u3 \
     libclang-dev=1:19.0-63 \
     build-essential=12.12 \
     cmake=3.31.6-2 \
-    librocksdb-dev=9.10.0-1+b1 \
+    librocksdb-dev=9.10.0-1 \
     protobuf-compiler=3.21.12-11 \
     && rm -rf /var/lib/apt/lists/*
 
-# Create container_user
-RUN groupadd --gid ${GID} ${USER} && \
+# Create container_user. The GID may already belong to a base-image group
+# (e.g. on macOS hosts the caller's primary group is `staff`, GID 20, which
+# collides with Debian's `dialout`); `--non-unique` lets the `container_user`
+# group share that GID so later `--chown=container_user:container_user` COPYs
+# still resolve the group by name.
+RUN groupadd --non-unique --gid ${GID} ${USER} && \
     useradd --uid ${UID} --gid ${GID} --home-dir ${HOME} --create-home ${USER}
 
 # Install the toolchain under the same channel name rust-toolchain.toml asks

--- a/tools/scripts/base-script-pre.sh
+++ b/tools/scripts/base-script-pre.sh
@@ -35,11 +35,14 @@ podman_cleanup() {
 Cleaning up..."
     fi
 
-    # Kill all child processes
+    # Kill all child processes. Avoid `mapfile` (bash 4+) so this works under
+    # the bash 3.2 that macOS ships as /bin/bash; PIDs are numeric, so the
+    # unquoted word-split on `$pids` is safe.
     local pids
-    mapfile -t pids < <(jobs -pr)
-    if [ "${#pids[@]}" -gt 0 ]; then
-        kill "${pids[@]}" 2>/dev/null || true
+    pids=$(jobs -pr)
+    if [ -n "$pids" ]; then
+        # shellcheck disable=SC2086
+        kill $pids 2>/dev/null || true
     fi
 
     # Stop any containers started by this script


### PR DESCRIPTION
## Summary

Three fixes that unblock `makers integration-test`. The first is a real CI/build breakage; the other two are local-developer portability fixes for Apple Silicon / macOS.

- **Containerfile: bump drifted Debian pins.** `librocksdb-dev=9.10.0-1+b1` is a binNMU that has been superseded and no longer resolves in `rust:1.95.0-trixie`, breaking the image build for everyone. Updated to the current candidates: `librocksdb-dev=9.10.0-1` and `libssl-dev=3.5.6-1~deb13u2`.
- **Containerfile: `groupadd --non-unique`.** On macOS hosts the caller's primary group is `staff` (GID 20), which collides with Debian's `dialout`. `--non-unique` lets the `container_user` group share that GID so later `--chown=container_user:container_user` COPYs still resolve the group by name.
- **base-script-pre.sh: drop `mapfile`.** `mapfile` is a bash 4+ builtin; macOS ships bash 3.2 as `/bin/bash`. Replaced with a portable command substitution (PIDs are numeric, so the unquoted word-split is safe).

## Test plan

`makers integration-test` now builds the image, compiles, links, and runs the suite. All `zebra`/`zebrad`-backed tests pass. The remaining `zcashd::*` failures on Apple Silicon are an unrelated upstream limitation (the `zodlinc/zcash` image is amd64-only) and are out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)