### PR TITLE
Release 0.4.2: Prometheus metrics and structured tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5563,6 +5563,7 @@ dependencies = [
  "http",
  "indexmap 2.14.0",
  "jsonrpsee-types",
+ "metrics",
  "prost",
  "reqwest",
  "serde",
@@ -5599,6 +5600,7 @@ version = "0.3.0"
 dependencies = [
  "futures",
  "jsonrpsee",
+ "metrics",
  "serde",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2478,6 +2478,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7399781913e5393588a8d8c6a2867bf85fb38eaf2502fdce465aad2dc6f034"
+dependencies = [
+ "base64",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "indexmap 2.14.0",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8496cc523d1f94c1385dd8f0f0c2c480b2b8aeccb5b7e4485ad6365523ae376"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.5",
+ "metrics",
+ "quanta",
+ "rand 0.9.4",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3142,6 +3178,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3362,12 +3413,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rapidhash"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4098,6 +4167,12 @@ name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -5139,6 +5214,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-core"
 version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5534,6 +5631,7 @@ dependencies = [
  "indexmap 2.14.0",
  "lmdb",
  "lmdb-sys",
+ "metrics",
  "nonempty",
  "once_cell",
  "primitive-types 0.13.1",
@@ -5576,6 +5674,8 @@ dependencies = [
  "clap",
  "config",
  "http",
+ "metrics",
+ "metrics-exporter-prometheus",
  "serde",
  "tempfile",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-fetch"
-version = "0.2.0"
+version = "0.2.1-rc.1"
 dependencies = [
  "base64",
  "byteorder",
@@ -5596,7 +5596,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-serve"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-state"
-version = "0.3.0"
+version = "0.3.1-rc.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5671,7 +5671,7 @@ dependencies = [
 
 [[package]]
 name = "zainod"
-version = "0.4.1"
+version = "0.4.2-rc.1"
 dependencies = [
  "clap",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,10 @@ async-stream = "0.3"
 async-trait = "0.1"
 futures = "0.3.30"
 
+# Metrics
+metrics = "0.24"
+metrics-exporter-prometheus = { version = "0.16", default-features = false, features = ["http-listener"] }
+
 # Utility
 thiserror = "1.0"
 lazy-regex = "3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,10 +125,10 @@ portpicker = "0.1"
 tempfile = "3.2"
 zainod = { path = "packages/zainod" }
 zaino-common = { path = "packages/zaino-common", version = "0.2.0" }
-zaino-fetch = { path = "packages/zaino-fetch", version = "0.2.0" }
+zaino-fetch = { path = "packages/zaino-fetch", version = "0.2.1-rc.1" }
 zaino-proto = { path = "packages/zaino-proto", version = "0.1.3" }
-zaino-state = { path = "packages/zaino-state", version = "0.3.0" }
-zaino-serve = { path = "packages/zaino-serve", version = "0.3.0" }
+zaino-state = { path = "packages/zaino-state", version = "0.3.1-rc.1" }
+zaino-serve = { path = "packages/zaino-serve", version = "0.3.1-rc.1" }
 wire_serialized_transaction_test_data = "1.0.0"
 config = { version = "0.15", default-features = false, features = ["toml"] }
 nonempty = "0.11.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ WORKDIR /app
 # Toggle to build without TLS feature if needed
 ARG NO_TLS=false
 
+# Extra cargo features to enable (comma-separated, e.g. "prometheus,no_tls_with_prometheus").
+# Takes precedence over NO_TLS when set.
+ARG CARGO_FEATURES=""
+
 # Build deps incl. protoc for prost-build
 RUN apt-get update && apt-get install -y --no-install-recommends \
       pkg-config clang cmake make libssl-dev ca-certificates \
@@ -37,7 +41,9 @@ COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/app/target \
-    if [ "${NO_TLS}" = "true" ]; then \
+    if [ -n "${CARGO_FEATURES}" ]; then \
+      cargo install --locked --path packages/zainod --bin zainod --root /out --features "${CARGO_FEATURES}"; \
+    elif [ "${NO_TLS}" = "true" ]; then \
       cargo install --locked --path packages/zainod --bin zainod --root /out --features no_tls_use_unencrypted_traffic; \
     else \
       cargo install --locked --path packages/zainod --bin zainod --root /out; \

--- a/packages/zaino-fetch/Cargo.toml
+++ b/packages/zaino-fetch/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.0"
+version = "0.2.1-rc.1"
 
 [features]
 default = []

--- a/packages/zaino-fetch/Cargo.toml
+++ b/packages/zaino-fetch/Cargo.toml
@@ -8,6 +8,12 @@ edition = { workspace = true }
 license = { workspace = true }
 version = "0.2.0"
 
+[features]
+default = []
+
+# Prometheus metrics emission (outbound RPC request counting / latency).
+prometheus = ["metrics"]
+
 [dependencies]
 zaino-common = { workspace = true }
 zaino-proto = { workspace = true }
@@ -18,6 +24,9 @@ zebra-rpc = { workspace = true }
 
 # Tracing
 tracing = { workspace = true }
+
+# Metrics
+metrics = { workspace = true, optional = true }
 
 # Miscellaneous Workspace
 tokio = { workspace = true, features = ["full"] }

--- a/packages/zaino-fetch/src/jsonrpsee/connector.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/connector.rs
@@ -1044,7 +1044,7 @@ pub async fn test_node_and_return_url(
         }
         interval.tick().await;
     }
-    error!("Error: Zainod needs to connect to a zcash Validator node. (either zcashd or zebrad). Failed to connect to a Validator at {url}. Perhaps the Validator is not running or perhaps there was an authentication error.");
+    error!(%url, "failed to connect to validator node — is zcashd/zebrad running? check authentication");
     std::process::exit(1);
 }
 

--- a/packages/zaino-fetch/src/jsonrpsee/connector.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/connector.rs
@@ -300,6 +300,8 @@ impl JsonRpSeeConnector {
         R::RpcError: Send + Sync + 'static,
     {
         let id = self.id_counter.fetch_add(1, Ordering::SeqCst);
+        #[cfg(feature = "prometheus")]
+        let _rpc_start = std::time::Instant::now();
 
         let max_attempts = 5;
         let mut attempts = 0;
@@ -326,14 +328,28 @@ impl JsonRpSeeConnector {
 
             if body_str.contains("Work queue depth exceeded") {
                 if attempts >= max_attempts {
+                    #[cfg(feature = "prometheus")]
+                    {
+                        let m = method.to_owned();
+                        metrics::counter!("zaino.rpc.outbound.requests_total", "method" => m.clone())
+                            .increment(1);
+                        metrics::histogram!("zaino.rpc.outbound.request_duration_seconds", "method" => m.clone())
+                            .record(_rpc_start.elapsed().as_secs_f64());
+                        metrics::counter!("zaino.rpc.outbound.errors_total", "method" => m)
+                            .increment(1);
+                    }
                     return Err(RpcRequestError::ServerWorkQueueFull);
                 }
+                #[cfg(feature = "prometheus")]
+                metrics::counter!("zaino.rpc.outbound.retries_total", "method" => method.to_owned())
+                    .increment(1);
                 tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                 continue;
             }
 
             let code = status.as_u16();
-            return match code {
+            #[allow(unused_variables)]
+            let rpc_result = match code {
                 // Invalid
                 ..100 | 600.. => Err(RpcRequestError::Transport(
                     TransportError::InvalidStatusCode(code),
@@ -369,6 +385,21 @@ impl JsonRpSeeConnector {
                     code,
                 ))),
             };
+
+            #[cfg(feature = "prometheus")]
+            {
+                let m = method.to_owned();
+                metrics::counter!("zaino.rpc.outbound.requests_total", "method" => m.clone())
+                    .increment(1);
+                metrics::histogram!("zaino.rpc.outbound.request_duration_seconds", "method" => m.clone())
+                    .record(_rpc_start.elapsed().as_secs_f64());
+                if rpc_result.is_err() {
+                    metrics::counter!("zaino.rpc.outbound.errors_total", "method" => m)
+                        .increment(1);
+                }
+            }
+
+            return rpc_result;
         }
     }
 

--- a/packages/zaino-fetch/src/jsonrpsee/connector.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/connector.rs
@@ -46,6 +46,9 @@ use crate::jsonrpsee::{
 
 use super::response::{GetDifficultyResponse, GetNetworkSolPsResponse};
 
+#[cfg(feature = "prometheus")]
+use crate::metric_names::*;
+
 #[derive(Serialize, Deserialize, Debug)]
 struct RpcRequest<T> {
     jsonrpc: String,
@@ -194,6 +197,19 @@ pub struct JsonRpSeeConnector {
     auth_method: AuthMethod,
 }
 
+/// Emit the standard outbound-JSON-RPC metric triple for one completed request:
+/// request count, request duration, and — when `is_err` — an error count. Keyed
+/// by method so the emission lives in exactly one place.
+#[cfg(feature = "prometheus")]
+fn record_outbound_rpc_metrics(method: &'static str, start: std::time::Instant, is_err: bool) {
+    metrics::counter!(RPC_OUTBOUND_REQUESTS_TOTAL, "method" => method).increment(1);
+    metrics::histogram!(RPC_OUTBOUND_REQUEST_DURATION_SECONDS, "method" => method)
+        .record(start.elapsed().as_secs_f64());
+    if is_err {
+        metrics::counter!(RPC_OUTBOUND_ERRORS_TOTAL, "method" => method).increment(1);
+    }
+}
+
 impl JsonRpSeeConnector {
     /// Creates a new JsonRpSeeConnector with Basic Authentication.
     pub fn new_with_basic_auth(
@@ -293,7 +309,7 @@ impl JsonRpSeeConnector {
         R: std::fmt::Debug + for<'de> Deserialize<'de> + ResponseToError,
     >(
         &self,
-        method: &str,
+        method: &'static str,
         params: T,
     ) -> Result<R, RpcRequestError<R::RpcError>>
     where
@@ -301,7 +317,7 @@ impl JsonRpSeeConnector {
     {
         let id = self.id_counter.fetch_add(1, Ordering::SeqCst);
         #[cfg(feature = "prometheus")]
-        let _rpc_start = std::time::Instant::now();
+        let rpc_start = std::time::Instant::now();
 
         let max_attempts = 5;
         let mut attempts = 0;
@@ -329,26 +345,16 @@ impl JsonRpSeeConnector {
             if body_str.contains("Work queue depth exceeded") {
                 if attempts >= max_attempts {
                     #[cfg(feature = "prometheus")]
-                    {
-                        let m = method.to_owned();
-                        metrics::counter!("zaino.rpc.outbound.requests_total", "method" => m.clone())
-                            .increment(1);
-                        metrics::histogram!("zaino.rpc.outbound.request_duration_seconds", "method" => m.clone())
-                            .record(_rpc_start.elapsed().as_secs_f64());
-                        metrics::counter!("zaino.rpc.outbound.errors_total", "method" => m)
-                            .increment(1);
-                    }
+                    record_outbound_rpc_metrics(method, rpc_start, true);
                     return Err(RpcRequestError::ServerWorkQueueFull);
                 }
                 #[cfg(feature = "prometheus")]
-                metrics::counter!("zaino.rpc.outbound.retries_total", "method" => method.to_owned())
-                    .increment(1);
+                metrics::counter!(RPC_OUTBOUND_RETRIES_TOTAL, "method" => method).increment(1);
                 tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                 continue;
             }
 
             let code = status.as_u16();
-            #[allow(unused_variables)]
             let rpc_result = match code {
                 // Invalid
                 ..100 | 600.. => Err(RpcRequestError::Transport(
@@ -387,17 +393,7 @@ impl JsonRpSeeConnector {
             };
 
             #[cfg(feature = "prometheus")]
-            {
-                let m = method.to_owned();
-                metrics::counter!("zaino.rpc.outbound.requests_total", "method" => m.clone())
-                    .increment(1);
-                metrics::histogram!("zaino.rpc.outbound.request_duration_seconds", "method" => m.clone())
-                    .record(_rpc_start.elapsed().as_secs_f64());
-                if rpc_result.is_err() {
-                    metrics::counter!("zaino.rpc.outbound.errors_total", "method" => m)
-                        .increment(1);
-                }
-            }
+            record_outbound_rpc_metrics(method, rpc_start, rpc_result.is_err());
 
             return rpc_result;
         }

--- a/packages/zaino-fetch/src/lib.rs
+++ b/packages/zaino-fetch/src/lib.rs
@@ -7,3 +7,14 @@
 
 pub mod chain;
 pub mod jsonrpsee;
+
+/// Prometheus metric names emitted by this crate; the single source of truth shared with `zainod`'s `describe_*` registrations (which carry the descriptions).
+#[cfg(feature = "prometheus")]
+#[allow(missing_docs)] // names are self-describing; descriptions live in zainod
+pub mod metric_names {
+    pub const RPC_OUTBOUND_REQUESTS_TOTAL: &str = "zaino.rpc.outbound.requests_total";
+    pub const RPC_OUTBOUND_REQUEST_DURATION_SECONDS: &str =
+        "zaino.rpc.outbound.request_duration_seconds";
+    pub const RPC_OUTBOUND_ERRORS_TOTAL: &str = "zaino.rpc.outbound.errors_total";
+    pub const RPC_OUTBOUND_RETRIES_TOTAL: &str = "zaino.rpc.outbound.retries_total";
+}

--- a/packages/zaino-serve/Cargo.toml
+++ b/packages/zaino-serve/Cargo.toml
@@ -12,6 +12,9 @@ version = "0.3.0"
 # Removes network restrictions.
 no_tls_use_unencrypted_traffic = ["tonic/tls-native-roots"]
 
+# Prometheus metrics emission (request counting / latency in gRPC handlers).
+prometheus = ["metrics"]
+
 # **Experimental and alpha features**
 # Exposes the **complete** set of experimental / alpha features currently implemented in Zaino.
 experimental_features = ["transparent_address_history_experimental"]
@@ -32,6 +35,9 @@ zebra-rpc = { workspace = true }
 
 # Tracing
 tracing = { workspace = true }
+
+# Metrics
+metrics = { workspace = true, optional = true }
 
 # Miscellaneous Workspace
 tokio = { workspace = true, features = ["full"] }

--- a/packages/zaino-serve/Cargo.toml
+++ b/packages/zaino-serve/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.0"
+version = "0.3.1-rc.1"
 
 [features]
 # Removes network restrictions.

--- a/packages/zaino-serve/src/lib.rs
+++ b/packages/zaino-serve/src/lib.rs
@@ -9,3 +9,12 @@
 
 pub mod rpc;
 pub mod server;
+
+/// Prometheus metric names emitted by this crate; the single source of truth shared with `zainod`'s `describe_*` registrations (which carry the descriptions).
+#[cfg(feature = "prometheus")]
+#[allow(missing_docs)] // names are self-describing; descriptions live in zainod
+pub mod metric_names {
+    pub const GRPC_REQUESTS_TOTAL: &str = "zaino.grpc.requests_total";
+    pub const GRPC_REQUEST_DURATION_SECONDS: &str = "zaino.grpc.request_duration_seconds";
+    pub const GRPC_ERRORS_TOTAL: &str = "zaino.grpc.errors_total";
+}

--- a/packages/zaino-serve/src/rpc/grpc/service.rs
+++ b/packages/zaino-serve/src/rpc/grpc/service.rs
@@ -111,12 +111,31 @@ macro_rules! implement_client_methods {
             {
                 info!(method = stringify!($method_name), "[TEST] received call");
                 Box::pin(async {
-                    Ok(
-                        // here we pass in pinbox, to optionally add
-                        // Box::pin to the returned response type for
-                        // streaming
-                        client_method_helper!($($streaming)? self __input $method_name)
-                    )
+                    #[cfg(feature = "prometheus")]
+                    let _grpc_start = std::time::Instant::now();
+
+                    let _grpc_result: std::result::Result<tonic::Response<$return>, tonic::Status> = async {
+                        Ok(client_method_helper!($($streaming)? self __input $method_name))
+                    }.await;
+
+                    #[cfg(feature = "prometheus")]
+                    {
+                        let _method: &str = stringify!($method_name);
+                        metrics::counter!("zaino.grpc.requests_total", "method" => _method)
+                            .increment(1);
+                        metrics::histogram!("zaino.grpc.request_duration_seconds", "method" => _method)
+                            .record(_grpc_start.elapsed().as_secs_f64());
+                        if let Err(ref _status) = _grpc_result {
+                            metrics::counter!(
+                                "zaino.grpc.errors_total",
+                                "method" => _method,
+                                "code" => _status.code().description(),
+                            )
+                            .increment(1);
+                        }
+                    }
+
+                    _grpc_result
                 })
             }
         )+
@@ -229,8 +248,11 @@ where
         'life0: 'async_trait,
         Self: 'async_trait,
     {
-        info!("[TEST] Received call of get_taddress_balance_stream.");
+        info!(method = "get_taddress_balance_stream", "[TEST] received call");
         Box::pin(async {
+            #[cfg(feature = "prometheus")]
+            let _grpc_start = std::time::Instant::now();
+
             let (channel_tx, channel_rx) =
                 tokio::sync::mpsc::channel::<Result<Address, tonic::Status>>(32);
             let mut request_stream = request.into_inner();
@@ -245,13 +267,34 @@ where
             });
             let address_stream = AddressStream::new(channel_rx);
 
-            Ok(tonic::Response::new(
-                self.service_subscriber
-                    .inner_ref()
-                    .get_taddress_balance_stream(address_stream)
-                    .await
-                    .map_err(Into::into)?,
-            ))
+            let _grpc_result: Result<tonic::Response<Balance>, tonic::Status> = async {
+                Ok(tonic::Response::new(
+                    self.service_subscriber
+                        .inner_ref()
+                        .get_taddress_balance_stream(address_stream)
+                        .await
+                        .map_err(Into::into)?,
+                ))
+            }
+            .await;
+
+            #[cfg(feature = "prometheus")]
+            {
+                metrics::counter!("zaino.grpc.requests_total", "method" => "get_taddress_balance_stream")
+                    .increment(1);
+                metrics::histogram!("zaino.grpc.request_duration_seconds", "method" => "get_taddress_balance_stream")
+                    .record(_grpc_start.elapsed().as_secs_f64());
+                if let Err(ref _status) = _grpc_result {
+                    metrics::counter!(
+                        "zaino.grpc.errors_total",
+                        "method" => "get_taddress_balance_stream",
+                        "code" => _status.code().description(),
+                    )
+                    .increment(1);
+                }
+            }
+
+            _grpc_result
         })
     }
 

--- a/packages/zaino-serve/src/rpc/grpc/service.rs
+++ b/packages/zaino-serve/src/rpc/grpc/service.rs
@@ -109,7 +109,7 @@ macro_rules! implement_client_methods {
                 'life: 'async_trait,
                 Self: 'async_trait,
             {
-                info!("[TEST] Received call of {}.", stringify!($method_name));
+                info!(method = stringify!($method_name), "[TEST] received call");
                 Box::pin(async {
                     Ok(
                         // here we pass in pinbox, to optionally add

--- a/packages/zaino-serve/src/rpc/grpc/service.rs
+++ b/packages/zaino-serve/src/rpc/grpc/service.rs
@@ -112,34 +112,48 @@ macro_rules! implement_client_methods {
                 info!(method = stringify!($method_name), "[TEST] received call");
                 Box::pin(async {
                     #[cfg(feature = "prometheus")]
-                    let _grpc_start = std::time::Instant::now();
+                    let grpc_start = std::time::Instant::now();
 
-                    let _grpc_result: std::result::Result<tonic::Response<$return>, tonic::Status> = async {
+                    // The inner `async {}.await` contains the `?` from
+                    // `client_method_helper!`, so an error is captured into
+                    // `grpc_result` (for metrics) rather than early-returning
+                    // from this outer future.
+                    let grpc_result: std::result::Result<tonic::Response<$return>, tonic::Status> = async {
                         Ok(client_method_helper!($($streaming)? self __input $method_name))
                     }.await;
 
                     #[cfg(feature = "prometheus")]
-                    {
-                        let _method: &str = stringify!($method_name);
-                        metrics::counter!("zaino.grpc.requests_total", "method" => _method)
-                            .increment(1);
-                        metrics::histogram!("zaino.grpc.request_duration_seconds", "method" => _method)
-                            .record(_grpc_start.elapsed().as_secs_f64());
-                        if let Err(ref _status) = _grpc_result {
-                            metrics::counter!(
-                                "zaino.grpc.errors_total",
-                                "method" => _method,
-                                "code" => _status.code().description(),
-                            )
-                            .increment(1);
-                        }
-                    }
+                    record_grpc_metrics(stringify!($method_name), grpc_start, &grpc_result);
 
-                    _grpc_result
+                    grpc_result
                 })
             }
         )+
     };
+}
+
+/// Emit the standard inbound-gRPC metric triple for one handler invocation:
+/// request count, request duration, and — on error — an error count keyed by
+/// status code. Shared by `implement_client_methods!` and the hand-written
+/// streaming handlers so the emission lives in exactly one place.
+#[cfg(feature = "prometheus")]
+fn record_grpc_metrics<T>(
+    method: &'static str,
+    start: std::time::Instant,
+    result: &Result<tonic::Response<T>, tonic::Status>,
+) {
+    use crate::metric_names::*;
+    metrics::counter!(GRPC_REQUESTS_TOTAL, "method" => method).increment(1);
+    metrics::histogram!(GRPC_REQUEST_DURATION_SECONDS, "method" => method)
+        .record(start.elapsed().as_secs_f64());
+    if let Err(status) = result {
+        metrics::counter!(
+            GRPC_ERRORS_TOTAL,
+            "method" => method,
+            "code" => status.code().description(),
+        )
+        .increment(1);
+    }
 }
 
 impl<Indexer: ZcashIndexer + LightWalletIndexer> CompactTxStreamer for GrpcClient<Indexer>
@@ -248,10 +262,13 @@ where
         'life0: 'async_trait,
         Self: 'async_trait,
     {
-        info!(method = "get_taddress_balance_stream", "[TEST] received call");
+        info!(
+            method = "get_taddress_balance_stream",
+            "[TEST] received call"
+        );
         Box::pin(async {
             #[cfg(feature = "prometheus")]
-            let _grpc_start = std::time::Instant::now();
+            let grpc_start = std::time::Instant::now();
 
             let (channel_tx, channel_rx) =
                 tokio::sync::mpsc::channel::<Result<Address, tonic::Status>>(32);
@@ -267,7 +284,7 @@ where
             });
             let address_stream = AddressStream::new(channel_rx);
 
-            let _grpc_result: Result<tonic::Response<Balance>, tonic::Status> = async {
+            let grpc_result: Result<tonic::Response<Balance>, tonic::Status> = async {
                 Ok(tonic::Response::new(
                     self.service_subscriber
                         .inner_ref()
@@ -279,22 +296,9 @@ where
             .await;
 
             #[cfg(feature = "prometheus")]
-            {
-                metrics::counter!("zaino.grpc.requests_total", "method" => "get_taddress_balance_stream")
-                    .increment(1);
-                metrics::histogram!("zaino.grpc.request_duration_seconds", "method" => "get_taddress_balance_stream")
-                    .record(_grpc_start.elapsed().as_secs_f64());
-                if let Err(ref _status) = _grpc_result {
-                    metrics::counter!(
-                        "zaino.grpc.errors_total",
-                        "method" => "get_taddress_balance_stream",
-                        "code" => _status.code().description(),
-                    )
-                    .increment(1);
-                }
-            }
+            record_grpc_metrics("get_taddress_balance_stream", grpc_start, &grpc_result);
 
-            _grpc_result
+            grpc_result
         })
     }
 

--- a/packages/zaino-serve/src/server/jsonrpc.rs
+++ b/packages/zaino-serve/src/server/jsonrpc.rs
@@ -118,7 +118,7 @@ impl JsonRpcServer {
 
         if let Some(dir) = &self.cookie_dir {
             if let Err(e) = remove_from_disk(dir) {
-                warn!("Error removing cookie: {e}");
+                warn!(%e, "error removing cookie");
             }
         }
 

--- a/packages/zaino-state/Cargo.toml
+++ b/packages/zaino-state/Cargo.toml
@@ -11,6 +11,9 @@ version = "0.3.0"
 [features]
 default = []
 
+# Prometheus metrics emission (gauge! calls in sync paths).
+prometheus = ["metrics"]
+
 # test_dependencies - Exposes internal functionality for testing.
 test_dependencies = []
 
@@ -44,6 +47,9 @@ zebra-rpc = { workspace = true }
 
 # Tracing
 tracing = { workspace = true }
+
+# Metrics
+metrics = { workspace = true, optional = true }
 
 # Documentation
 simple-mermaid = "0.2.0"

--- a/packages/zaino-state/Cargo.toml
+++ b/packages/zaino-state/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.0"
+version = "0.3.1-rc.1"
 
 [features]
 default = []

--- a/packages/zaino-state/src/backends/fetch.rs
+++ b/packages/zaino-state/src/backends/fetch.rs
@@ -1122,7 +1122,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
                             )))
                             .await
                         {
-                            warn!("GetBlockRange channel closed unexpectedly: {}", e);
+                            warn!(%e, "GetBlockRange channel closed unexpectedly");
                         };
                         return;
                     };
@@ -1160,7 +1160,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
                             {
                                 Ok(_) => {}
                                 Err(e) => {
-                                    warn!("GetBlockRange channel closed unexpectedly: {}", e);
+                                    warn!(%e, "GetBlockRange channel closed unexpectedly");
                                 }
                             }
                         }
@@ -1181,7 +1181,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
                                 {
                                     Ok(_) => {}
                                     Err(e) => {
-                                        warn!("GetBlockRange channel closed unexpectedly: {}", e);
+                                        warn!(%e, "GetBlockRange channel closed unexpectedly");
                                     }
                                 }
                             } else {
@@ -1191,7 +1191,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
                                     .await
                                     .is_err()
                                 {
-                                    warn!("GetBlockRangeStream closed unexpectedly: {}", e);
+                                    warn!(%e, "GetBlockRangeStream closed unexpectedly");
                                 }
                             }
                         }
@@ -1255,7 +1255,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
                             )))
                             .await
                         {
-                            warn!("GetBlockRangeNullifiers channel closed unexpectedly: {}", e);
+                            warn!(%e, "GetBlockRangeNullifiers channel closed unexpectedly");
                         };
                         return;
                     };
@@ -1307,7 +1307,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
                             {
                                 Ok(_) => {}
                                 Err(e) => {
-                                    warn!("GetBlockRange channel closed unexpectedly: {}", e);
+                                    warn!(%e, "GetBlockRange channel closed unexpectedly");
                                 }
                             }
                         }
@@ -1329,7 +1329,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
                                 {
                                     Ok(_) => {}
                                     Err(e) => {
-                                        warn!("GetBlockRange channel closed unexpectedly: {}", e);
+                                        warn!(%e, "GetBlockRange channel closed unexpectedly");
                                     }
                                 }
                             } else {
@@ -1340,7 +1340,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
                                     .await
                                     .is_err()
                                 {
-                                    warn!("GetBlockRangeStream closed unexpectedly: {}", e);
+                                    warn!(%e, "GetBlockRangeStream closed unexpectedly");
                                 }
                             }
                         }
@@ -1748,7 +1748,7 @@ impl LightWalletIndexer for FetchServiceSubscriber {
                             )))
                             .await
                         {
-                            warn!("GetMempoolStream channel closed unexpectedly: {}", e);
+                            warn!(%e, "GetMempoolStream channel closed unexpectedly");
                         };
                         return;
                     };

--- a/packages/zaino-state/src/backends/state.rs
+++ b/packages/zaino-state/src/backends/state.rs
@@ -625,7 +625,7 @@ impl StateServiceSubscriber {
                         {
                             Ok(_) => {}
                             Err(e) => {
-                                warn!("GetBlockRange channel closed unexpectedly: {}", e);
+                                warn!(%e, "GetBlockRange channel closed unexpectedly");
                             }
                         }
                     }
@@ -643,7 +643,7 @@ impl StateServiceSubscriber {
                             {
                                 Ok(_) => {}
                                 Err(e) => {
-                                    warn!("GetBlockRange channel closed unexpectedly: {}", e);
+                                    warn!(%e, "GetBlockRange channel closed unexpectedly");
                                 }
                             }
                         } else {
@@ -653,7 +653,7 @@ impl StateServiceSubscriber {
                                 .await
                                 .is_err()
                             {
-                                warn!("GetBlockRangeStream closed unexpectedly: {}", e);
+                                warn!(%e, "GetBlockRangeStream closed unexpectedly");
                             }
                         }
                     }
@@ -2399,7 +2399,7 @@ impl LightWalletIndexer for StateServiceSubscriber {
                     {
                         Ok(stream) => stream,
                         Err(e) => {
-                            warn!("Error fetching stream from mempool: {:?}", e);
+                            warn!(?e, "error fetching mempool stream");
                             channel_tx
                                 .send(Err(tonic::Status::internal("Error getting mempool stream")))
                                 .await

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -872,6 +872,8 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                                 "node returned no best block height",
                             ))
                         })?;
+                    #[cfg(feature = "prometheus")]
+                    metrics::gauge!("zaino.chain.tip_height").set(chain_height.0 as f64);
                     let finalised_height = finalized_height_floor(chain_height.0);
 
                     fs.sync_to_height(finalised_height, &source)

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -939,16 +939,19 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                         consecutive_failures += 1;
                         if consecutive_failures >= timings.max_consecutive_failures {
                             tracing::error!(
-                                "Sync loop failed {consecutive_failures} consecutive times, \
-                                 giving up: {e:?}"
+                                consecutive_failures,
+                                ?e,
+                                "sync loop failed, giving up"
                             );
                             status.store(StatusType::CriticalError);
                             return Err(e);
                         }
                         tracing::warn!(
-                            "Sync loop iteration failed ({consecutive_failures}/{}), \
-                             retrying in {current_backoff:?}: {e:?}",
-                            timings.max_consecutive_failures
+                            consecutive_failures,
+                            max = timings.max_consecutive_failures,
+                            backoff = ?current_backoff,
+                            ?e,
+                            "sync loop iteration failed, retrying"
                         );
                         status.store(StatusType::RecoverableError);
                         // Race the failure-path backoff sleep against

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -834,6 +834,8 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
             let mut change_rx = source.subscribe_to_blocks_received();
             let mut consecutive_failures: u32 = 0;
             let mut current_backoff = timings.initial_backoff;
+            #[cfg(feature = "prometheus")]
+            let mut has_reached_tip = false;
 
             loop {
                 let source = source.clone();
@@ -843,6 +845,8 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                 }
 
                 status.store(StatusType::Syncing);
+                #[cfg(feature = "prometheus")]
+                let iteration_start = std::time::Instant::now();
 
                 // Race the iter body against cancellation: any await inside
                 // — `source.get_best_block_height`, `fs.sync_to_height`,
@@ -873,7 +877,12 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                             ))
                         })?;
                     #[cfg(feature = "prometheus")]
-                    metrics::gauge!("zaino.chain.tip_height").set(chain_height.0 as f64);
+                    {
+                        metrics::gauge!("zaino.chain.tip_height").set(chain_height.0 as f64);
+                        let finalised_height_val = finalized_height_floor(chain_height.0);
+                        metrics::gauge!("zaino.sync.lag_blocks")
+                            .set((chain_height.0 - finalised_height_val.0) as f64);
+                    }
                     let finalised_height = finalized_height_floor(chain_height.0);
 
                     fs.sync_to_height(finalised_height, &source)
@@ -918,6 +927,22 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                         consecutive_failures = 0;
                         current_backoff = timings.initial_backoff;
                         status.store(StatusType::Ready);
+                        #[cfg(feature = "prometheus")]
+                        {
+                            metrics::counter!("zaino.sync.iterations_total").increment(1);
+                            metrics::histogram!("zaino.sync.iteration_duration_seconds")
+                                .record(iteration_start.elapsed().as_secs_f64());
+                            if !has_reached_tip {
+                                has_reached_tip = true;
+                                metrics::gauge!("zaino.sync.has_reached_tip").set(1.0);
+                                metrics::gauge!("zaino.sync.reached_tip_at").set(
+                                    std::time::SystemTime::now()
+                                        .duration_since(std::time::UNIX_EPOCH)
+                                        .map(|d| d.as_secs_f64())
+                                        .unwrap_or(0.0),
+                                );
+                            }
+                        }
                         // Race the post-success wait against cancellation
                         // and a source-change notification. `shutdown()`'s
                         // `cancel_token.cancel()` releases this immediately
@@ -937,7 +962,16 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                     }
                     Err(e) => {
                         consecutive_failures += 1;
+                        #[cfg(feature = "prometheus")]
+                        {
+                            metrics::counter!("zaino.sync.iterations_total").increment(1);
+                            metrics::histogram!("zaino.sync.iteration_duration_seconds")
+                                .record(iteration_start.elapsed().as_secs_f64());
+                        }
                         if consecutive_failures >= timings.max_consecutive_failures {
+                            #[cfg(feature = "prometheus")]
+                            metrics::counter!("zaino.sync.errors_total", "severity" => "critical")
+                                .increment(1);
                             tracing::error!(
                                 consecutive_failures,
                                 ?e,
@@ -954,6 +988,9 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                             "sync loop iteration failed, retrying"
                         );
                         status.store(StatusType::RecoverableError);
+                        #[cfg(feature = "prometheus")]
+                        metrics::counter!("zaino.sync.errors_total", "severity" => "recoverable")
+                            .increment(1);
                         // Race the failure-path backoff sleep against
                         // cancellation. Without this, `shutdown()` after
                         // `fs.shutdown()` would force the worker through

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -18,6 +18,8 @@ use crate::chain_index::types::helpers::{BlockMetadata, BlockWithMetadata, TreeR
 use crate::chain_index::types::BlockIndex;
 use crate::chain_index::types::{BestChainLocation, NonBestChainLocation};
 use crate::error::{ChainIndexError, ChainIndexErrorKind, FinalisedStateError};
+#[cfg(feature = "prometheus")]
+use crate::metric_names::*;
 use crate::status::Status;
 use crate::{
     ChainWork, CompactBlockStream, NamedAtomicStatus, NonFinalizedState, StatusType, SyncError,
@@ -85,6 +87,17 @@ pub(crate) const NON_FINALIZED_DEPTH: u32 = zebra_state::MAX_BLOCK_REORG_HEIGHT 
 /// (see zingolabs/zaino#1128).
 pub(crate) fn finalized_height_floor(chain_tip: u32) -> crate::Height {
     crate::Height(chain_tip.saturating_sub(NON_FINALIZED_DEPTH))
+}
+
+/// Current wall-clock time as a Unix timestamp in fractional seconds, for
+/// "event happened at" gauges. Falls back to `0.0` if the clock is before the
+/// Unix epoch (never in practice).
+#[cfg(feature = "prometheus")]
+pub(crate) fn unix_now_secs() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
 }
 
 /// Builds a zcashd-compatible `getchaintips` response from the local non-finalized snapshot.
@@ -876,14 +889,13 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                                 "node returned no best block height",
                             ))
                         })?;
+                    let finalised_height = finalized_height_floor(chain_height.0);
                     #[cfg(feature = "prometheus")]
                     {
-                        metrics::gauge!("zaino.chain.tip_height").set(chain_height.0 as f64);
-                        let finalised_height_val = finalized_height_floor(chain_height.0);
-                        metrics::gauge!("zaino.sync.lag_blocks")
-                            .set((chain_height.0 - finalised_height_val.0) as f64);
+                        metrics::gauge!(CHAIN_TIP_HEIGHT).set(chain_height.0 as f64);
+                        metrics::gauge!(SYNC_LAG_BLOCKS)
+                            .set((chain_height.0 - finalised_height.0) as f64);
                     }
-                    let finalised_height = finalized_height_floor(chain_height.0);
 
                     fs.sync_to_height(finalised_height, &source)
                         .await
@@ -929,18 +941,13 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                         status.store(StatusType::Ready);
                         #[cfg(feature = "prometheus")]
                         {
-                            metrics::counter!("zaino.sync.iterations_total").increment(1);
-                            metrics::histogram!("zaino.sync.iteration_duration_seconds")
+                            metrics::counter!(SYNC_ITERATIONS_TOTAL).increment(1);
+                            metrics::histogram!(SYNC_ITERATION_DURATION_SECONDS)
                                 .record(iteration_start.elapsed().as_secs_f64());
                             if !has_reached_tip {
                                 has_reached_tip = true;
-                                metrics::gauge!("zaino.sync.has_reached_tip").set(1.0);
-                                metrics::gauge!("zaino.sync.reached_tip_at").set(
-                                    std::time::SystemTime::now()
-                                        .duration_since(std::time::UNIX_EPOCH)
-                                        .map(|d| d.as_secs_f64())
-                                        .unwrap_or(0.0),
-                                );
+                                metrics::gauge!(SYNC_HAS_REACHED_TIP).set(1.0);
+                                metrics::gauge!(SYNC_REACHED_TIP_AT).set(unix_now_secs());
                             }
                         }
                         // Race the post-success wait against cancellation
@@ -964,13 +971,13 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                         consecutive_failures += 1;
                         #[cfg(feature = "prometheus")]
                         {
-                            metrics::counter!("zaino.sync.iterations_total").increment(1);
-                            metrics::histogram!("zaino.sync.iteration_duration_seconds")
+                            metrics::counter!(SYNC_ITERATIONS_TOTAL).increment(1);
+                            metrics::histogram!(SYNC_ITERATION_DURATION_SECONDS)
                                 .record(iteration_start.elapsed().as_secs_f64());
                         }
                         if consecutive_failures >= timings.max_consecutive_failures {
                             #[cfg(feature = "prometheus")]
-                            metrics::counter!("zaino.sync.errors_total", "severity" => "critical")
+                            metrics::counter!(SYNC_ERRORS_TOTAL, "severity" => "critical")
                                 .increment(1);
                             tracing::error!(
                                 consecutive_failures,
@@ -989,7 +996,7 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                         );
                         status.store(StatusType::RecoverableError);
                         #[cfg(feature = "prometheus")]
-                        metrics::counter!("zaino.sync.errors_total", "severity" => "recoverable")
+                        metrics::counter!(SYNC_ERRORS_TOTAL, "severity" => "recoverable")
                             .increment(1);
                         // Race the failure-path backoff sleep against
                         // cancellation. Without this, `shutdown()` after

--- a/packages/zaino-state/src/chain_index/finalised_state/db.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db.rs
@@ -136,7 +136,7 @@ pub(super) trait LmdbLifecycle: Sync {
             _ = sleep(Duration::from_secs(5)) => {},
             _ = maintenance.tick() => {
                 if let Err(e) = self.clean_trailing().await {
-                    warn!("clean_trailing failed: {}", e);
+                    warn!(%e, "clean_trailing failed");
                 }
             }
             _ = self.cancel_token().cancelled() => {},
@@ -161,7 +161,7 @@ pub(super) trait LmdbLifecycle: Sync {
                     match res {
                         Ok(_) => {}
                         Err(e) if e.is_cancelled() => {}
-                        Err(e) => warn!("background task ended with error: {e:?}"),
+                        Err(e) => warn!(?e, "background task ended with error"),
                     }
                 }
                 _ = &mut timeout => {
@@ -173,7 +173,7 @@ pub(super) trait LmdbLifecycle: Sync {
 
         let _ = self.clean_trailing().await;
         if let Err(e) = self.env().sync(true) {
-            warn!("LMDB fsync before close failed: {e}");
+            warn!(%e, "LMDB fsync before close failed");
         }
         Ok(())
     }

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1.rs
@@ -554,7 +554,7 @@ impl DbV1 {
                         ("block scan", r3),
                     ] {
                         if let Err(e) = result {
-                            error!("initial {desc} failed: {e}");
+                            error!(%e, desc, "initial validation failed");
                             zaino_db.status.store(StatusType::CriticalError);
                             // TODO: Handle error better? - Return invalid block error from validate?
                             return;
@@ -568,7 +568,7 @@ impl DbV1 {
 
                     for (desc, result) in [("spent scan", r1), ("block scan", r2)] {
                         if let Err(e) = result {
-                            error!("initial {desc} failed: {e}");
+                            error!(%e, desc, "initial validation failed");
                             zaino_db.status.store(StatusType::CriticalError);
                             // TODO: Handle error better? - Return invalid block error from validate?
                             return;
@@ -577,8 +577,8 @@ impl DbV1 {
                 }
 
                 info!(
-                    "initial validation complete – tip={}",
-                    zaino_db.validated_tip.load(Ordering::Relaxed)
+                    tip = zaino_db.validated_tip.load(Ordering::Relaxed),
+                    "initial validation complete"
                 );
                 zaino_db.status.store(StatusType::Ready);
 
@@ -605,7 +605,7 @@ impl DbV1 {
                     let hkey = match next_height.to_bytes() {
                         Ok(bytes) => bytes,
                         Err(e) => {
-                            warn!("Failed to serialize height {}: {}", next_height, e);
+                            warn!(height = ?next_height, %e, "failed to serialize height");
                             zaino_db.zaino_db_handler_sleep(&mut maintenance).await;
                             continue;
                         }
@@ -620,7 +620,7 @@ impl DbV1 {
 
                     if let Some(hash) = hash_opt {
                         if let Err(e) = zaino_db.validate_block_blocking(next_height, hash) {
-                            warn!("{e}");
+                            warn!(%e, "block validation failed");
                         }
                         // Immediately loop – maybe the chain has more blocks ready.
                         continue;
@@ -839,10 +839,9 @@ impl DbV1 {
             }
 
             warn!(
-                "detected a 0.4.0-alpha.1 cache recorded at v{} with an unbuilt txid_location \
-                 index; rolling the recorded version back to 1.1.0 so the corrected migration \
-                 rebuilds it in place",
-                metadata.version
+                version = %metadata.version,
+                "detected 0.4.0-alpha.1 cache with unbuilt txid_location index; \
+                 rolling version back to 1.1.0 for corrected migration"
             );
 
             // Clear the `spent` index the alpha migration built: the corrected Stage B rebuilds it

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/transparent_address_history.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/transparent_address_history.rs
@@ -1035,7 +1035,7 @@ impl DbV1 {
                         }
                     }
                 } else if val.len() != StoredEntryFixed::<AddrEventBytes>::VERSIONED_LEN {
-                    tracing::warn!("bad addrhist dup (len={})", val.len());
+                    tracing::warn!(len = val.len(), "bad addrhist dup");
                 }
 
                 // step backwards through duplicates

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/validation.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/validation.rs
@@ -747,10 +747,9 @@ impl DbV1 {
                     //       so we do not return an error here. Maybe we can improve this?
                     if meta.schema_hash != DB_SCHEMA_V1_HASH {
                         warn!(
-                            "schema hash mismatch: db_schema_v1.txt has likely changed \
-                         without bumping version; expected 0x{:02x?}, found 0x{:02x?}",
-                            &DB_SCHEMA_V1_HASH[..4],
-                            &meta.schema_hash[..4],
+                            expected = ?&DB_SCHEMA_V1_HASH[..4],
+                            found = ?&meta.schema_hash[..4],
+                            "schema hash mismatch: db_schema_v1.txt likely changed without version bump"
                         );
                     }
                 }

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -107,8 +107,10 @@ impl DbWrite for DbV1 {
         }
 
         info!(
-            "write_blocks_to_height: syncing finalised blocks {start_height}..={} on {:?}",
-            height.0, network
+            start_height,
+            target = height.0,
+            ?network,
+            "write_blocks_to_height: syncing finalised blocks"
         );
 
         // Bulk path: buffer blocks up to a byte budget, then write the whole batch in one
@@ -165,10 +167,10 @@ impl DbWrite for DbV1 {
                                 .set(height.0 as f64);
                         }
                         info!(
-                            "write_blocks_to_height: syncing height {} / {} on {:?}",
-                            next - 1,
-                            height.0,
-                            network
+                            current = next - 1,
+                            target = height.0,
+                            ?network,
+                            "write_blocks_to_height: syncing"
                         );
                         last_progress_log = std::time::Instant::now();
                     }
@@ -198,9 +200,9 @@ impl DbWrite for DbV1 {
                 }
                 self.status.store(StatusType::Ready);
                 info!(
-                    "write_blocks_to_height: committed batch to height {} ({} blocks)",
-                    next - 1,
-                    batch.len()
+                    height = next - 1,
+                    blocks = batch.len(),
+                    "write_blocks_to_height: committed batch"
                 );
             }
         }
@@ -231,17 +233,17 @@ impl DbWrite for DbV1 {
             Some(built) if built.0 >= height.0 => {}
             Some(built) if height.0.saturating_sub(built.0) <= ACCUMULATOR_INCREMENTAL_MAX_GAP => {
                 info!(
-                    "write_blocks_to_height: updating txout-set accumulator {}..={}",
-                    built.0 + 1,
-                    height.0
+                    from = built.0 + 1,
+                    to = height.0,
+                    "write_blocks_to_height: updating txout-set accumulator"
                 );
                 self.update_tx_out_set_accumulator_for_range(built, height)
                     .await?;
             }
             _ => {
                 info!(
-                    "write_blocks_to_height: rebuilding txout-set accumulator to height {}",
-                    height.0
+                    height = height.0,
+                    "write_blocks_to_height: rebuilding txout-set accumulator"
                 );
                 self.rebuild_tx_out_set_accumulator().await?;
             }
@@ -400,8 +402,9 @@ impl DbV1 {
         if block_already_exists {
             self.status.store(StatusType::Ready);
             info!(
-                "Block {} at height {} already exists in ZainoDB, skipping write.",
-                &block_hash, &block_height.0
+                %block_hash,
+                height = block_height.0,
+                "block already exists in ZainoDB, skipping write"
             );
             return Ok(());
         }
@@ -884,7 +887,7 @@ impl DbV1 {
         let post_result = match join_handle.await {
             Ok(inner_res) => inner_res,
             Err(join_err) => {
-                warn!("Tokio task error (spawn_blocking join error): {}", join_err);
+                warn!(%join_err, "tokio spawn_blocking join error");
 
                 // Best-effort delete of partially written block; ignore delete result.
                 let _ = self.delete_block(&block).await;
@@ -911,14 +914,15 @@ impl DbV1 {
                 }
                 if block.context.index.height.0 % 100 == 0 {
                     info!(
-                        "Successfully committed block {} at height {} to ZainoDB.",
-                        &block.context.index.hash, &block.context.index.height
+                        hash = %block.context.index.hash,
+                        height = ?block.context.index.height,
+                        "committed block to ZainoDB"
                     );
                 } else {
                     tracing::debug!(
-                        "Successfully committed block {} at height {} to ZainoDB.",
-                        &block.context.index.hash,
-                        &block.context.index.height
+                        hash = %block.context.index.hash,
+                        height = ?block.context.index.height,
+                        "committed block to ZainoDB"
                     );
                 }
 
@@ -981,16 +985,18 @@ impl DbV1 {
                         // Block was already written correctly by another process
                         self.status.store(StatusType::Ready);
                         info!(
-                            "Block {} at height {} was already written by another process, skipping.",
-                            &block_hash, &block_height.0
+                            %block_hash,
+                            height = block_height.0,
+                            "block already written by another process, skipping"
                         );
                         Ok(())
                     }
                     Err(e) => {
-                        warn!("Error writing block to DB: {e}");
+                        warn!(%e, "error writing block to DB");
                         warn!(
-                            "Deleting corrupt block from DB at height: {} with hash: {:?}",
-                            block_height.0, block_hash.0
+                            height = block_height.0,
+                            hash = ?block_hash.0,
+                            "deleting corrupt block from DB"
                         );
 
                         let _ = self.delete_block(&block).await;
@@ -1008,10 +1014,11 @@ impl DbV1 {
                 }
             }
             Err(e) => {
-                warn!("Error writing block to DB: {e}");
+                warn!(%e, "error writing block to DB");
                 warn!(
-                    "Deleting corrupt block from DB at height: {} with hash: {:?}",
-                    block_height.0, block_hash.0
+                    height = block_height.0,
+                    hash = ?block_hash.0,
+                    "deleting corrupt block from DB"
                 );
 
                 let _ = self.delete_block(&block).await;

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -135,6 +135,8 @@ impl DbWrite for DbV1 {
                     && batch.len() < SYNC_WRITE_BATCH_MAX_BLOCKS
                     && batch_started.elapsed() < SYNC_WRITE_BATCH_MAX_INTERVAL
                 {
+                    #[cfg(feature = "prometheus")]
+                    let build_start = std::time::Instant::now();
                     let block = build_indexed_block_from_source(
                         source,
                         network,
@@ -144,6 +146,9 @@ impl DbWrite for DbV1 {
                         parent_chainwork,
                     )
                     .await?;
+                    #[cfg(feature = "prometheus")]
+                    metrics::histogram!("zaino.sync.block_build_seconds")
+                        .record(build_start.elapsed().as_secs_f64());
                     parent_chainwork = block.context.chainwork;
                     batch_bytes = batch_bytes.saturating_add(approx_indexed_block_bytes(&block));
                     batch.push(block);
@@ -152,6 +157,13 @@ impl DbWrite for DbV1 {
                     // In-flight progress: the block being fetched, throttled by time. (The committed
                     // tip is reported by the per-batch commit log below.)
                     if last_progress_log.elapsed() >= SYNC_PROGRESS_LOG_INTERVAL {
+                        #[cfg(feature = "prometheus")]
+                        {
+                            metrics::gauge!("zaino.sync.finalized_height")
+                                .set((next - 1) as f64);
+                            metrics::gauge!("zaino.sync.target_height")
+                                .set(height.0 as f64);
+                        }
                         info!(
                             "write_blocks_to_height: syncing height {} / {} on {:?}",
                             next - 1,
@@ -168,14 +180,21 @@ impl DbWrite for DbV1 {
 
                 // Write + sort + commit the batch atomically, then force durability. The on-disk
                 // `headers` tip never runs ahead of the indexes, so resume is gap-free.
+                #[cfg(feature = "prometheus")]
+                let write_start = std::time::Instant::now();
                 tokio::task::block_in_place(|| self.write_block_batch_blocking(&batch))?;
                 tokio::task::block_in_place(|| self.env.sync(true)).map_err(|e| {
                     FinalisedStateError::Custom(format!("LMDB checkpoint sync failed: {e}"))
                 })?;
+                #[cfg(feature = "prometheus")]
+                metrics::histogram!("zaino.sync.block_write_seconds")
+                    .record(write_start.elapsed().as_secs_f64());
 
                 // Only after the batch is committed + synced do we advance the validated tip.
                 for block in &batch {
                     self.mark_validated(block.context.index.height.0);
+                    #[cfg(feature = "prometheus")]
+                    record_block_throughput(block);
                 }
                 self.status.store(StatusType::Ready);
                 info!(
@@ -1934,4 +1953,20 @@ impl DbV1 {
         self.status.store(StatusType::Ready);
         Ok(())
     }
+}
+
+/// Increments per-block throughput counters (transactions, Sapling outputs,
+/// Orchard actions). Only compiled when the `prometheus` feature is enabled.
+#[cfg(feature = "prometheus")]
+fn record_block_throughput(block: &IndexedBlock) {
+    let transactions = block.transactions().len() as u64;
+    let mut sapling_outputs: u64 = 0;
+    let mut orchard_actions: u64 = 0;
+    for tx in block.transactions() {
+        sapling_outputs = sapling_outputs.saturating_add(tx.sapling().outputs().len() as u64);
+        orchard_actions = orchard_actions.saturating_add(tx.orchard().actions().len() as u64);
+    }
+    metrics::counter!("zaino.sync.transactions_total").increment(transactions);
+    metrics::counter!("zaino.sync.sapling_outputs_total").increment(sapling_outputs);
+    metrics::counter!("zaino.sync.orchard_actions_total").increment(orchard_actions);
 }

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -204,6 +204,16 @@ impl DbWrite for DbV1 {
                     blocks = batch.len(),
                     "write_blocks_to_height: committed batch"
                 );
+                #[cfg(feature = "prometheus")]
+                {
+                    metrics::gauge!("zaino.db.tip_height").set((next - 1) as f64);
+                    metrics::gauge!("zaino.sync.last_block_written_at").set(
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .map(|d| d.as_secs_f64())
+                            .unwrap_or(0.0),
+                    );
+                }
             }
         }
         #[cfg(feature = "transparent_address_history_experimental")]

--- a/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/db/v1/write_core.rs
@@ -2,6 +2,9 @@
 
 use super::*;
 
+#[cfg(feature = "prometheus")]
+use crate::metric_names::*;
+
 /// Cheap heap-size estimate for a buffered [`IndexedBlock`], used only to bound the bulk-sync write
 /// batch in [`DbV1::write_blocks_to_height`]. Exactness is not required — it just keeps the batch's
 /// peak memory roughly within the configured budget.
@@ -149,7 +152,7 @@ impl DbWrite for DbV1 {
                     )
                     .await?;
                     #[cfg(feature = "prometheus")]
-                    metrics::histogram!("zaino.sync.block_build_seconds")
+                    metrics::histogram!(SYNC_BLOCK_BUILD_SECONDS)
                         .record(build_start.elapsed().as_secs_f64());
                     parent_chainwork = block.context.chainwork;
                     batch_bytes = batch_bytes.saturating_add(approx_indexed_block_bytes(&block));
@@ -161,10 +164,8 @@ impl DbWrite for DbV1 {
                     if last_progress_log.elapsed() >= SYNC_PROGRESS_LOG_INTERVAL {
                         #[cfg(feature = "prometheus")]
                         {
-                            metrics::gauge!("zaino.sync.finalized_height")
-                                .set((next - 1) as f64);
-                            metrics::gauge!("zaino.sync.target_height")
-                                .set(height.0 as f64);
+                            metrics::gauge!(SYNC_FINALIZED_HEIGHT).set((next - 1) as f64);
+                            metrics::gauge!(SYNC_TARGET_HEIGHT).set(height.0 as f64);
                         }
                         info!(
                             current = next - 1,
@@ -189,7 +190,7 @@ impl DbWrite for DbV1 {
                     FinalisedStateError::Custom(format!("LMDB checkpoint sync failed: {e}"))
                 })?;
                 #[cfg(feature = "prometheus")]
-                metrics::histogram!("zaino.sync.block_write_seconds")
+                metrics::histogram!(SYNC_BLOCK_WRITE_SECONDS)
                     .record(write_start.elapsed().as_secs_f64());
 
                 // Only after the batch is committed + synced do we advance the validated tip.
@@ -206,13 +207,9 @@ impl DbWrite for DbV1 {
                 );
                 #[cfg(feature = "prometheus")]
                 {
-                    metrics::gauge!("zaino.db.tip_height").set((next - 1) as f64);
-                    metrics::gauge!("zaino.sync.last_block_written_at").set(
-                        std::time::SystemTime::now()
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .map(|d| d.as_secs_f64())
-                            .unwrap_or(0.0),
-                    );
+                    metrics::gauge!(DB_TIP_HEIGHT).set((next - 1) as f64);
+                    metrics::gauge!(SYNC_LAST_BLOCK_WRITTEN_AT)
+                        .set(crate::chain_index::unix_now_secs());
                 }
             }
         }
@@ -1983,7 +1980,7 @@ fn record_block_throughput(block: &IndexedBlock) {
         sapling_outputs = sapling_outputs.saturating_add(tx.sapling().outputs().len() as u64);
         orchard_actions = orchard_actions.saturating_add(tx.orchard().actions().len() as u64);
     }
-    metrics::counter!("zaino.sync.transactions_total").increment(transactions);
-    metrics::counter!("zaino.sync.sapling_outputs_total").increment(sapling_outputs);
-    metrics::counter!("zaino.sync.orchard_actions_total").increment(orchard_actions);
+    metrics::counter!(SYNC_TRANSACTIONS_TOTAL).increment(transactions);
+    metrics::counter!(SYNC_SAPLING_OUTPUTS_TOTAL).increment(sapling_outputs);
+    metrics::counter!(SYNC_ORCHARD_ACTIONS_TOTAL).increment(orchard_actions);
 }

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -281,9 +281,9 @@ pub trait Migration<T: BlockchainSource> {
         _source: T,
     ) -> Result<(), FinalisedStateError> {
         info!(
-            "Starting metadata-only migration from {} to {}.",
-            Self::CURRENT_VERSION,
-            Self::TO_VERSION,
+            from = %Self::CURRENT_VERSION,
+            to = %Self::TO_VERSION,
+            "starting metadata-only migration"
         );
 
         let mut metadata: DbMetadata = router.get_metadata().await?;
@@ -295,9 +295,9 @@ pub trait Migration<T: BlockchainSource> {
         router.update_metadata(metadata).await?;
 
         info!(
-            "Metadata-only migration from {} to {} complete.",
-            Self::CURRENT_VERSION,
-            Self::TO_VERSION,
+            from = %Self::CURRENT_VERSION,
+            to = %Self::TO_VERSION,
+            "metadata-only migration complete"
         );
 
         Ok(())
@@ -494,8 +494,9 @@ impl<T: BlockchainSource> Migration<T> for Migration0To1 {
                 let mut primary_db_height = router.db_height().await?.unwrap_or(GENESIS_HEIGHT);
 
                 info!(
-                    "Starting shadow database build, current database tips: v0:{} v1:{}",
-                    primary_db_height, shadow_db_height
+                    v0_tip = ?primary_db_height,
+                    v1_tip = ?shadow_db_height,
+                    "starting shadow database build"
                 );
 
                 loop {
@@ -593,7 +594,7 @@ impl<T: BlockchainSource> Migration<T> for Migration0To1 {
 
             // shutdown database
             if let Err(e) = db_v0.shutdown().await {
-                tracing::warn!("Old primary shutdown failed: {e}");
+                tracing::warn!(%e, "old primary shutdown failed");
             }
 
             // Now safe to delete old database files
@@ -607,11 +608,11 @@ impl<T: BlockchainSource> Migration<T> for Migration0To1 {
             info!("Wiping v0 database from disk.");
 
             match tokio::fs::remove_dir_all(&db_path).await {
-                Ok(_) => tracing::info!("Deleted old database at {}", db_path.display()),
+                Ok(_) => tracing::info!(path = %db_path.display(), "deleted old database"),
                 Err(e) => tracing::error!(
-                    "Failed to delete old database at {}: {}",
-                    db_path.display(),
-                    e
+                    path = %db_path.display(),
+                    %e,
+                    "failed to delete old database"
                 ),
             }
         });

--- a/packages/zaino-state/src/chain_index/mempool.rs
+++ b/packages/zaino-state/src/chain_index/mempool.rs
@@ -201,6 +201,11 @@ impl<T: BlockchainSource> Mempool<T> {
                     status.store(StatusType::Syncing);
                     state.notify(status.load());
                     state.clear();
+                    #[cfg(feature = "prometheus")]
+                    {
+                        metrics::counter!("zaino.mempool.tip_changes_total").increment(1);
+                        metrics::gauge!("zaino.mempool.transactions").set(0.0);
+                    }
 
                     mempool
                         .mempool_chain_tip
@@ -215,6 +220,9 @@ impl<T: BlockchainSource> Mempool<T> {
                     Ok(mempool_transactions) => {
                         status.store(StatusType::Ready);
                         state.insert_filtered_set(mempool_transactions, status.load());
+                        #[cfg(feature = "prometheus")]
+                        metrics::gauge!("zaino.mempool.transactions")
+                            .set(state.len() as f64);
                     }
                     Err(e) => {
                         status.store(StatusType::RecoverableError);

--- a/packages/zaino-state/src/chain_index/mempool.rs
+++ b/packages/zaino-state/src/chain_index/mempool.rs
@@ -2,6 +2,8 @@
 
 use std::{collections::HashSet, sync::Arc};
 
+#[cfg(feature = "prometheus")]
+use crate::metric_names::*;
 use crate::{
     broadcast::{Broadcast, BroadcastSubscriber},
     chain_index::{
@@ -203,8 +205,8 @@ impl<T: BlockchainSource> Mempool<T> {
                     state.clear();
                     #[cfg(feature = "prometheus")]
                     {
-                        metrics::counter!("zaino.mempool.tip_changes_total").increment(1);
-                        metrics::gauge!("zaino.mempool.transactions").set(0.0);
+                        metrics::counter!(MEMPOOL_TIP_CHANGES_TOTAL).increment(1);
+                        metrics::gauge!(MEMPOOL_TRANSACTIONS).set(0.0);
                     }
 
                     mempool
@@ -221,8 +223,7 @@ impl<T: BlockchainSource> Mempool<T> {
                         status.store(StatusType::Ready);
                         state.insert_filtered_set(mempool_transactions, status.load());
                         #[cfg(feature = "prometheus")]
-                        metrics::gauge!("zaino.mempool.transactions")
-                            .set(state.len() as f64);
+                        metrics::gauge!(MEMPOOL_TRANSACTIONS).set(state.len() as f64);
                     }
                     Err(e) => {
                         status.store(StatusType::RecoverableError);

--- a/packages/zaino-state/src/chain_index/mempool.rs
+++ b/packages/zaino-state/src/chain_index/mempool.rs
@@ -116,7 +116,7 @@ impl<T: BlockchainSource> Mempool<T> {
                 }
                 Err(e) => {
                     mempool.state.notify(mempool.status.load());
-                    warn!("{e}");
+                    warn!(%e, "mempool source fetch failed");
                     tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                     continue;
                 }
@@ -165,7 +165,7 @@ impl<T: BlockchainSource> Mempool<T> {
                     Err(e) => {
                         mempool.status.store(StatusType::RecoverableError);
                         state.notify(status.load());
-                        warn!("{e}");
+                        warn!(%e, "mempool initial block hash fetch failed");
                         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                         continue;
                     }
@@ -190,7 +190,7 @@ impl<T: BlockchainSource> Mempool<T> {
                     },
                     Err(e) => {
                         state.notify(status.load());
-                        warn!("{e}");
+                        warn!(%e, "mempool chain tip check failed");
                         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                         continue;
                     }
@@ -219,7 +219,7 @@ impl<T: BlockchainSource> Mempool<T> {
                     Err(e) => {
                         status.store(StatusType::RecoverableError);
                         state.notify(status.load());
-                        warn!("{e}");
+                        warn!(%e, "mempool transaction fetch failed");
                         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                         continue;
                     }
@@ -487,7 +487,7 @@ impl MempoolSubscriber {
             .await;
 
             if let Err(mempool_error) = mempool_result {
-                warn!("Error in mempool stream: {:?}", mempool_error);
+                warn!(?mempool_error, "error in mempool stream");
                 match mempool_error {
                     MempoolError::StatusError(error_status) => {
                         let _ = channel_tx.send(Err(error_status)).await;

--- a/packages/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/non_finalised_state.rs
@@ -1,4 +1,6 @@
 use super::{finalised_state::ZainoDB, source::BlockchainSource, NON_FINALIZED_DEPTH};
+#[cfg(feature = "prometheus")]
+use crate::metric_names::*;
 use crate::{
     chain_index::types::{
         self, BlockHash, BlockIndex, BlockMetadata, BlockWithMetadata, Height, TreeRootData,
@@ -617,13 +619,12 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
                     if new_best_tip.height == stale_best_tip.height
                         && new_best_tip.hash != stale_best_tip.hash
                     {
-                        metrics::counter!("zaino.sync.reorg_total").increment(1);
-                        metrics::histogram!("zaino.sync.reorg_depth").record(0.0);
+                        metrics::counter!(SYNC_REORG_TOTAL).increment(1);
+                        metrics::histogram!(SYNC_REORG_DEPTH).record(0.0);
                     } else if new_best_tip.height < stale_best_tip.height {
-                        metrics::counter!("zaino.sync.reorg_total").increment(1);
-                        metrics::histogram!("zaino.sync.reorg_depth").record(
-                            (stale_best_tip.height.0 - new_best_tip.height.0) as f64,
-                        );
+                        metrics::counter!(SYNC_REORG_TOTAL).increment(1);
+                        metrics::histogram!(SYNC_REORG_DEPTH)
+                            .record((stale_best_tip.height.0 - new_best_tip.height.0) as f64);
                     }
                 }
             }

--- a/packages/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/non_finalised_state.rs
@@ -611,6 +611,21 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
                         "Non-finalized tip rollback"
                     );
                 }
+
+                #[cfg(feature = "prometheus")]
+                {
+                    if new_best_tip.height == stale_best_tip.height
+                        && new_best_tip.hash != stale_best_tip.hash
+                    {
+                        metrics::counter!("zaino.sync.reorg_total").increment(1);
+                        metrics::histogram!("zaino.sync.reorg_depth").record(0.0);
+                    } else if new_best_tip.height < stale_best_tip.height {
+                        metrics::counter!("zaino.sync.reorg_total").increment(1);
+                        metrics::histogram!("zaino.sync.reorg_depth").record(
+                            (stale_best_tip.height.0 - new_best_tip.height.0) as f64,
+                        );
+                    }
+                }
             }
             Ok(())
         } else {

--- a/packages/zaino-state/src/config.rs
+++ b/packages/zaino-state/src/config.rs
@@ -133,8 +133,8 @@ impl StateServiceConfig {
         donation_address: Option<DonationAddress>,
     ) -> Self {
         tracing::trace!(
-            "State service expecting NU activations:\n{:?}",
-            network.to_zebra_network().full_activation_list()
+            activations = ?network.to_zebra_network().full_activation_list(),
+            "state service expecting NU activations"
         );
         StateServiceConfig {
             common: CommonBackendConfig {

--- a/packages/zaino-state/src/indexer.rs
+++ b/packages/zaino-state/src/indexer.rs
@@ -805,8 +805,8 @@ pub trait LightWalletIndexer: Send + Sync + Clone + ZcashIndexer + 'static {
                                             Ok(_) => break,
                                             Err(e) => {
                                                 warn!(
-                                                    "GetSubtreeRoots channel closed unexpectedly: {}",
-                                                    e
+                                                    %e,
+                                                    "GetSubtreeRoots channel closed unexpectedly"
                                                 );
                                                 break;
                                             }
@@ -825,8 +825,8 @@ pub trait LightWalletIndexer: Send + Sync + Clone + ZcashIndexer + 'static {
                                             Ok(_) => break,
                                             Err(e) => {
                                                 warn!(
-                                                    "GetSubtreeRoots channel closed unexpectedly: {}",
-                                                    e
+                                                    %e,
+                                                    "GetSubtreeRoots channel closed unexpectedly"
                                                 );
                                                 break;
                                             }

--- a/packages/zaino-state/src/indexer.rs
+++ b/packages/zaino-state/src/indexer.rs
@@ -792,7 +792,7 @@ pub trait LightWalletIndexer: Send + Sync + Clone + ZcashIndexer + 'static {
                             .z_get_block(subtree.end_height.0.to_string(), Some(1))
                             .await
                         {
-                            Ok(GetBlock::Object (block_object)) => {
+                            Ok(GetBlock::Object(block_object)) => {
                                 let checked_height = match block_object.height() {
                                     Some(h) => h.0 as u64,
                                     None => {
@@ -836,7 +836,8 @@ pub trait LightWalletIndexer: Send + Sync + Clone + ZcashIndexer + 'static {
                                 if channel_tx
                                     .send(Ok(SubtreeRoot {
                                         root_hash: checked_root_hash,
-                                        completing_block_hash: block_object.hash()
+                                        completing_block_hash: block_object
+                                            .hash()
                                             .bytes_in_display_order()
                                             .to_vec(),
                                         completing_block_height: checked_height,

--- a/packages/zaino-state/src/lib.rs
+++ b/packages/zaino-state/src/lib.rs
@@ -9,6 +9,35 @@
 #![warn(missing_docs)]
 #![forbid(unsafe_code)]
 
+/// Prometheus metric names emitted by this crate; the single source of truth shared with `zainod`'s `describe_*` registrations (which carry the descriptions).
+#[cfg(feature = "prometheus")]
+#[allow(missing_docs)] // names are self-describing; descriptions live in zainod
+pub mod metric_names {
+    pub const CHAIN_TIP_HEIGHT: &str = "zaino.chain.tip_height";
+
+    pub const SYNC_FINALIZED_HEIGHT: &str = "zaino.sync.finalized_height";
+    pub const SYNC_TARGET_HEIGHT: &str = "zaino.sync.target_height";
+    pub const SYNC_LAG_BLOCKS: &str = "zaino.sync.lag_blocks";
+    pub const SYNC_ITERATIONS_TOTAL: &str = "zaino.sync.iterations_total";
+    pub const SYNC_ITERATION_DURATION_SECONDS: &str = "zaino.sync.iteration_duration_seconds";
+    pub const SYNC_ERRORS_TOTAL: &str = "zaino.sync.errors_total";
+    pub const SYNC_HAS_REACHED_TIP: &str = "zaino.sync.has_reached_tip";
+    pub const SYNC_REACHED_TIP_AT: &str = "zaino.sync.reached_tip_at";
+    pub const SYNC_REORG_TOTAL: &str = "zaino.sync.reorg_total";
+    pub const SYNC_REORG_DEPTH: &str = "zaino.sync.reorg_depth";
+    pub const SYNC_BLOCK_BUILD_SECONDS: &str = "zaino.sync.block_build_seconds";
+    pub const SYNC_BLOCK_WRITE_SECONDS: &str = "zaino.sync.block_write_seconds";
+    pub const SYNC_TRANSACTIONS_TOTAL: &str = "zaino.sync.transactions_total";
+    pub const SYNC_SAPLING_OUTPUTS_TOTAL: &str = "zaino.sync.sapling_outputs_total";
+    pub const SYNC_ORCHARD_ACTIONS_TOTAL: &str = "zaino.sync.orchard_actions_total";
+    pub const SYNC_LAST_BLOCK_WRITTEN_AT: &str = "zaino.sync.last_block_written_at";
+
+    pub const DB_TIP_HEIGHT: &str = "zaino.db.tip_height";
+
+    pub const MEMPOOL_TRANSACTIONS: &str = "zaino.mempool.transactions";
+    pub const MEMPOOL_TIP_CHANGES_TOTAL: &str = "zaino.mempool.tip_changes_total";
+}
+
 // Zaino's Indexer library frontend.
 pub(crate) mod indexer;
 

--- a/packages/zainod/Cargo.toml
+++ b/packages/zainod/Cargo.toml
@@ -20,6 +20,12 @@ path = "src/lib.rs"
 # Removes network restrictions.
 no_tls_use_unencrypted_traffic = ["zaino-serve/no_tls_use_unencrypted_traffic"]
 
+# Operator build: no TLS + Prometheus metrics endpoint.
+no_tls_with_prometheus = ["no_tls_use_unencrypted_traffic", "prometheus"]
+
+# Prometheus /metrics scrape endpoint.
+prometheus = ["metrics", "metrics-exporter-prometheus", "zaino-state/prometheus"]
+
 # DANGER: allows the JSON-RPC server to bind to a public (non-private,
 # non-loopback) address. The JSON-RPC interface has NO transport encryption and
 # is intended for loopback or trusted private networks only. Enabling this
@@ -63,6 +69,10 @@ tracing-subscriber = { workspace = true, features = ["fmt", "env-filter", "time"
 # Network / RPC
 http = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+
+# Metrics (behind "prometheus" feature)
+metrics = { workspace = true, optional = true }
+metrics-exporter-prometheus = { workspace = true, optional = true }
 
 # Utility
 thiserror = { workspace = true }

--- a/packages/zainod/Cargo.toml
+++ b/packages/zainod/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.1"
+version = "0.4.2-rc.1"
 
 [[bin]]
 name = "zainod"

--- a/packages/zainod/Cargo.toml
+++ b/packages/zainod/Cargo.toml
@@ -24,7 +24,7 @@ no_tls_use_unencrypted_traffic = ["zaino-serve/no_tls_use_unencrypted_traffic"]
 no_tls_with_prometheus = ["no_tls_use_unencrypted_traffic", "prometheus"]
 
 # Prometheus /metrics scrape endpoint.
-prometheus = ["metrics", "metrics-exporter-prometheus", "zaino-state/prometheus"]
+prometheus = ["metrics", "metrics-exporter-prometheus", "zaino-state/prometheus", "zaino-serve/prometheus", "zaino-fetch/prometheus"]
 
 # DANGER: allows the JSON-RPC server to bind to a public (non-private,
 # non-loopback) address. The JSON-RPC interface has NO transport encryption and

--- a/packages/zainod/src/config.rs
+++ b/packages/zainod/src/config.rs
@@ -76,6 +76,11 @@ pub struct ZainodConfig {
     pub zebra_db_path: PathBuf,
     /// Network to connect to (Mainnet, Testnet, or Regtest).
     pub network: Network,
+    /// Prometheus metrics endpoint listen address.
+    ///
+    /// Set to enable the `/metrics` scrape endpoint. Disabled when `None`.
+    /// Requires the `prometheus` feature; ignored without it.
+    pub metrics_endpoint: Option<SocketAddr>,
 
     // Table sections
     /// JSON-RPC server settings. Set to enable Zaino's JSON-RPC interface.
@@ -220,6 +225,7 @@ impl Default for ZainodConfig {
     fn default() -> Self {
         Self {
             backend: BackendType::default(),
+            metrics_endpoint: None,
             json_server_settings: None,
             grpc_settings: GrpcServerConfig {
                 listen_address: "127.0.0.1:8137".parse().unwrap(),

--- a/packages/zainod/src/config.rs
+++ b/packages/zainod/src/config.rs
@@ -150,8 +150,8 @@ impl ZainodConfig {
             }
             AddressResolution::UnresolvedHostname { ref address, .. } => {
                 info!(
-                    "Validator address '{}' cannot be resolved at config time.",
-                    address
+                    %address,
+                    "validator address cannot be resolved at config time"
                 );
             }
             AddressResolution::InvalidFormat { address, reason } => {
@@ -348,8 +348,8 @@ pub fn load_config_with_env(
 
     parsed_config.check_config()?;
     info!(
-        "Successfully loaded and validated config. Base TOML file checked: '{}'",
-        file_path.display()
+        path = %file_path.display(),
+        "config loaded and validated"
     );
     Ok(parsed_config)
 }

--- a/packages/zainod/src/error.rs
+++ b/packages/zainod/src/error.rs
@@ -34,6 +34,10 @@ pub enum IndexerError {
     /// Custom indexor errors.
     #[error("Misc indexer error: {0}")]
     MiscIndexerError(String),
+    /// Metrics endpoint errors.
+    #[cfg(feature = "prometheus")]
+    #[error("Metrics error: {0}")]
+    MetricsError(String),
     /// Zaino restart signal.
     #[error("Restart Zaino")]
     Restart,

--- a/packages/zainod/src/indexer.rs
+++ b/packages/zainod/src/indexer.rs
@@ -49,7 +49,7 @@ pub async fn spawn_indexer(
         "Checking connection with node"
     );
     if let Some(donation_address) = &config.donation_address {
-        info!("Instance donation address: {}", donation_address);
+        info!(%donation_address, "instance donation address");
     }
     let zebrad_uri = test_node_and_return_url(
         &config.validator_settings.validator_jsonrpc_listen_address,
@@ -250,18 +250,11 @@ where
             None => StatusType::Offline,
         };
 
-        let service_status_symbol = service_status.get_status_symbol();
-        let json_server_status_symbol = json_server_status.get_status_symbol();
-        let grpc_server_status_symbol = grpc_server_status.get_status_symbol();
-
         info!(
-            "Zaino status check - ChainState Service:{}{} JsonRPC Server:{}{} gRPC Server:{}{}",
-            service_status_symbol,
-            service_status,
-            json_server_status_symbol,
-            json_server_status,
-            grpc_server_status_symbol,
-            grpc_server_status
+            chain_state = %service_status,
+            json_rpc = %json_server_status,
+            grpc = %grpc_server_status,
+            "Zaino status check"
         );
     }
 }

--- a/packages/zainod/src/lib.rs
+++ b/packages/zainod/src/lib.rs
@@ -14,6 +14,8 @@ pub mod cli;
 pub mod config;
 pub mod error;
 pub mod indexer;
+#[cfg(feature = "prometheus")]
+pub mod metrics;
 
 /// Run the Zaino indexer.
 ///
@@ -25,6 +27,11 @@ pub async fn run(config_path: PathBuf) -> Result<(), IndexerError> {
 
     info!("zainod v{}", env!("CARGO_PKG_VERSION"));
     let config = load_config(&config_path)?;
+
+    #[cfg(feature = "prometheus")]
+    if let Some(endpoint) = config.metrics_endpoint {
+        crate::metrics::init(endpoint)?;
+    }
 
     loop {
         match start_indexer(config.clone()).await {

--- a/packages/zainod/src/lib.rs
+++ b/packages/zainod/src/lib.rs
@@ -25,7 +25,7 @@ pub mod metrics;
 pub async fn run(config_path: PathBuf) -> Result<(), IndexerError> {
     zaino_common::logging::try_init();
 
-    info!("zainod v{}", env!("CARGO_PKG_VERSION"));
+    info!(version = env!("CARGO_PKG_VERSION"), "zainod started");
     let config = load_config(&config_path)?;
 
     #[cfg(feature = "prometheus")]
@@ -48,18 +48,18 @@ pub async fn run(config_path: PathBuf) -> Result<(), IndexerError> {
                             continue;
                         }
                         Err(e) => {
-                            error!("Exiting Zaino with error: {}", e);
+                            error!(%e, "exiting Zaino with error");
                             return Err(e);
                         }
                     },
                     Err(e) => {
-                        error!("Zaino exited early with error: {}", e);
+                        error!(%e, "Zaino exited early with error");
                         return Err(e.into());
                     }
                 }
             }
             Err(e) => {
-                error!("Zaino failed to start with error: {}", e);
+                error!(%e, "Zaino failed to start");
                 return Err(e);
             }
         }

--- a/packages/zainod/src/metrics.rs
+++ b/packages/zainod/src/metrics.rs
@@ -8,7 +8,17 @@ use std::net::SocketAddr;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use tracing::info;
 
+// Metric names are owned by the crates that emit them, so the `describe_*`
+// registrations below share one source of truth with the emit sites and can
+// never drift.
+use zaino_fetch::metric_names::*;
+use zaino_serve::metric_names::*;
+use zaino_state::metric_names::*;
+
 use crate::error::IndexerError;
+
+/// Static build-metadata gauge name (`zainod.build_info`); see [`set_build_info`].
+const BUILD_INFO: &str = "zainod.build_info";
 
 /// Install the Prometheus metrics recorder and spawn the HTTP listener.
 ///
@@ -34,128 +44,125 @@ pub fn init(endpoint: SocketAddr) -> Result<(), IndexerError> {
 /// These appear as `# HELP` lines in the scrape output.
 fn describe_metrics() {
     metrics::describe_gauge!(
-        "zaino.sync.finalized_height",
+        SYNC_FINALIZED_HEIGHT,
         "Current finalized block height being synced"
     );
     metrics::describe_gauge!(
-        "zaino.sync.target_height",
+        SYNC_TARGET_HEIGHT,
         "Target finalized block height for current sync iteration"
     );
     metrics::describe_gauge!(
-        "zaino.chain.tip_height",
+        CHAIN_TIP_HEIGHT,
         "Latest chain tip height reported by the validator"
     );
 
     metrics::describe_counter!(
-        "zaino.sync.transactions_total",
+        SYNC_TRANSACTIONS_TOTAL,
         "Total transactions indexed during sync"
     );
     metrics::describe_counter!(
-        "zaino.sync.sapling_outputs_total",
+        SYNC_SAPLING_OUTPUTS_TOTAL,
         "Total Sapling outputs indexed during sync"
     );
     metrics::describe_counter!(
-        "zaino.sync.orchard_actions_total",
+        SYNC_ORCHARD_ACTIONS_TOTAL,
         "Total Orchard actions indexed during sync"
     );
 
     metrics::describe_histogram!(
-        "zaino.sync.block_build_seconds",
+        SYNC_BLOCK_BUILD_SECONDS,
         "Seconds to fetch and build one indexed block (fetch + treestate + parse)"
     );
     metrics::describe_histogram!(
-        "zaino.sync.block_write_seconds",
+        SYNC_BLOCK_WRITE_SECONDS,
         "Seconds to durably write one batch of blocks to the database"
     );
 
     metrics::describe_gauge!(
-        "zainod.build_info",
+        BUILD_INFO,
         "Static build metadata; always 1. Version exposed as a label."
     );
 
     // Sync lifecycle
     metrics::describe_gauge!(
-        "zaino.sync.has_reached_tip",
+        SYNC_HAS_REACHED_TIP,
         "Whether the indexer has ever reached the chain tip (0 or 1, never resets)"
     );
     metrics::describe_gauge!(
-        "zaino.sync.reached_tip_at",
+        SYNC_REACHED_TIP_AT,
         "Unix timestamp of the first time the indexer reached the chain tip"
     );
     metrics::describe_gauge!(
-        "zaino.sync.lag_blocks",
+        SYNC_LAG_BLOCKS,
         "Number of blocks between chain tip and finalized height"
     );
     metrics::describe_counter!(
-        "zaino.sync.iterations_total",
+        SYNC_ITERATIONS_TOTAL,
         "Total sync loop iterations completed"
     );
     metrics::describe_histogram!(
-        "zaino.sync.iteration_duration_seconds",
+        SYNC_ITERATION_DURATION_SECONDS,
         "Wall-clock duration of each sync loop iteration"
     );
     metrics::describe_counter!(
-        "zaino.sync.errors_total",
+        SYNC_ERRORS_TOTAL,
         "Total sync loop errors by severity (recoverable or critical)"
     );
     metrics::describe_counter!(
-        "zaino.sync.reorg_total",
+        SYNC_REORG_TOTAL,
         "Total chain reorganization events detected in the non-finalized state"
     );
     metrics::describe_histogram!(
-        "zaino.sync.reorg_depth",
+        SYNC_REORG_DEPTH,
         "Depth of chain reorganizations in blocks (0 for same-height reorgs)"
     );
 
     // DB
     metrics::describe_gauge!(
-        "zaino.db.tip_height",
+        DB_TIP_HEIGHT,
         "Height of the last block committed to the finalized database"
     );
     metrics::describe_gauge!(
-        "zaino.sync.last_block_written_at",
+        SYNC_LAST_BLOCK_WRITTEN_AT,
         "Unix timestamp of the last block written to the finalized database"
     );
 
     // Inbound gRPC
-    metrics::describe_counter!(
-        "zaino.grpc.requests_total",
-        "Total inbound gRPC requests by method"
-    );
+    metrics::describe_counter!(GRPC_REQUESTS_TOTAL, "Total inbound gRPC requests by method");
     metrics::describe_histogram!(
-        "zaino.grpc.request_duration_seconds",
+        GRPC_REQUEST_DURATION_SECONDS,
         "Duration of inbound gRPC requests by method"
     );
     metrics::describe_counter!(
-        "zaino.grpc.errors_total",
+        GRPC_ERRORS_TOTAL,
         "Total inbound gRPC errors by method and status code"
     );
 
     // Outbound JSON-RPC
     metrics::describe_counter!(
-        "zaino.rpc.outbound.requests_total",
+        RPC_OUTBOUND_REQUESTS_TOTAL,
         "Total outbound JSON-RPC requests by method"
     );
     metrics::describe_histogram!(
-        "zaino.rpc.outbound.request_duration_seconds",
+        RPC_OUTBOUND_REQUEST_DURATION_SECONDS,
         "Duration of outbound JSON-RPC requests by method"
     );
     metrics::describe_counter!(
-        "zaino.rpc.outbound.errors_total",
+        RPC_OUTBOUND_ERRORS_TOTAL,
         "Total outbound JSON-RPC errors by method"
     );
     metrics::describe_counter!(
-        "zaino.rpc.outbound.retries_total",
+        RPC_OUTBOUND_RETRIES_TOTAL,
         "Total outbound JSON-RPC retries due to work queue depth exceeded"
     );
 
     // Mempool
     metrics::describe_gauge!(
-        "zaino.mempool.transactions",
+        MEMPOOL_TRANSACTIONS,
         "Current number of transactions in the mempool"
     );
     metrics::describe_counter!(
-        "zaino.mempool.tip_changes_total",
+        MEMPOOL_TIP_CHANGES_TOTAL,
         "Total mempool resets due to chain tip changes"
     );
 }
@@ -165,7 +172,7 @@ fn describe_metrics() {
 /// pattern Zebra uses with `zebrad_build_info`.
 fn set_build_info() {
     metrics::gauge!(
-        "zainod.build_info",
+        BUILD_INFO,
         "version" => env!("CARGO_PKG_VERSION"),
     )
     .set(1.0);

--- a/packages/zainod/src/metrics.rs
+++ b/packages/zainod/src/metrics.rs
@@ -1,0 +1,86 @@
+//! Prometheus metrics endpoint for Zaino.
+//!
+//! Installs a global metrics recorder and spawns an HTTP listener
+//! that serves the `/metrics` scrape endpoint.
+
+use std::net::SocketAddr;
+
+use metrics_exporter_prometheus::PrometheusBuilder;
+use tracing::info;
+
+use crate::error::IndexerError;
+
+/// Install the Prometheus metrics recorder and spawn the HTTP listener.
+///
+/// This must be called **once** before any `metrics::gauge!()` / `metrics::counter!()`
+/// calls, otherwise those calls silently no-op.
+pub fn init(endpoint: SocketAddr) -> Result<(), IndexerError> {
+    PrometheusBuilder::new()
+        .with_http_listener(endpoint)
+        .install()
+        .map_err(|e| {
+            IndexerError::MetricsError(format!("Failed to install metrics recorder: {e}"))
+        })?;
+
+    describe_metrics();
+    set_build_info();
+
+    info!(%endpoint, "Prometheus metrics endpoint started");
+    Ok(())
+}
+
+/// Register human-readable descriptions for all Zaino metrics.
+///
+/// These appear as `# HELP` lines in the scrape output.
+fn describe_metrics() {
+    metrics::describe_gauge!(
+        "zaino.sync.finalized_height",
+        "Current finalized block height being synced"
+    );
+    metrics::describe_gauge!(
+        "zaino.sync.target_height",
+        "Target finalized block height for current sync iteration"
+    );
+    metrics::describe_gauge!(
+        "zaino.chain.tip_height",
+        "Latest chain tip height reported by the validator"
+    );
+
+    metrics::describe_counter!(
+        "zaino.sync.transactions_total",
+        "Total transactions indexed during sync"
+    );
+    metrics::describe_counter!(
+        "zaino.sync.sapling_outputs_total",
+        "Total Sapling outputs indexed during sync"
+    );
+    metrics::describe_counter!(
+        "zaino.sync.orchard_actions_total",
+        "Total Orchard actions indexed during sync"
+    );
+
+    metrics::describe_histogram!(
+        "zaino.sync.block_build_seconds",
+        "Seconds to fetch and build one indexed block (fetch + treestate + parse)"
+    );
+    metrics::describe_histogram!(
+        "zaino.sync.block_write_seconds",
+        "Seconds to durably write one batch of blocks to the database"
+    );
+
+    metrics::describe_gauge!(
+        "zainod.build_info",
+        "Static build metadata; always 1. Version exposed as a label."
+    );
+}
+
+/// Emit a constant gauge `zainod_build_info{version="x.y.z"} 1` so the
+/// deployed binary version is queryable in PromQL / Grafana, matching the
+/// pattern Zebra uses with `zebrad_build_info`.
+fn set_build_info() {
+    metrics::gauge!(
+        "zainod.build_info",
+        "version" => env!("CARGO_PKG_VERSION"),
+    )
+    .set(1.0);
+}

--- a/packages/zainod/src/metrics.rs
+++ b/packages/zainod/src/metrics.rs
@@ -72,6 +72,92 @@ fn describe_metrics() {
         "zainod.build_info",
         "Static build metadata; always 1. Version exposed as a label."
     );
+
+    // Sync lifecycle
+    metrics::describe_gauge!(
+        "zaino.sync.has_reached_tip",
+        "Whether the indexer has ever reached the chain tip (0 or 1, never resets)"
+    );
+    metrics::describe_gauge!(
+        "zaino.sync.reached_tip_at",
+        "Unix timestamp of the first time the indexer reached the chain tip"
+    );
+    metrics::describe_gauge!(
+        "zaino.sync.lag_blocks",
+        "Number of blocks between chain tip and finalized height"
+    );
+    metrics::describe_counter!(
+        "zaino.sync.iterations_total",
+        "Total sync loop iterations completed"
+    );
+    metrics::describe_histogram!(
+        "zaino.sync.iteration_duration_seconds",
+        "Wall-clock duration of each sync loop iteration"
+    );
+    metrics::describe_counter!(
+        "zaino.sync.errors_total",
+        "Total sync loop errors by severity (recoverable or critical)"
+    );
+    metrics::describe_counter!(
+        "zaino.sync.reorg_total",
+        "Total chain reorganization events detected in the non-finalized state"
+    );
+    metrics::describe_histogram!(
+        "zaino.sync.reorg_depth",
+        "Depth of chain reorganizations in blocks (0 for same-height reorgs)"
+    );
+
+    // DB
+    metrics::describe_gauge!(
+        "zaino.db.tip_height",
+        "Height of the last block committed to the finalized database"
+    );
+    metrics::describe_gauge!(
+        "zaino.sync.last_block_written_at",
+        "Unix timestamp of the last block written to the finalized database"
+    );
+
+    // Inbound gRPC
+    metrics::describe_counter!(
+        "zaino.grpc.requests_total",
+        "Total inbound gRPC requests by method"
+    );
+    metrics::describe_histogram!(
+        "zaino.grpc.request_duration_seconds",
+        "Duration of inbound gRPC requests by method"
+    );
+    metrics::describe_counter!(
+        "zaino.grpc.errors_total",
+        "Total inbound gRPC errors by method and status code"
+    );
+
+    // Outbound JSON-RPC
+    metrics::describe_counter!(
+        "zaino.rpc.outbound.requests_total",
+        "Total outbound JSON-RPC requests by method"
+    );
+    metrics::describe_histogram!(
+        "zaino.rpc.outbound.request_duration_seconds",
+        "Duration of outbound JSON-RPC requests by method"
+    );
+    metrics::describe_counter!(
+        "zaino.rpc.outbound.errors_total",
+        "Total outbound JSON-RPC errors by method"
+    );
+    metrics::describe_counter!(
+        "zaino.rpc.outbound.retries_total",
+        "Total outbound JSON-RPC retries due to work queue depth exceeded"
+    );
+
+    // Mempool
+    metrics::describe_gauge!(
+        "zaino.mempool.transactions",
+        "Current number of transactions in the mempool"
+    );
+    metrics::describe_counter!(
+        "zaino.mempool.tip_changes_total",
+        "Total mempool resets due to chain tip changes"
+    );
 }
 
 /// Emit a constant gauge `zainod_build_info{version="x.y.z"} 1` so the


### PR DESCRIPTION
## Summary

Merges rc/0.4.2 into stable for the 0.4.2 release.

### What's in 0.4.2

- **Prometheus `/metrics` endpoint** behind `prometheus` feature flag
- **28 metrics** covering sync lifecycle, inbound gRPC per-method, outbound JSON-RPC per-method, mempool, reorgs, and DB state
- **Structured tracing fields** across all crates (~45 call sites)
- **Docker `CARGO_FEATURES` build arg** for enabling metrics in container builds

### Crate versions (rc → stable strip pending)

| Crate | 0.4.1 | 0.4.2 |
|-------|-------|-------|
| zainod | 0.4.1 | 0.4.2-rc.1 → 0.4.2 |
| zaino-state | 0.3.0 | 0.3.1-rc.1 → 0.3.1 |
| zaino-serve | 0.3.0 | 0.3.1-rc.1 → 0.3.1 |
| zaino-fetch | 0.2.0 | 0.2.1-rc.1 → 0.2.1 |

After merge, a follow-up commit on stable strips the `-rc.1` suffixes
and tags the final release versions.

### Post-merge checklist

- [ ] Strip `-rc.1` suffixes on stable
- [ ] Tag final versions
- [ ] Backport stable → dev