### PR TITLE
Bump versions for 0.4.2-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-fetch"
-version = "0.2.0"
+version = "0.2.1-rc.1"
 dependencies = [
  "base64",
  "byteorder",
@@ -5596,7 +5596,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-serve"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-state"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5671,7 +5671,7 @@ dependencies = [
 
 [[package]]
 name = "zainod"
-version = "0.4.1"
+version = "0.4.2-rc.1"
 dependencies = [
  "clap",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,10 +125,10 @@ portpicker = "0.1"
 tempfile = "3.2"
 zainod = { path = "packages/zainod" }
 zaino-common = { path = "packages/zaino-common", version = "0.2.0" }
-zaino-fetch = { path = "packages/zaino-fetch", version = "0.2.0" }
+zaino-fetch = { path = "packages/zaino-fetch", version = "0.2.1-rc.1" }
 zaino-proto = { path = "packages/zaino-proto", version = "0.1.3" }
-zaino-state = { path = "packages/zaino-state", version = "0.3.0" }
-zaino-serve = { path = "packages/zaino-serve", version = "0.3.0" }
+zaino-state = { path = "packages/zaino-state", version = "0.3.1-rc.1" }
+zaino-serve = { path = "packages/zaino-serve", version = "0.3.1-rc.1" }
 wire_serialized_transaction_test_data = "1.0.0"
 config = { version = "0.15", default-features = false, features = ["toml"] }
 nonempty = "0.11.0"

--- a/packages/zaino-fetch/Cargo.toml
+++ b/packages/zaino-fetch/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.0"
+version = "0.2.1-rc.1"
 
 [features]
 default = []

--- a/packages/zaino-serve/Cargo.toml
+++ b/packages/zaino-serve/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.0"
+version = "0.3.1-rc.1"
 
 [features]
 # Removes network restrictions.

--- a/packages/zaino-state/Cargo.toml
+++ b/packages/zaino-state/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.0"
+version = "0.3.1-rc.1"
 
 [features]
 default = []

--- a/packages/zainod/Cargo.toml
+++ b/packages/zainod/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.1"
+version = "0.4.2-rc.1"
 
 [[bin]]
 name = "zainod"


### PR DESCRIPTION
## Summary

Bump crate versions for the 0.4.2 release candidate:

- zainod 0.4.1 → 0.4.2-rc.1
- zaino-state 0.3.0 → 0.3.1-rc.1
- zaino-serve 0.3.0 → 0.3.1-rc.1
- zaino-fetch 0.2.0 → 0.2.1-rc.1

Unchanged: zaino-proto (0.1.3), zaino-common (0.2.0)

## Process friction note

This version bump should not require a PR. The current branch protection
on `rc/*` forces a merge commit for what is a routine, mechanical version
bump + tag operation — adding 2 commits (bump + merge) for zero-review-value
work. This is a strong signal that version bumping and rc tagging should be
a CI workflow (knope + post-merge hook), not a manual contributor step.
Contributors should PR their changes normally; the pipeline should handle
versions and tags on merge.