### PR TITLE
Stopgap while integration-tests are restructured.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,16 @@ debug = true
 #zcash_protocol = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
 #zcash_transparent = { git = "https://github.com/zcash/librustzcash", tag = "zcash_client_backend-0.21.0"}
 
+# TEMPORARY: zebra is pinned to an unreleased ZcashFoundation/zebra rev whose
+# ReadRequest::NonFinalizedBlocksListener is a struct variant carrying
+# `known_chain_tips` (its Cargo version is 9.0.1, but it is NOT the published
+# crates.io 9.0.1 — that one is still a unit variant). Revert to a plain
+# version requirement once the change is released. This patch MUST be mirrored
+# in every workspace that builds zaino-state — integration-tests/Cargo.toml and
+# integration-tests/wallet-tests/Cargo.toml — because zaino-state is a path
+# dependency and compiles against the host workspace's patched zebra; any skew
+# compiles it against the crates.io unit variant and fails with E0559. See
+# docs/updating_zebra_crates.md. Tracking: zaino#<TODO-revert-zebra-fork>.
 zebra-chain = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "9a27f886a5bfb143f65d1712e912cef252426800" }
 zebra-rpc = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "9a27f886a5bfb143f65d1712e912cef252426800" }
 zebra-state = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "9a27f886a5bfb143f65d1712e912cef252426800" }

--- a/docs/updating_zebra_crates.md
+++ b/docs/updating_zebra_crates.md
@@ -35,16 +35,52 @@ Find out which dependencies use `zebra-*` crates by running
 Make sure you build and run the project with `all-features` in
 order to catch any posible compile errors early.
 
-## Updating Zingo dependencies.
-Zaino makes use of ZingoLabs tooling extensively. This means that
-when updating a major dependency on Zaino, "different versions of
-crate {NAME} are being used" kind of errors. Use `cargo tree` to
-find out the crate {NAME} usage and evaluate a highest common denominator
-to update all the affected dependencies to that version.
+## Keep the zebra pin in sync across all three workspaces
+
+This repo is **three separate Cargo workspaces**, each with its own
+`Cargo.lock`:
+
+- `Cargo.toml` — the root/production workspace (`packages/*`).
+- `integration-tests/Cargo.toml` — the walletless-tests workspace.
+- `integration-tests/wallet-tests/Cargo.toml` — the wallet-tests workspace.
+
+The production crates (notably `zaino-state`) are consumed by both
+integration-test workspaces as **path dependencies**. A path dependency
+is compiled against the **host workspace's** dependency resolution — not
+the root's. So a `[patch.crates-io]` (or version bump) applied only to the
+root `Cargo.toml` does **not** reach `zaino-state` when it is built inside
+an integration-test workspace; that workspace resolves whatever the plain
+version requirement points at (a crates.io release).
+
+Consequence: any change to the zebra pin — a version bump, or pinning to a
+git rev — **must be applied identically in all three manifests**. If they
+drift, the same `zaino-state` source compiles against two different zebra
+versions and you get errors like `E0559` (a field/variant that exists on
+one zebra version but not the other), typically surfacing first in a
+container test run rather than in `cargo check` at the root.
+
+## Pinning to an unreleased zebra (git rev)
+
+Sometimes Zaino needs a zebra change that has not yet been published to
+crates.io (for example, a new field on a `ReadRequest` variant). In that
+case the `[patch.crates-io]` entries point `zebra-chain` / `zebra-rpc` /
+`zebra-state` at a specific `ZcashFoundation/zebra.git` rev instead of a
+published version.
+
+When you do this:
+
+1. Mirror the **exact same** patch block into all three workspace
+   manifests (see the section above) — the git source carries a Cargo
+   version that can equal a published version while differing in content
+   (e.g. an unreleased `9.0.1` that is not the crates.io `9.0.1`).
+2. Add an inline comment at each patch site explaining *why* the pin is a
+   git rev, and reference a tracking issue to revert to a plain version
+   once the upstream change is released. Pinning to an unreleased rev is
+   tech debt; it should not outlive the release that obsoletes it.
 
 ## Juggling transitive dependencies
 ### Tonic
-Tonic is used in Zebra, Zaino, ZingoLib and Librustzcash. This one is
+Tonic is used in Zebra, Zaino and Librustzcash. This one is
 going to be a challenge. Priotize what works with Zebra and then work
 your way down the stack. Tonic can break the `.proto` files downstream if
 you notice that there are significant issues consult with Zebra and
@@ -52,10 +88,12 @@ you notice that there are significant issues consult with Zebra and
 
 ### Prost
 Prost is used in conjunction with `tonic` to build gRPC .rs files from `.proto` files
-it is also used accross many crates like `zaino-proto`, `zerba-rpc`, zingo `infrastructure` and `zaino-integration-tests`. Zaino can't build without reliably generating the files so it's
+it is also used accross many crates like `zaino-proto` and `zebra-rpc`. Zaino can't build
+without reliably generating the files so it's
 important to figure this dependency graph out.
 
 ## Updating Librustzcash dependencies.
-Always try to stick with the latest tag you can find. Although given Zebra uses Librustzcash
-as well as ZingoLib, these may clash. Strategy here is to find the highest common denominator
-for the two in a per-crate basis.
+Always try to stick with the latest tag you can find. Zebra uses Librustzcash
+as well, so a zebra update can force a librustzcash update. Find the highest
+common denominator across the zebra-pinned librustzcash crates on a per-crate
+basis.

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -71,3 +71,14 @@ zip32 = "0.2.1"
 [profile.test]
 opt-level = 3
 debug = true
+
+# Mirror of root Cargo.toml [patch.crates-io]: pins zebra to an unreleased rev
+# that makes ReadRequest::NonFinalizedBlocksListener a struct variant carrying
+# `known_chain_tips`. All workspaces that build zaino-state must carry the
+# identical patch (zaino-state is a path dep — it compiles against the host
+# workspace's patched zebra). See docs/updating_zebra_crates.md. Tracking:
+# zaino#<TODO-revert-zebra-fork>.
+[patch.crates-io]
+zebra-chain = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "9a27f886a5bfb143f65d1712e912cef252426800" }
+zebra-rpc = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "9a27f886a5bfb143f65d1712e912cef252426800" }
+zebra-state = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "9a27f886a5bfb143f65d1712e912cef252426800" }

--- a/integration-tests/wallet-tests/Cargo.toml
+++ b/integration-tests/wallet-tests/Cargo.toml
@@ -69,3 +69,14 @@ serde_json = "1.0"
 [profile.test]
 opt-level = 3
 debug = true
+
+# Mirror of root Cargo.toml [patch.crates-io]: pins zebra to an unreleased rev
+# that makes ReadRequest::NonFinalizedBlocksListener a struct variant carrying
+# `known_chain_tips`. All workspaces that build zaino-state must carry the
+# identical patch (zaino-state is a path dep — it compiles against the host
+# workspace's patched zebra). See docs/updating_zebra_crates.md. Tracking:
+# zaino#<TODO-revert-zebra-fork>.
+[patch.crates-io]
+zebra-chain = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "9a27f886a5bfb143f65d1712e912cef252426800" }
+zebra-rpc = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "9a27f886a5bfb143f65d1712e912cef252426800" }
+zebra-state = { git = "https://github.com/ZcashFoundation/zebra.git", rev = "9a27f886a5bfb143f65d1712e912cef252426800" }


### PR DESCRIPTION
wallet-less tests are temporarily broken.

I am going to re-unitfy workspaces now that zingolib is excised.

  Mirror zebra [patch.crates-io] fork pin into both integration-test workspaces

  zaino-state consumes the unreleased zebra rev 9a27f886, where
  ReadRequest::NonFinalizedBlocksListener is a struct variant carrying
  `known_chain_tips`. The root workspace patches zebra to that rev, but the
  walletless and wallet-tests workspaces did not — and zaino-state is a path
  dependency, so it compiles against the host workspace's patched zebra. With
  no patch there, those workspaces resolved the crates.io 9.0.1 unit variant
  and the build failed in-container with E0559 (no field `known_chain_tips`).

  Add the identical [patch.crates-io] zebra block (chain/rpc/state @ 9a27f886)
  to integration-tests/Cargo.toml and integration-tests/wallet-tests/Cargo.toml,
  and a rationale comment at the root patch site. zingolib is fully purged, so
  wallet-tests takes the fork patch with no dup-zebra conflict.

  Document the cross-workspace patch-sync rule and the unreleased-rev pinning
  practice in docs/updating_zebra_crates.md, and drop the obsolete zingolib
  sections.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>