### PR TITLE
Patch reorg depth unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5889,9 +5889,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "9.0.0"
+version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ed3a4e00e8f0b2197f3d8fd6cad02351a25ddbffcf0a6dc1fe463d7ea4ccfa"
+checksum = "9a3a32562497425712e17b78c42d73bb69560053205653bb6b6e3e1aed6217ec"
 dependencies = [
  "bech32",
  "bitflags 2.13.0",
@@ -5958,9 +5958,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-consensus"
-version = "8.0.0"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15475adf8c271d03de99d18d622a8ae4c512c401e3e29da1f27a0ba62b22057c"
+checksum = "78c5b49c3cfef4df307ed6f6e8b1bd8cf0baa475c6841620bc17f9e9f53f8e77"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6001,9 +6001,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ba4f7dcd795eb84a5a33f5c4f29df60dd4971be363d2cd98d5fba5ce0477f2"
+checksum = "d957623f215fcc049ef1178efba186440ac17c05ceeb68edf8f2999ce7f6eca8"
 dependencies = [
  "bitflags 2.13.0",
  "byteorder",
@@ -6039,9 +6039,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abeece0fb4503a1df00c5ab736754b55c702613968f622f6aa3c2f9842aed2b2"
+checksum = "799017e2ade4fd2169bd4e14ddcbe180b62332e0b8d2ec9745d3256d8482684d"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -6055,9 +6055,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "9.0.0"
+version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b460869e352c9f1b49a00ed9beaae04ca3e6498381c7189d4b90a79e51c260bd"
+checksum = "5eedf51b44db5c6c8b21aad40e88746a858185b812680e210a7eb44189489cf9"
 dependencies = [
  "base64",
  "chrono",
@@ -6115,9 +6115,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fc38c19388671df8a77c767e279b135ffaecd5e7df6ed7cd096390c080b4a3"
+checksum = "851f8533916035873c1543945bc425d7b7f3b1daa68a1ba2ba700a0714e75a8d"
 dependencies = [
  "libzcash_script",
  "rand 0.8.6",
@@ -6129,9 +6129,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-state"
-version = "8.0.0"
+version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b351fde5047dce0d505c9dc26863ee818b7579e9cf8d8e44489deb9decfbb7"
+checksum = "0f75fbe6845c042d64608664f3c66550c6cd9ed09efbd71a3849c617c14da137"
 dependencies = [
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ zcash_transparent = "0.8"
 zcash_client_backend = "0.23"
 
 # Zebra
-zebra-chain = "9.0.0"
-zebra-state = "8.0.0"
-zebra-rpc = "9.0.0"
+zebra-chain = "10.0.0"
+zebra-state = "9.0.0"
+zebra-rpc = "10.0.0"
 
 # Runtime
 tokio = { version = "1.38", features = ["full"] }

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -43,9 +43,9 @@ zcash_protocol = { version = "0.9", features = ["local-consensus"] }
 zcash_client_backend = "0.23"
 
 # Zebra
-zebra-chain = "9.0.0"
-zebra-state = "8.0.0"
-zebra-rpc = "9.0.0"
+zebra-chain = "10.0.0"
+zebra-state = "9.0.0"
+zebra-rpc = "10.0.0"
 
 # Runtime
 tokio = { version = "1.38", features = ["full"] }

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -73,7 +73,21 @@ mod tests;
 /// preserves the original literal-`100` behavior; deriving the
 /// depth from an explicit wider-consensus reference is tracked in
 /// zingolabs/zaino#1130.
+#[cfg(not(test))]
 pub(crate) const NON_FINALIZED_DEPTH: u32 = zebra_state::MAX_BLOCK_REORG_HEIGHT + 1;
+
+/// In-crate unit tests pin the depth at the pre-zebra-10 value (`100`).
+///
+/// Zebra 10 raised `MAX_BLOCK_REORG_HEIGHT` from 99 to 1000, so the
+/// production depth is now 1001. The 201-block mock-chain test vector is
+/// far shorter than that, so at the production depth `finalized_height_floor`
+/// saturates to genesis for the whole fixture: the finalized seam never moves
+/// off block 0 and the eviction/seam invariants become untestable (see
+/// zingolabs/zaino#1288). The eviction and seam invariants are scale-free, so
+/// exercising them at a tractable depth is sound; the production depth is
+/// covered by the integration suite, which reaches real chain heights.
+#[cfg(test)]
+pub(crate) const NON_FINALIZED_DEPTH: u32 = 100;
 
 /// Lower bound on zaino's finalized-DB tip, derived from the current
 /// best-known chain tip.

--- a/packages/zaino-state/src/chain_index/CONTEXT.md
+++ b/packages/zaino-state/src/chain_index/CONTEXT.md
@@ -1,0 +1,34 @@
+# Chain Index — glossary
+
+Canonical terms for the chain-index domain. Glossary only: no implementation
+details, no design decisions. When a term below conflicts with usage in code
+or discussion, this file wins until deliberately revised.
+
+## Non-finalized state (NFS)
+The in-memory cache of blocks within the reorg-possible window near the chain
+tip. Holds full blocks, may temporarily hold competing branches.
+
+## Finalized state
+The on-disk store of blocks deep enough below the tip to be considered
+irreversible. Append-only: never incrementally rolled back.
+
+## Non-finalized depth
+The size of the reorg-possible window, in blocks below the best-known tip.
+Tracks the validator's (zebra's) maximum reorg height. Blocks within this
+depth of the tip live in the NFS; blocks below it are finalized.
+
+## Finalized floor
+The height below which blocks are finalized and therefore evicted from the
+NFS. Derived from the best-known tip minus the non-finalized depth, clamped
+at genesis. After a chain-shortening reorg the floor can move backward while
+the on-disk finalized height does not.
+
+## Seam
+The single height at which the NFS's lowest retained block meets the
+finalized state's tip. The two layers must reference the same block at this
+height — the seam is where they overlap, not a gap or an overlap of many
+blocks.
+
+## Eviction
+Removal of a block from the NFS once the finalized floor rises past its
+height. A block is evicted when it passes below the seam.

--- a/packages/zaino-state/src/chain_index/tests/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/tests/non_finalised_state.rs
@@ -229,8 +229,6 @@ async fn shutdown_terminates_sync_loop_cleanly() {
 /// land in iter N+1 (which would compute the correct post-mine finalized
 /// height and trim properly).
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "Fails due to finalized height never reached. \
-See https://github.com/zingolabs/zaino/issues/1288"]
 async fn race_pre_mine_finalized_height_block_is_evicted_when_source_advances_mid_iter() {
     let (_blocks, _indexer, index_reader, mockchain) =
         load_test_vectors_and_sync_chain_index(MockchainMode::Active).await;

--- a/packages/zaino-state/src/chain_index/tests/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/tests/non_finalised_state.rs
@@ -229,12 +229,14 @@ async fn shutdown_terminates_sync_loop_cleanly() {
 /// land in iter N+1 (which would compute the correct post-mine finalized
 /// height and trim properly).
 #[tokio::test(flavor = "multi_thread")]
+#[ignore = "Fails due to finalized height never reached. \
+See https://github.com/zingolabs/zaino/issues/1288"]
 async fn race_pre_mine_finalized_height_block_is_evicted_when_source_advances_mid_iter() {
     let (_blocks, _indexer, index_reader, mockchain) =
         load_test_vectors_and_sync_chain_index(MockchainMode::Active).await;
 
     let initial_active = mockchain.active_height();
-    let pre_mine_finalized_height = finalized_height_floor(initial_active);
+    let pre_mine_finalized_height = dbg!(finalized_height_floor(initial_active));
 
     let initial_snapshot = index_reader.snapshot_nonfinalized_state().await.unwrap();
     let initial_nfs = initial_snapshot

--- a/packages/zaino-state/src/chain_index/tests/proptest_blockgen.rs
+++ b/packages/zaino-state/src/chain_index/tests/proptest_blockgen.rs
@@ -23,7 +23,7 @@ use zebra_rpc::{
     client::{GetAddressBalanceRequest, GetAddressTxIdsRequest},
     methods::{AddressBalance, GetAddressUtxos},
 };
-use zebra_state::{FromDisk, HashOrHeight, IntoDisk as _, MAX_BLOCK_REORG_HEIGHT};
+use zebra_state::{FromDisk, HashOrHeight, IntoDisk as _};
 
 use crate::{
     chain_index::{
@@ -32,7 +32,7 @@ use crate::{
         source::{BlockchainSourceResult, GetTransactionLocation},
         tests::{init_tracing, poll::poll_until, proptest_blockgen::proptest_helpers::add_segment},
         types::BestChainLocation,
-        NonFinalizedSnapshot,
+        NonFinalizedSnapshot, NON_FINALIZED_DEPTH,
     },
     BlockHash, BlockchainSource, ChainIndex, ChainIndexConfig, NodeBackedChainIndex,
     NodeBackedChainIndexSubscriber, TransactionHash,
@@ -53,7 +53,7 @@ fn passthrough_test(
     init_tracing();
     let network = Network::Regtest(ActivationHeights::default());
     // Long enough to have some finalized blocks to play with
-    let segment_length = MAX_BLOCK_REORG_HEIGHT as usize + 20;
+    let segment_length = NON_FINALIZED_DEPTH as usize + 20;
     // No need to worry about non-best chains for this test
     let branch_count = 1;
 
@@ -94,8 +94,12 @@ fn passthrough_test(
                 .await
                 .unwrap();
             let index_reader = indexer.subscriber();
-            // + 1 as heights are 0-indexed. + an additional one due to a + 1 in some other constant definition.
-            let expected_max_serviceable_height = (2 * segment_length) - (MAX_BLOCK_REORG_HEIGHT as usize + 2);
+            // The best chain is `2 * segment_length` blocks (genesis segment +
+            // one branch), so its tip height is `2 * segment_length - 1`. The
+            // serviceable cutoff is the finalized floor at that tip — mirror
+            // production's `finalized_height_floor` exactly.
+            let tip_height = (2 * segment_length - 1) as u32;
+            let expected_max_serviceable_height = finalized_height_floor(tip_height).0 as usize;
             // Poll rather than sleeping a fixed 5 s: the indexer discovers the
             // chain topology as soon as the sync task has walked enough of the
             // source to identify the finalized-state cutoff. With a 1 s

--- a/packages/zaino-state/src/chain_index/tests/proptest_blockgen.rs
+++ b/packages/zaino-state/src/chain_index/tests/proptest_blockgen.rs
@@ -23,7 +23,7 @@ use zebra_rpc::{
     client::{GetAddressBalanceRequest, GetAddressTxIdsRequest},
     methods::{AddressBalance, GetAddressUtxos},
 };
-use zebra_state::{FromDisk, HashOrHeight, IntoDisk as _};
+use zebra_state::{FromDisk, HashOrHeight, IntoDisk as _, MAX_BLOCK_REORG_HEIGHT};
 
 use crate::{
     chain_index::{
@@ -53,7 +53,7 @@ fn passthrough_test(
     init_tracing();
     let network = Network::Regtest(ActivationHeights::default());
     // Long enough to have some finalized blocks to play with
-    let segment_length = 120;
+    let segment_length = MAX_BLOCK_REORG_HEIGHT as usize + 20;
     // No need to worry about non-best chains for this test
     let branch_count = 1;
 
@@ -94,8 +94,8 @@ fn passthrough_test(
                 .await
                 .unwrap();
             let index_reader = indexer.subscriber();
-            // 101 instead of 100 as heights are 0-indexed
-            let expected_max_serviceable_height = (2 * segment_length) - 101;
+            // + 1 as heights are 0-indexed. + an additional one due to a + 1 in some other constant definition.
+            let expected_max_serviceable_height = (2 * segment_length) - (MAX_BLOCK_REORG_HEIGHT as usize + 2);
             // Poll rather than sleeping a fixed 5 s: the indexer discovers the
             // chain topology as soon as the sync task has walked enough of the
             // source to identify the finalized-state cutoff. With a 1 s


### PR DESCRIPTION
Fixes:  #1288

This does not fix issues in the integration tests.

We'll keep a back-compatibility patch for tests that are impractical or inaccurate with a 1_000 block reorg bound, and begin adding tests that specifically enforce invariants that are scale dependent.

See https://github.com/zingolabs/zaino/issues/1292 for planned work.