### PR TITLE
Dry spent outpoint

### DIFF
--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -2534,12 +2534,7 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
                 }
 
                 // Spent prev outputs leave the UTXO set.
-                for input in transparent.inputs() {
-                    if input.is_null_prevout() {
-                        continue;
-                    }
-
-                    let outpoint = Outpoint::new(*input.prevout_txid(), input.prevout_index());
+                for outpoint in transparent.spent_outpoints() {
                     let prev_txid = TransactionHash::from(*outpoint.prev_txid());
 
                     let prev_out_from_nfs = nfs_created.remove(&outpoint);

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/tx_out_set_accumulator.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/tx_out_set_accumulator.rs
@@ -1175,12 +1175,7 @@ impl DbV1 {
                             .push(outpoint);
                     }
 
-                    for input in transparent_tx.inputs().iter() {
-                        if input.is_null_prevout() {
-                            continue;
-                        }
-                        spends.push(Outpoint::new(*input.prevout_txid(), input.prevout_index()));
-                    }
+                    spends.extend(transparent_tx.spent_outpoints());
                 }
 
                 height += 1;
@@ -1780,12 +1775,8 @@ mod tests {
         for chain_block in indexed_block_chain(&blocks) {
             for transaction in chain_block.transactions() {
                 // First apply spends, removing spent transparent outputs from the expected UTXO set.
-                for input in transaction.transparent().inputs() {
-                    if input.is_null_prevout() {
-                        continue;
-                    }
-
-                    let previous_transaction_hash = TransactionHash::from(*input.prevout_txid());
+                for outpoint in transaction.transparent().spent_outpoints() {
+                    let previous_transaction_hash = TransactionHash::from(*outpoint.prev_txid());
 
                     let unspent_output_indices = unspent_output_indices_by_transaction_hash
                         .get_mut(&previous_transaction_hash)
@@ -1797,11 +1788,11 @@ mod tests {
 
                     assert!(
                         unspent_output_indices
-                            .remove(&input.prevout_index())
+                            .remove(&outpoint.prev_index())
                             .is_some(),
                         "test vectors spend unknown output: transaction {:?}, output {}",
                         previous_transaction_hash,
-                        input.prevout_index()
+                        outpoint.prev_index()
                     );
 
                     // If a transaction has no remaining unspent outputs, it should no longer
@@ -2116,12 +2107,8 @@ mod tests {
         for chain_block in indexed_block_chain(&blocks[..blocks.len() - 1]) {
             for transaction in chain_block.transactions() {
                 // Remove any transparent outputs spent by this transaction.
-                for input in transaction.transparent().inputs() {
-                    if input.is_null_prevout() {
-                        continue;
-                    }
-
-                    let previous_transaction_hash = TransactionHash::from(*input.prevout_txid());
+                for outpoint in transaction.transparent().spent_outpoints() {
+                    let previous_transaction_hash = TransactionHash::from(*outpoint.prev_txid());
 
                     let unspent_output_indices = unspent_output_indices_by_transaction_hash
                         .get_mut(&previous_transaction_hash)
@@ -2133,11 +2120,11 @@ mod tests {
 
                     assert!(
                         unspent_output_indices
-                            .remove(&input.prevout_index())
+                            .remove(&outpoint.prev_index())
                             .is_some(),
                         "test vectors spend unknown output: transaction {:?}, output {}",
                         previous_transaction_hash,
-                        input.prevout_index()
+                        outpoint.prev_index()
                     );
 
                     if unspent_output_indices.is_empty() {

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/validation.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/validation.rs
@@ -320,14 +320,8 @@ impl DbV1 {
                 let Some(tx) = tx_opt else { continue };
 
                 // Inputs: check spent + addrhist input record
-                for input in tx.inputs().iter() {
-                    // Continue if coinbase.
-                    if input.is_null_prevout() {
-                        continue;
-                    }
-
+                for outpoint in tx.spent_outpoints() {
                     // Check spent record
-                    let outpoint = Outpoint::new(*input.prevout_txid(), input.prevout_index());
                     let outpoint_bytes = outpoint.to_bytes()?;
                     let val = ro.get(self.spent, &outpoint_bytes).map_err(|_| {
                         fail(&format!("missing spent index for outpoint {outpoint:?}"))

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
@@ -457,13 +457,7 @@ impl DbV1 {
             let tx_location = TxLocation::new(block_height.into(), tx_index);
 
             // Transparent Inputs: Build Spent Outpoints Index
-            for input in tx.transparent().inputs().iter() {
-                if input.is_null_prevout() {
-                    continue;
-                }
-
-                let prev_outpoint = Outpoint::new(*input.prevout_txid(), input.prevout_index());
-
+            for prev_outpoint in tx.transparent().spent_outpoints() {
                 if spent_map.insert(prev_outpoint, tx_location).is_some() {
                     return Err(FinalisedStateError::InvalidBlock {
                         height: block_height.0,
@@ -1136,11 +1130,7 @@ impl DbV1 {
                     })?;
                 let tx_location = TxLocation::new(block_height.0, tx_index);
 
-                for input in tx.transparent().inputs().iter() {
-                    if input.is_null_prevout() {
-                        continue;
-                    }
-                    let prev_outpoint = Outpoint::new(*input.prevout_txid(), input.prevout_index());
+                for prev_outpoint in tx.transparent().spent_outpoints() {
                     spent_batch.push((prev_outpoint.to_bytes()?, tx_location));
                 }
 
@@ -1372,13 +1362,7 @@ impl DbV1 {
             let tx_location = TxLocation::new(block_height.into(), _tx_index as u16);
 
             // Build Spent Outpoints Index
-            for input in tx.transparent().inputs().iter() {
-                if input.is_null_prevout() {
-                    continue;
-                }
-
-                let prev_outpoint = Outpoint::new(*input.prevout_txid(), input.prevout_index());
-
+            for prev_outpoint in tx.transparent().spent_outpoints() {
                 if spent_map.insert(prev_outpoint, tx_location).is_some() {
                     return Err(FinalisedStateError::InvalidBlock {
                         height: block_height.0,

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -160,7 +160,7 @@ use crate::{
     },
     config::ChainIndexConfig,
     error::FinalisedStateError,
-    Height, Outpoint, TransparentTxList, TxLocation, TxidList, ZainoVersionedSerde as _,
+    Height, TransparentTxList, TxLocation, TxidList, ZainoVersionedSerde as _,
 };
 
 use lmdb::{Transaction, WriteFlags};
@@ -855,13 +855,7 @@ impl<T: BlockchainSource> Migration<T> for Migration1_1_0To1_2_0 {
 
                     let tx_location = TxLocation::new(height.0, tx_index);
 
-                    for input in transparent_tx.inputs() {
-                        if input.is_null_prevout() {
-                            continue;
-                        }
-
-                        let outpoint = Outpoint::new(*input.prevout_txid(), input.prevout_index());
-
+                    for outpoint in transparent_tx.spent_outpoints() {
                         if spent_map.insert(outpoint, tx_location).is_some() {
                             return Err(FinalisedStateError::Custom(format!(
                                 "duplicate transparent spend for outpoint {:?} at height {}",

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/migrations/v1_1_to_v1_2.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/migrations/v1_1_to_v1_2.rs
@@ -20,7 +20,7 @@ use crate::chain_index::tests::init_tracing;
 use crate::chain_index::tests::vectors::{
     build_active_mockchain_source, load_test_vectors, TestVectorData,
 };
-use crate::{ChainIndexConfig, Height, Outpoint, TxLocation, ZainoVersionedSerde as _};
+use crate::{ChainIndexConfig, Height, TxLocation, ZainoVersionedSerde as _};
 
 const MIGRATION_SPENT_PROGRESS_KEY: &[u8] = b"_migration_spent_progress_1_2_0_next_height";
 
@@ -246,12 +246,7 @@ async fn assert_spent_index_matches_transparent_data(
 
             let expected_transaction_location = TxLocation::new(height.0, transaction_index as u16);
 
-            for input in transparent_transaction.inputs() {
-                if input.is_null_prevout() {
-                    continue;
-                }
-
-                let outpoint = Outpoint::new(*input.prevout_txid(), input.prevout_index());
+            for outpoint in transparent_transaction.spent_outpoints() {
                 let outpoint_bytes = outpoint.to_bytes().unwrap();
 
                 let spent_bytes = transaction

--- a/packages/zaino-state/src/chain_index/types/db/legacy.rs
+++ b/packages/zaino-state/src/chain_index/types/db/legacy.rs
@@ -3131,3 +3131,31 @@ pub mod serde_arrays {
             .map_err(|_| serde::de::Error::custom(format!("invalid length for [u8; {N}]")))
     }
 }
+
+#[cfg(test)]
+mod spent_outpoints {
+    use super::*;
+
+    #[test]
+    fn skips_null_prevout_and_maps_each_input() {
+        let tx = TransparentCompactTx::new(
+            vec![
+                TxInCompact::null_prevout(),    // coinbase input → skipped
+                TxInCompact::new([7u8; 32], 3), // spends output 3 of txid 0x07..
+                TxInCompact::new([8u8; 32], 0), // spends output 0 of txid 0x08..
+            ],
+            vec![],
+        );
+
+        assert_eq!(
+            tx.spent_outpoints().collect::<Vec<_>>(),
+            vec![Outpoint::new([7u8; 32], 3), Outpoint::new([8u8; 32], 0)],
+        );
+    }
+
+    #[test]
+    fn coinbase_only_transaction_yields_no_outpoints() {
+        let tx = TransparentCompactTx::new(vec![TxInCompact::null_prevout()], vec![]);
+        assert_eq!(tx.spent_outpoints().count(), 0);
+    }
+}

--- a/packages/zaino-state/src/chain_index/types/db/legacy.rs
+++ b/packages/zaino-state/src/chain_index/types/db/legacy.rs
@@ -1719,6 +1719,18 @@ impl TransparentCompactTx {
         &self.vout
     }
 
+    /// The outpoints this transaction spends — its non-coinbase prevouts.
+    ///
+    /// Coinbase inputs carry a null prevout (they reference no prior output) and
+    /// are skipped, so every yielded outpoint names a real previously-created
+    /// output.
+    pub(crate) fn spent_outpoints(&self) -> impl Iterator<Item = Outpoint> + '_ {
+        self.inputs()
+            .iter()
+            .filter(|input| !input.is_null_prevout())
+            .map(|input| Outpoint::new(*input.prevout_txid(), input.prevout_index()))
+    }
+
     /// Returns Proto CompactTxIn values, omitting the null prevout used by coinbase.
     pub fn compact_vin(&self) -> Vec<zaino_proto::proto::compact_formats::CompactTxIn> {
         self.inputs()


### PR DESCRIPTION
DRYs spent_outpoint collection.

All local test pass.

This PR unifies some ~8 disparate copies of the same logic into a single helper, and adds a unit-test to protect against regression across the helper.

With the ADDITION of a test, and documentation, this PR still nets ~ -11 LOC.