### PR TITLE
Harden init-podman-volumes against stale volume records

### DIFF
--- a/tools/scripts/init-podman-volumes.sh
+++ b/tools/scripts/init-podman-volumes.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 # Initialize named podman volumes for container builds.
 
+# `podman volume inspect` reads podman's database, not the filesystem, so a
+# volume can "exist" in the DB while its backing directory is gone (e.g. after
+# a partial ~/.local/share/containers cleanup or an interrupted `podman system
+# reset`). Podman then refuses to mount it with "failed to validate if host
+# path is dangerous: lstat .../volumes/<vol>: no such file or directory". Guard
+# on the actual Mountpoint directory, and force-recreate a stale record so the
+# DB and on-disk storage stay in sync.
 for vol in zaino-container-target zaino-cargo-git zaino-cargo-registry; do
-    if ! podman volume inspect "$vol" >/dev/null 2>&1; then
+    mountpoint="$(podman volume inspect --format '{{.Mountpoint}}' "$vol" 2>/dev/null)"
+    if [[ -z "$mountpoint" || ! -d "$mountpoint" ]]; then
+        # -z: no DB record. `! -d`: DB record present but backing dir gone;
+        # rm --force drops the dangling record before we recreate it.
+        podman volume rm --force "$vol" >/dev/null 2>&1 || true
         podman volume create "$vol"
         echo "Created podman volume: $vol"
     fi


### PR DESCRIPTION
## Problem

On `tekau`, `makers test all` failed with:

```
Error: failed to validate if host path is dangerous:
lstat /home/pua/.local/share/containers/storage/volumes/zaino-container-target: no such file or directory
Error while executing command, exit code: 127
```

Both live partitions produced no nextest summary because the container never started.

## Root cause

`init-podman-volumes.sh` guarded volume creation on `podman volume inspect`, which reads podman's **database**, not the filesystem. A named volume can exist in the DB while its backing directory is gone (after a partial `~/.local/share/containers` cleanup or an interrupted `podman system reset`). `inspect` then succeeds → `podman volume create` is skipped → the later `container-test` mount fails at `lstat`.

## Fix

Guard on the actual `Mountpoint` directory. When the DB record is missing **or** its backing dir is gone, `podman volume rm --force` drops the dangling record before recreating it, keeping the DB and on-disk storage in sync. The next `makers test` self-heals instead of requiring a full `podman system reset`.

## Notes

- No behavior change on a healthy host: volumes with an existing backing dir are left untouched.
- Kept as an in-place bash patch to minimize churn; folding this logic into the workbench crate can follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
