### PR TITLE
docs: add containerized test how-to (podman, zcashd toggle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ Do not expose it to untrusted networks, and only enable
 `allow_unencrypted_public_json_rpc_bind` when an external layer secures the
 connection.
 
+## Running tests
+
+The test suites run inside a **podman** container via `makers` (cargo-make):
+
+```sh
+makers container-test     # root-workspace (packages/*) tests
+makers integration-test   # both integration-test workspaces + combined summary
+```
+
+zcashd-backed tests are **off by default**; add `--with-zcashd` (or set
+`CONTAINER_TEST_WITH_ZCASHD=1`) to include them. On lower-resource machines you
+may hit occasional contention flakes under full parallelism — re-run, or lower
+`test-threads` in the nextest config. See [docs/testing.md](./docs/testing.md)
+for full instructions.
+
 ## Documentation
 - [Use Cases](./docs/use_cases.md): Holds instructions and example use cases.
 - [Testing](./docs/testing.md): Holds instructions for running tests.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,3 +19,41 @@ From that point you will have two executables available: `cargo-make` (invoked w
 `cargo make help`
 will print a help output.
 `Makefile.toml` holds a configuration file.
+
+## Containerized test tasks (podman)
+
+The `makers` tasks below build and run the test suites inside a **podman**
+container, so you don't need the validator binaries on your host `$PATH`. The
+container image is built or pulled automatically on first run.
+
+- `makers container-test` — runs the root-workspace (`packages/*`) test suite.
+- `makers integration-test` — runs both integration-test workspaces (the
+  walletless `integration-tests`, then the `wallet-tests` workspace) and prints
+  a combined pass/fail summary.
+
+### zcashd-backed tests are OFF by default
+
+zcashd is being deprecated, so the suites compile with `--no-default-features`
+(the default-on `zcashd_support` feature turned OFF), and the zcashd-backed
+tests are compiled out. To include them, turn the feature back on in any of
+these equivalent ways:
+
+- pass the flag: `makers container-test --with-zcashd` or
+  `makers integration-test --with-zcashd`
+- set the env var: `CONTAINER_TEST_WITH_ZCASHD=1 makers integration-test`
+- use the convenience task: `makers zcashd_test` (runs `container-test` and
+  `integration-test` with zcashd on)
+
+See `docs/adr/0001-zcashd-support-feature-gate.md` for the rationale.
+
+### Test contention on lower-resource machines
+
+The suites run at full parallelism (one test thread per CPU), and each
+integration test can spawn its own validator. On machines with fewer cores or
+less RAM this can surface as occasional flaky failures caused by contention
+rather than real regressions — re-running usually passes. To make runs more
+reliable, lower the parallelism by reducing `test-threads` in the relevant
+nextest config (`.config/nextest.toml` for `container-test`,
+`integration-tests/.config/nextest.toml` for the integration suites). For a
+one-off run you can instead forward a nextest flag through the per-workspace
+tasks, e.g. `makers container-test --test-threads 6`.


### PR DESCRIPTION
Document running the suites via `makers container-test` and `makers integration-test` inside podman. Note that zcashd-backed tests are off by default and how to flip them on (--with-zcashd / CONTAINER_TEST_WITH_ZCASHD=1 / makers zcashd_test), and add a generic test-contention note for lower-resource machines with config-tuning guidance. Docs-only: README.md + docs/testing.md.
