### PR TITLE
Finalize 0.4.2: strip -rc.1 release-candidate suffixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-fetch"
-version = "0.2.1-rc.1"
+version = "0.2.1"
 dependencies = [
  "base64",
  "byteorder",
@@ -5596,7 +5596,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-serve"
-version = "0.3.1-rc.1"
+version = "0.3.1"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -5616,7 +5616,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-state"
-version = "0.3.1-rc.1"
+version = "0.3.1"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -5671,7 +5671,7 @@ dependencies = [
 
 [[package]]
 name = "zainod"
-version = "0.4.2-rc.1"
+version = "0.4.2"
 dependencies = [
  "clap",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,10 +125,10 @@ portpicker = "0.1"
 tempfile = "3.2"
 zainod = { path = "packages/zainod" }
 zaino-common = { path = "packages/zaino-common", version = "0.2.0" }
-zaino-fetch = { path = "packages/zaino-fetch", version = "0.2.1-rc.1" }
+zaino-fetch = { path = "packages/zaino-fetch", version = "0.2.1" }
 zaino-proto = { path = "packages/zaino-proto", version = "0.1.3" }
-zaino-state = { path = "packages/zaino-state", version = "0.3.1-rc.1" }
-zaino-serve = { path = "packages/zaino-serve", version = "0.3.1-rc.1" }
+zaino-state = { path = "packages/zaino-state", version = "0.3.1" }
+zaino-serve = { path = "packages/zaino-serve", version = "0.3.1" }
 wire_serialized_transaction_test_data = "1.0.0"
 config = { version = "0.15", default-features = false, features = ["toml"] }
 nonempty = "0.11.0"

--- a/packages/zaino-fetch/Cargo.toml
+++ b/packages/zaino-fetch/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.1-rc.1"
+version = "0.2.1"
 
 [features]
 default = []

--- a/packages/zaino-serve/Cargo.toml
+++ b/packages/zaino-serve/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.1-rc.1"
+version = "0.3.1"
 
 [features]
 # Removes network restrictions.

--- a/packages/zaino-state/Cargo.toml
+++ b/packages/zaino-state/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.1-rc.1"
+version = "0.3.1"
 
 [features]
 default = []

--- a/packages/zainod/Cargo.toml
+++ b/packages/zainod/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.2-rc.1"
+version = "0.4.2"
 
 [[bin]]
 name = "zainod"


### PR DESCRIPTION
PR #1306 ("Release 0.4.2") merged `rc/0.4.2` into `stable` and the `0.4.2` tag was stamped on the result — but it never stripped the release-candidate suffixes. The tagged tree still self-identifies as `0.4.2-rc.1`, so it cannot be published to crates.io and no `0.4.2` Docker image / GitHub Release exist.

This drops `-rc.1` across the workspace so the crate versions match the tag:

| Crate | Before | After |
|---|---|---|
| `zainod` | `0.4.2-rc.1` | `0.4.2` |
| `zaino-fetch` | `0.2.1-rc.1` | `0.2.1` |
| `zaino-state` | `0.3.1-rc.1` | `0.3.1` |
| `zaino-serve` | `0.3.1-rc.1` | `0.3.1` |

Root `[workspace.dependencies]` pins updated to match and `Cargo.lock` regenerated (`cargo update --workspace`, 4 packages, no other churn). `zaino-common` (0.2.0) and `zaino-proto` (0.1.3) were already final and are untouched.

### Follow-up after merge
- Move the `0.4.2` tag onto the merge commit (`git tag -d 0.4.2 && git push origin :refs/tags/0.4.2`, then retag). The current tag never produced a Docker image, crates.io release, or GitHub Release, so nothing references it.
- Publish in dependency order — `zaino-fetch 0.2.1`, `zaino-state 0.3.1`, `zaino-serve 0.3.1` are new crates.io releases (registry currently has `.2.0`/`.3.0`/`.3.0`), then `zainod 0.4.2`.