### PR TITLE
changed feature to test only

### DIFF
--- a/integration-tests/walletless-tests/Cargo.toml
+++ b/integration-tests/walletless-tests/Cargo.toml
@@ -11,10 +11,11 @@ license.workspace = true
 version.workspace = true
 
 [features]
-# gettxoutsetinfo RPC + its finalised txout-set accumulator (non-default in zaino-state).
-# Feature-on, the gettxoutsetinfo fetch test asserts zcashd parity; the default (gated-off) build
+# TEST-ONLY, SUBTRACTIVE gate (removes the finalised txout-set accumulator in
+# zaino-state). The default build keeps the accumulator: the gettxoutsetinfo
+# fetch test asserts zcashd parity. Feature-on (accumulator removed), the test
 # instead asserts the RPC reports the feature unavailable.
-gettxoutsetinfo = ["zaino-state/gettxoutsetinfo"]
+test_only_skip_txout_set_accumulator = ["zaino-state/test_only_skip_txout_set_accumulator"]
 
 # **Experimental and alpha features**
 # Exposes the **complete** set of experimental / alpha features currently implemented in Zaino.

--- a/integration-tests/walletless-tests/tests/fetch_service.rs
+++ b/integration-tests/walletless-tests/tests/fetch_service.rs
@@ -140,21 +140,22 @@ async fn assert_fetch_service_gettxoutsetinfo_matches_rpc<V: ValidatorExt>(
 
     let fetch_service_txoutset_info = fetch_service_subscriber.get_tx_out_set_info().await;
 
-    // The finalised txout-set accumulator that backs `gettxoutsetinfo` is behind the non-default
-    // `gettxoutsetinfo` feature. The default build must report it unavailable (the gate's
-    // contract); only the feature-on build serves real data and is checked for zcashd parity.
-    #[cfg(not(feature = "gettxoutsetinfo"))]
+    // The finalised txout-set accumulator that backs `gettxoutsetinfo` is built by default; the
+    // test-only `test_only_skip_txout_set_accumulator` feature subtracts it. With the accumulator
+    // removed, the RPC must report the feature unavailable (the gate's contract); the default build
+    // serves real data and is checked for zcashd parity.
+    #[cfg(feature = "test_only_skip_txout_set_accumulator")]
     {
         let _ = &test_manager;
         let error = fetch_service_txoutset_info
-            .expect_err("gated-off build must report the txout-set accumulator unavailable");
+            .expect_err("accumulator-skipped build must report the txout-set accumulator unavailable");
         assert!(
             format!("{error:?}").contains("feature unavailable: gettxoutsetinfo"),
             "expected a gettxoutsetinfo-unavailable error, got: {error:?}"
         );
     }
 
-    #[cfg(feature = "gettxoutsetinfo")]
+    #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
     {
         let fetch_service_txoutset_info = fetch_service_txoutset_info.unwrap();
 

--- a/packages/zaino-fetch/CHANGELOG.md
+++ b/packages/zaino-fetch/CHANGELOG.md
@@ -10,9 +10,10 @@ and this library adheres to Rust's notion of
 ### Added
 ### Changed
 - No change to the `gettxoutsetinfo` types here: `GetTxOutSetInfoResponse` and
-  `JsonRpSeeConnector::get_tx_out_set_info` remain available in every build. Serving
-  `gettxoutsetinfo` from the indexer is now behind `zaino-state`'s non-default `gettxoutsetinfo`
-  feature, so the default build returns `FeatureUnavailable` rather than a populated response.
+  `JsonRpSeeConnector::get_tx_out_set_info` remain available in every build. The indexer serves
+  `gettxoutsetinfo` by default; `zaino-state`'s test-only, subtractive
+  `test_only_skip_txout_set_accumulator` feature removes the backing accumulator, after which the
+  RPC returns `FeatureUnavailable` rather than a populated response.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/packages/zaino-serve/Cargo.toml
+++ b/packages/zaino-serve/Cargo.toml
@@ -12,9 +12,10 @@ version = "0.4.0"
 # Removes network restrictions.
 no_tls_use_unencrypted_traffic = ["tonic/tls-native-roots"]
 
-# gettxoutsetinfo RPC + finalised txout-set accumulator (non-default). Re-exports
-# the zaino-state gate.
-gettxoutsetinfo = ["zaino-state/gettxoutsetinfo"]
+# TEST-ONLY, SUBTRACTIVE. Re-exports the zaino-state gate: enabling it REMOVES
+# the finalised txout-set accumulator build (and the gettxoutsetinfo RPC).
+# Never enable in production.
+test_only_skip_txout_set_accumulator = ["zaino-state/test_only_skip_txout_set_accumulator"]
 
 # **Experimental and alpha features**
 # Exposes the **complete** set of experimental / alpha features currently implemented in Zaino.

--- a/packages/zaino-state/CHANGELOG.md
+++ b/packages/zaino-state/CHANGELOG.md
@@ -21,11 +21,13 @@ and this library adheres to Rust's notion of
   sync/migration to reach its target (distinct from `wait_until_ready`, which
   reflects serving-readiness).
 ### Changed
-- **BREAKING:** `gettxoutsetinfo` and its finalised txout-set accumulator are now behind a
-  non-default `gettxoutsetinfo` Cargo feature. The default build does not build or store the
-  accumulator and returns `FeatureUnavailable` from `get_tx_out_set_info` (the RPC stays
-  registered); enable with `--features gettxoutsetinfo`. The on-disk schema is unchanged — the
-  accumulator table still exists, it is simply not maintained when the feature is off.
+- **BREAKING:** `gettxoutsetinfo` and its finalised txout-set accumulator are built and served by
+  default. They sit behind a **test-only, subtractive** Cargo feature,
+  `test_only_skip_txout_set_accumulator`: enabling it *removes* the accumulator build and makes
+  `get_tx_out_set_info` return `FeatureUnavailable` (the RPC stays registered). The feature exists
+  only so tests can skip the from-genesis accumulator build — never enable it in production. The
+  on-disk schema is unchanged either way — with the feature on the accumulator table simply is not
+  maintained.
 - `chain_index::finalised_state` renames (internal, `pub(crate)`):
   - facade type `ZainoDB` -> `FinalisedState`
   - module `db` -> `finalised_source`; enum `DbBackend` -> `FinalisedSource`

--- a/packages/zaino-state/Cargo.toml
+++ b/packages/zaino-state/Cargo.toml
@@ -11,11 +11,12 @@ version = "0.4.0"
 [features]
 default = []
 
-# gettxoutsetinfo RPC + the finalised txout-set accumulator it is the sole
-# consumer of. Non-default: the default build neither stores nor builds the
-# accumulator (whose from-genesis build is OOM-prone) and answers the RPC with
-# FeatureUnavailable.
-gettxoutsetinfo = []
+# TEST-ONLY, SUBTRACTIVE. The default (production) build stores and builds the
+# finalised txout-set accumulator and serves the gettxoutsetinfo RPC from it.
+# Enabling this feature REMOVES the accumulator build (and serves the
+# gettxoutsetinfo RPC with FeatureUnavailable), letting tests skip the
+# from-genesis accumulator build. Never enable in production.
+test_only_skip_txout_set_accumulator = []
 
 # Prometheus metrics emission (gauge! calls in sync paths).
 prometheus = ["metrics"]

--- a/packages/zaino-state/src/chain_index/finalised_state/CHANGELOG.md
+++ b/packages/zaino-state/src/chain_index/finalised_state/CHANGELOG.md
@@ -179,10 +179,10 @@ Summary
 - Promote the `spent` outpoint index to core finalised-state data.
 - Add a finalised txout-set accumulator (`tx_out_set_info_accumulator`)
   maintaining the data needed to serve `gettxoutsetinfo` directly from the
-  indexer. NOTE: this table is built and maintained only in builds with the
-  non-default `gettxoutsetinfo` Cargo feature; the on-disk schema below is
-  identical either way — the table is simply left unmaintained when the feature
-  is off.
+  indexer. NOTE: this table is built and maintained by default; the test-only,
+  subtractive `test_only_skip_txout_set_accumulator` Cargo feature removes it.
+  The on-disk schema below is identical either way — the table is simply left
+  unmaintained when that feature is on.
 - Add a reverse transaction-id index (`txid_location`, `txid -> TxLocation`)
   so previous-output resolution is an O(log n) point lookup instead of a full
   scan of the height-keyed `txids` table. This fixes a near-quadratic slowdown

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source.rs
@@ -842,7 +842,7 @@ impl<T: BlockchainSource> TransparentHistExt for FinalisedSource<T> {
         &self,
     ) -> Result<FinalisedTxOutSetInfoAccumulator, FinalisedStateError> {
         match self {
-            #[cfg(feature = "gettxoutsetinfo")]
+            #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
             Self::V1(database) => database.get_tx_out_set_info_accumulator().await,
             _ => Err(FinalisedStateError::FeatureUnavailable("gettxoutsetinfo")),
         }
@@ -889,7 +889,7 @@ impl<T: BlockchainSource> FinalisedSource<T> {
 
 /// Accumulator test hooks, grouped so the whole `gettxoutsetinfo` test surface is a single
 /// `#[cfg]` unit (the enclosing `cfg(test)` is folded in via `cfg(all(...))`).
-#[cfg(all(test, feature = "gettxoutsetinfo"))]
+#[cfg(all(test, not(feature = "test_only_skip_txout_set_accumulator")))]
 impl<T: BlockchainSource> FinalisedSource<T> {
     /// Reads the height the persisted txout-set accumulator currently reflects (V1 only).
     ///

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
@@ -89,7 +89,7 @@ pub(crate) mod indexed_block;
 
 pub(crate) mod transparent_address_history;
 
-#[cfg(feature = "gettxoutsetinfo")]
+#[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
 pub(crate) mod tx_out_set_accumulator;
 
 // ───────────────────────── Schema v1 constants ─────────────────────────
@@ -254,7 +254,7 @@ pub(crate) struct DbV1 {
     ///
     /// Stores the finalised-state portion of `gettxoutsetinfo` that can be maintained cheaply
     /// without adding per-UTXO storage.
-    #[cfg(feature = "gettxoutsetinfo")]
+    #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
     tx_out_set_info_accumulator: Database,
 
     /// Transparent address history: `AddrScript` -> duplicate values of `StoredEntryFixed<AddrEventBytes>`.
@@ -420,7 +420,7 @@ impl DbV1 {
             // Opened inline here, before `env` is moved into its `Arc` below (struct fields are
             // evaluated top-to-bottom), so the gated accumulator table needs a single `#[cfg]`
             // rather than a separate gated `let` plus a gated field-init.
-            #[cfg(feature = "gettxoutsetinfo")]
+            #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
             tx_out_set_info_accumulator: super::open_or_create_db(
                 &env,
                 TX_OUT_SET_INFO_ACCUMULATOR_DATABASE_NAME,
@@ -464,7 +464,7 @@ impl DbV1 {
             heights: self.heights,
             spent: self.spent,
             txid_location: self.txid_location,
-            #[cfg(feature = "gettxoutsetinfo")]
+            #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
             tx_out_set_info_accumulator: self.tx_out_set_info_accumulator,
             #[cfg(feature = "transparent_address_history_experimental")]
             address_history: self.address_history,

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/transparent_address_history.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/transparent_address_history.rs
@@ -77,11 +77,11 @@ impl TransparentHistExt for DbV1 {
     async fn get_tx_out_set_info_accumulator(
         &self,
     ) -> Result<FinalisedTxOutSetInfoAccumulator, FinalisedStateError> {
-        #[cfg(feature = "gettxoutsetinfo")]
+        #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
         {
             self.get_tx_out_set_info_accumulator().await
         }
-        #[cfg(not(feature = "gettxoutsetinfo"))]
+        #[cfg(feature = "test_only_skip_txout_set_accumulator")]
         {
             Err(FinalisedStateError::FeatureUnavailable("gettxoutsetinfo"))
         }

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/tx_out_set_accumulator.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/tx_out_set_accumulator.rs
@@ -1,6 +1,8 @@
 //! Finalised txout-set accumulator (schema table #9): the finalised-state portion of
-//! `gettxoutsetinfo`. The whole module is gated by `#[cfg(feature = "gettxoutsetinfo")]`
-//! on its `mod` declaration in `v1.rs`, so no item inside needs its own feature cfg.
+//! `gettxoutsetinfo`. The whole module is gated by
+//! `#[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]` on its `mod` declaration in
+//! `v1.rs`, so no item inside needs its own feature cfg. The accumulator is built by default;
+//! the test-only `test_only_skip_txout_set_accumulator` feature subtracts it.
 
 use super::*;
 use crate::chain_index::finalised_state::finalised_source::v1::TX_OUT_SET_INFO_ACCUMULATOR_KEY;
@@ -315,7 +317,7 @@ fn index_spent_outpoints(
 
 /// Read, maintenance, and bulk (re)build of the finalised txout-set accumulator (schema table #9).
 ///
-/// Gathered into one `impl` block so the entire `gettxoutsetinfo` capability is a single `#[cfg]`
+/// Gathered into one `impl` block so the entire accumulator capability is a single `#[cfg]`
 /// unit. This grouping is the natural structure for these methods regardless of the gate — they are
 /// exactly the accumulator's read / write-path-delta / rebuild surface and nothing else.
 impl DbV1 {

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
@@ -208,7 +208,7 @@ impl DbWrite for DbV1 {
         // once the chain is large. Use it only for the first build or an unusually large gap (e.g. a
         // sync interrupted far behind the on-disk tip); in steady state apply just the delta for the
         // blocks we wrote — O(range) work — which produces the identical accumulator at the tip.
-        #[cfg(feature = "gettxoutsetinfo")]
+        #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
         self.advance_tx_out_set_accumulator_to_tip(height).await?;
 
         Ok(())
@@ -263,9 +263,9 @@ impl DbV1 {
     async fn write_block_with_options(
         &self,
         block: IndexedBlock,
-        // Only consulted on the accumulator path; without that feature the bulk/append distinction
-        // it controls has no observable effect.
-        #[cfg_attr(not(feature = "gettxoutsetinfo"), allow(unused_variables))]
+        // Only consulted on the accumulator path; with the accumulator skipped the bulk/append
+        // distinction it controls has no observable effect.
+        #[cfg_attr(feature = "test_only_skip_txout_set_accumulator", allow(unused_variables))]
         update_tx_out_set: bool,
     ) -> Result<(), FinalisedStateError> {
         self.status.store(StatusType::Syncing);
@@ -558,7 +558,7 @@ impl DbV1 {
 
         // Accumulator maintenance is deferred on the bulk-sync path (`update_tx_out_set == false`)
         // and rebuilt once at the tip; only the single-block append path maintains it incrementally.
-        #[cfg(feature = "gettxoutsetinfo")]
+        #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
         let tx_out_set_info_accumulator = self
             .maybe_calculate_tx_out_set_info_accumulator_after_block(
                 update_tx_out_set,
@@ -693,7 +693,7 @@ impl DbV1 {
             // Persist the incrementally-maintained accumulator and advance its freshness watermark
             // in the same transaction as the block, so the watermark always tracks the height the
             // accumulator reflects. Skipped on the deferred (bulk-sync) path.
-            #[cfg(feature = "gettxoutsetinfo")]
+            #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
             zaino_db.put_maintained_tx_out_set_accumulator(
                 &mut txn,
                 tx_out_set_info_accumulator,
@@ -1483,7 +1483,7 @@ impl DbV1 {
             }
         }
 
-        #[cfg(feature = "gettxoutsetinfo")]
+        #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
         let tx_out_set_info_accumulator = self
             .calculate_tx_out_set_info_accumulator_after_delete_block(&transactions, &spent_map)
             .await?;
@@ -1499,7 +1499,7 @@ impl DbV1 {
         tokio::task::spawn_blocking(move || {
             let mut txn = zaino_db.env.begin_rw_txn()?;
 
-            #[cfg(feature = "gettxoutsetinfo")]
+            #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
             zaino_db.put_tx_out_set_accumulator(&mut txn, tx_out_set_info_accumulator)?;
 
             // Delete spent data

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -936,7 +936,7 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
             // migration is discarded and replaced with a correct value. It is idempotent, so a crash
             // mid-Stage-C is recovered by simply re-running the (skipped) earlier stages and
             // rebuilding again.
-            #[cfg(feature = "gettxoutsetinfo")]
+            #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
             backend.run_v1_2_migration_accumulator_stage(db_tip).await?;
         }
 

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/migrations/v1_1_to_v1_2.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/migrations/v1_1_to_v1_2.rs
@@ -12,7 +12,7 @@ use crate::chain_index::finalised_state::capability::{
 };
 use crate::chain_index::finalised_state::entry::StoredEntryFixed;
 use crate::chain_index::finalised_state::finalised_source::v1::DB_SCHEMA_V1_HASH;
-#[cfg(feature = "gettxoutsetinfo")]
+#[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
 use crate::chain_index::finalised_state::finalised_source::v1::TX_OUT_SET_INFO_ACCUMULATOR_KEY;
 use crate::chain_index::finalised_state::finalised_source::FinalisedSource;
 use crate::chain_index::finalised_state::FinalisedState;
@@ -122,7 +122,7 @@ async fn simulate_interrupted_v1_1_to_v1_2_spent_index_migration(
     let environment = database_backend.env().unwrap();
     let metadata_database = database_backend.metadata_db().unwrap();
     let spent_database = database_backend.spent_db().unwrap();
-    #[cfg(feature = "gettxoutsetinfo")]
+    #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
     let (tx_out_set_info_accumulator_database, expected_resume_accumulator) = (
         database_backend.tx_out_set_info_accumulator_db().unwrap(),
         crate::chain_index::finalised_state::finalised_source::v1::tx_out_set_accumulator::expected_tx_out_set_info_accumulator(database_backend, resume_height - 1).await,
@@ -176,7 +176,7 @@ async fn simulate_interrupted_v1_1_to_v1_2_spent_index_migration(
             transaction.del(spent_database, &spent_key, None).unwrap();
         }
 
-        #[cfg(feature = "gettxoutsetinfo")]
+        #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
         {
             let tx_out_set_info_accumulator_entry =
                 StoredEntryFixed::new(TX_OUT_SET_INFO_ACCUMULATOR_KEY, expected_resume_accumulator);
@@ -358,7 +358,7 @@ async fn v1_1_to_v1_2_spent_index_backfill_from_old_version() {
 
     assert_txid_location_index_matches_block_data(&migrated_backend).await;
     assert_spent_index_matches_transparent_data(&migrated_backend).await;
-    #[cfg(feature = "gettxoutsetinfo")]
+    #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
     crate::chain_index::finalised_state::finalised_source::v1::tx_out_set_accumulator::assert_tx_out_set_info_accumulator_matches_transparent_data(&migrated_backend).await;
 
     migrated_database.shutdown().await.unwrap();
@@ -456,7 +456,7 @@ async fn v1_1_to_v1_2_spent_index_migration_resumes_after_crash() {
 
     assert_txid_location_index_matches_block_data(&resumed_backend).await;
     assert_spent_index_matches_transparent_data(&resumed_backend).await;
-    #[cfg(feature = "gettxoutsetinfo")]
+    #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
     crate::chain_index::finalised_state::finalised_source::v1::tx_out_set_accumulator::assert_tx_out_set_info_accumulator_matches_transparent_data(&resumed_backend).await;
 
     resumed_database.shutdown().await.unwrap();
@@ -543,7 +543,7 @@ async fn v1_2_0_cache_missing_txid_location_index_is_rebuilt() {
 
     assert_txid_location_index_matches_block_data(&healed_backend).await;
     assert_spent_index_matches_transparent_data(&healed_backend).await;
-    #[cfg(feature = "gettxoutsetinfo")]
+    #[cfg(not(feature = "test_only_skip_txout_set_accumulator"))]
     crate::chain_index::finalised_state::finalised_source::v1::tx_out_set_accumulator::assert_tx_out_set_info_accumulator_matches_transparent_data(&healed_backend).await;
 
     healed_database.shutdown().await.unwrap();

--- a/packages/zainod/Cargo.toml
+++ b/packages/zainod/Cargo.toml
@@ -20,9 +20,10 @@ path = "src/lib.rs"
 # Removes network restrictions.
 no_tls_use_unencrypted_traffic = ["zaino-serve/no_tls_use_unencrypted_traffic"]
 
-# gettxoutsetinfo RPC + finalised txout-set accumulator (non-default). Re-exports
-# the gate through both crates.
-gettxoutsetinfo = ["zaino-state/gettxoutsetinfo", "zaino-serve/gettxoutsetinfo"]
+# TEST-ONLY, SUBTRACTIVE. Re-exports the gate through both crates: enabling it
+# REMOVES the finalised txout-set accumulator build (and the gettxoutsetinfo
+# RPC). Never enable in production.
+test_only_skip_txout_set_accumulator = ["zaino-state/test_only_skip_txout_set_accumulator", "zaino-serve/test_only_skip_txout_set_accumulator"]
 
 # Operator build: no TLS + Prometheus metrics endpoint.
 no_tls_with_prometheus = ["no_tls_use_unencrypted_traffic", "prometheus"]


### PR DESCRIPTION
Makes the new txoutsetinfo accumulator feature flag a test-only feature, simplifying db version safety.

**Reasoning**:
A subtractive test-only feature is preferred here because it keeps the production database format canonical and unconditional.

If the new behaviour is added as a normal/default production feature, then database compatibility becomes dependent on both the database version and the binary’s feature set. That means migrations must account for:

    previous database version
    target database version
    previous binary feature configuration
    current binary feature configuration

This creates unnecessary state-space growth and makes version safety harder to reason about.

By contrast, a subtractive test-only feature lets production builds always compile the real production path, while tests can explicitly disable that path to construct legacy fixtures, exercise migration behaviour or test limited builds. The feature does not define a supported production configuration, so it does not need to be tracked in the database metadata or migration matrix.