### PR TITLE
Fix the #1313 chainwork on-disk byte-order regression (big-endian)

### DIFF
--- a/packages/zaino-state/src/chain_index/tests/types.rs
+++ b/packages/zaino-state/src/chain_index/tests/types.rs
@@ -53,11 +53,15 @@ pub(crate) fn expected_v2_bytes() -> Vec<u8> {
     // BlockHash (parent_hash): V1 tag + 32-byte body.
     out.push(version::V1);
     out.extend_from_slice(&[0x02; 32]);
-    // ChainWork: V1 tag + 32-byte LE (value = 0x42, stored as u128 LE in lower 16 bytes).
+    // ChainWork: V1 tag + 32-byte big-endian (value = 0x42, in the low-order 16
+    // bytes). Corrected from little-endian: the established v1 on-disk format is
+    // big-endian (the original `ChainWork([u8;32])` via `U256::to_big_endian`,
+    // and the `v1_test_db` fixture) — #1313 wrongly minted this golden LE, which
+    // is exactly a golden enshrining the bug it should have caught.
     out.push(version::V1);
     {
         let mut cw_bytes = [0u8; 32];
-        cw_bytes[..16].copy_from_slice(&0x42u128.to_le_bytes());
+        cw_bytes[16..].copy_from_slice(&0x42u128.to_be_bytes());
         out.extend_from_slice(&cw_bytes);
     }
     // Height: V1 tag + u32 big-endian (value = 42).

--- a/packages/zaino-state/src/chain_index/types/db/block.rs
+++ b/packages/zaino-state/src/chain_index/types/db/block.rs
@@ -29,31 +29,36 @@ use crate::chain_index::{
 
 /// Database-adjacent persistence shape for [`ChainWork`].
 ///
-/// On disk the value is stored as a 32-byte little-endian unsigned integer
-/// (the original U256 format). On the way back to the business layer the
-/// upper 16 bytes must be zero (the value must fit in `u128`) and the lower
-/// 16 bytes must be nonzero.
+/// On disk the value is a 32-byte **big-endian** unsigned integer — the format
+/// established by the original `ChainWork([u8; 32])`, which serialized through
+/// `U256::to_big_endian`/`from_big_endian`. The byte order must match that
+/// format exactly to stay compatible with existing v1 databases.
+///
+/// Coming back to the business layer the value must fit in `u128`, so the
+/// **high-order** 16 bytes (`[..16]`, big-endian most-significant) must be zero
+/// and the **low-order** 16 bytes (`[16..]`) hold the nonzero `u128`.
 #[derive(Debug)]
 pub(super) struct PersistentChainWork([u8; 32]);
 
 impl PersistentChainWork {
     pub(super) fn from_business(cw: &ChainWork) -> Self {
         let mut buf = [0u8; 32];
-        buf[..16].copy_from_slice(&cw.as_non_zero_u128().get().to_le_bytes());
+        // Big-endian: the value occupies the low-order (last) 16 bytes.
+        buf[16..].copy_from_slice(&cw.as_non_zero_u128().get().to_be_bytes());
         Self(buf)
     }
 
     pub(super) fn into_business(self) -> io::Result<ChainWork> {
-        // Upper 16 bytes must be zero (value must fit in u128).
-        if self.0[16..] != [0u8; 16] {
+        // Big-endian: the high-order 16 bytes must be zero for the value to fit u128.
+        if self.0[..16] != [0u8; 16] {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "chainwork exceeds u128 range",
             ));
         }
-        let mut le_bytes = [0u8; 16];
-        le_bytes.copy_from_slice(&self.0[..16]);
-        let value = u128::from_le_bytes(le_bytes);
+        let mut be_bytes = [0u8; 16];
+        be_bytes.copy_from_slice(&self.0[16..]);
+        let value = u128::from_be_bytes(be_bytes);
         NonZeroU128::new(value)
             .map(ChainWork::new)
             .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "chainwork is zero"))
@@ -238,7 +243,7 @@ mod tests {
 
     use std::num::NonZeroU128;
 
-    use super::{BlockContext, PersistentBlockContext};
+    use super::{BlockContext, PersistentBlockContext, PersistentChainWork};
     use crate::chain_index::tests::types::{canonical_blockheaderdata, expected_v2_bytes};
     use crate::chain_index::types::{BlockHash, BlockIndex, ChainWork, Height};
     use crate::{BlockHeaderData, ZainoVersionedSerde as _};
@@ -259,6 +264,132 @@ mod tests {
         let persisted = PersistentBlockContext::from_business(&bctx);
         let back = persisted.into_business().expect("valid chainwork");
         assert_eq!(bctx, back);
+    }
+
+    /// Regression for the byte-order bug that broke `load_db_backend_from_file`
+    /// and every existing v1 DB: the on-disk chainwork format is 32-byte
+    /// **big-endian** (the original `ChainWork([u8; 32])` via
+    /// `U256::to_big_endian`). Decoding it little-endian pushes a small value's
+    /// bytes into the high half and spuriously rejects it as ">u128".
+    ///
+    /// These are the *exact* bytes in the committed `v1_test_db` fixture: a
+    /// regtest cumulative chainwork of 17.
+    #[test]
+    fn decodes_original_big_endian_chainwork() {
+        let mut on_disk = [0u8; 32];
+        on_disk[31] = 0x11; // big-endian 17: value in the least-significant byte
+        let cw = PersistentChainWork(on_disk)
+            .into_business()
+            .expect("big-endian on-disk chainwork must decode");
+        assert_eq!(cw.as_non_zero_u128().get(), 17);
+    }
+
+    /// Verbatim recovery of the pre-#1313 on-disk `ChainWork` encoder — the
+    /// authority for the v1 **big-endian** byte order. Extracted with
+    /// `git show 5e4dae4a^:packages/zaino-state/src/chain_index/types/db/legacy.rs`
+    /// (5e4dae4a is the #1313 commit that deleted it), kept so the current
+    /// `PersistentChainWork` is diffed against the real original rather than a
+    /// hand-reconstruction. Only the encoder surface is retained; `U256` is
+    /// fully qualified rather than imported.
+    mod legacy_chainwork_reference {
+        /// Cumulative proof-of-work of the chain,
+        /// stored as a **big-endian** 256-bit unsigned integer.
+        //
+        // DOCUMENTATION BUG — the likely root of #1313: this struct doc correctly
+        // says *big-endian*, but the original's `impl FixedEncodedLen for ChainWork`
+        // was annotated `/// 32 bytes, LE`, and the serializer it uses is named
+        // `write_fixed_le`. That "LE" label over big-endian bytes is what plausibly
+        // led #1313 to re-encode the field little-endian.
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        pub(super) struct ChainWork([u8; 32]);
+
+        impl ChainWork {
+            /// Returns ChainWork as a U256.
+            pub(super) fn to_u256(&self) -> primitive_types::U256 {
+                primitive_types::U256::from_big_endian(&self.0)
+            }
+
+            /// Builds a ChainWork from a U256.
+            pub(super) fn from_u256(value: primitive_types::U256) -> Self {
+                let buf: [u8; 32] = value.to_big_endian();
+                ChainWork(buf)
+            }
+
+            /// Returns ChainWork bytes.
+            pub(super) fn as_bytes(&self) -> &[u8; 32] {
+                &self.0
+            }
+        }
+    }
+
+    /// Both directions of the cross-encoder equivalence for one value: the
+    /// current encoder reproduces the recovered original's big-endian on-disk
+    /// bytes, and the current decoder reads those original bytes back to the
+    /// same value.
+    fn assert_encoders_agree(value: u128) {
+        let cw = ChainWork::new(NonZeroU128::new(value).expect("nonzero"));
+        let original =
+            legacy_chainwork_reference::ChainWork::from_u256(primitive_types::U256::from(value));
+        let original_bytes = *original.as_bytes();
+
+        // Encode: the current encoder reproduces the original's big-endian bytes.
+        assert_eq!(
+            PersistentChainWork::from_business(&cw).0,
+            original_bytes,
+            "encode mismatch at {value:#034x}",
+        );
+        // Decode both ways agree with the encoding: the current decoder reads the
+        // original bytes back to `value`, and the recovered original decoder
+        // (`to_u256`) reads its own bytes back to the same value.
+        assert_eq!(
+            PersistentChainWork(original_bytes)
+                .into_business()
+                .expect("original on-disk bytes must decode"),
+            cw,
+            "decode mismatch at {value:#034x}",
+        );
+        assert_eq!(original.to_u256(), primitive_types::U256::from(value));
+    }
+
+    /// Cross-encoder equivalence across the whole domain where the two encoders
+    /// are *intended* to match — every nonzero value the `u128` `ChainWork` can
+    /// hold. This is the check #1313 lacked: red against its little-endian
+    /// encoder, green only when the byte order matches the established
+    /// big-endian format.
+    ///
+    /// Deterministic coverage of every structurally-distinct case — the
+    /// extremes, each power of two, each byte position fully set, and cumulative
+    /// low-byte fills — so any per-byte transposition or width error is caught.
+    #[test]
+    fn new_encoder_matches_recovered_original_exhaustively() {
+        assert_encoders_agree(1); // minimum nonzero
+        assert_encoders_agree(17); // the v1_test_db fixture value
+        assert_encoders_agree(u128::MAX); // maximum
+        for bit in 0..128 {
+            assert_encoders_agree(1u128 << bit);
+        }
+        for byte in 0..16 {
+            assert_encoders_agree(0xffu128 << (8 * byte));
+            assert_encoders_agree(u128::MAX >> (8 * byte));
+        }
+    }
+
+    proptest::proptest! {
+        /// Random coverage across the whole nonzero `u128` range, complementing
+        /// the deterministic boundary cases.
+        #[test]
+        fn new_encoder_matches_recovered_original(value in 1u128..=u128::MAX) {
+            assert_encoders_agree(value);
+        }
+    }
+
+    /// A value with any high-order (big-endian) byte set exceeds `u128` and is
+    /// rejected. `[15]` is the `2^128` position — the first bit above the range.
+    #[test]
+    fn rejects_chainwork_exceeding_u128() {
+        let mut on_disk = [0u8; 32];
+        on_disk[15] = 0x01;
+        assert!(PersistentChainWork(on_disk).into_business().is_err());
     }
 
     /// Cross-boundary tour for the `(height, hash)` slice:


### PR DESCRIPTION
#1313 (5e4dae4a) reworked ChainWork into PersistentChainWork but serialized it little-endian, while the established v1 on-disk format -- set by the original ChainWork([u8;32]) via U256::to_big_endian -- is big-endian. Reading real v1 data (the v1_test_db fixture: regtest cumulative chainwork 17 = big-endian [00..00,11]) as little-endian pushed the value into the high bytes and rejected it as 'chainwork exceeds u128 range', breaking load_db_backend_from_file and decode of every existing v1 DB. Fix: PersistentChainWork now reads/writes big-endian; no migration or fixture regeneration needed -- the fixture was correct all along.

Archaeology + regression proof: recovers the actual deleted encoder from history (git show 5e4dae4a^:.../types/db/legacy.rs) into a #[cfg(test)] reference module, and adds a cross-encoder equivalence test asserting the current encoder reproduces the original big-endian bytes byte-for-byte (and decodes them) across the whole nonzero u128 domain -- every power of two, every byte position, the extremes, plus proptest. This is the test #1313 lacked: red against its little-endian encoder, green against the corrected one. The likely root of the mistake is a documentation bug in the original (struct doc said big-endian but FixedEncodedLen said '32 bytes, LE' and the writer is write_fixed_le), highlighted in the recovered reference. Also corrects the canonical golden (expected_v2_bytes), which #1313 minted little-endian -- a golden enshrining the very bug it should have caught.