### PR TITLE
Fix nfs depth bug

### DIFF
--- a/live-tests/clientless/Cargo.toml
+++ b/live-tests/clientless/Cargo.toml
@@ -40,6 +40,10 @@ tracing.workspace = true
 
 [dev-dependencies]
 anyhow = { workspace = true }
+# Enable the tractable seam depth (fast-test-seam) so the chain_cache tests exercise
+# finalisation/eviction at small chain heights. Dev-dependency only — the feature
+# must never reach a shipped build (see the zaino-state feature comment).
+zaino-state = { workspace = true, features = ["fast-test-seam"] }
 
 # Test utility
 zainod = { workspace = true }

--- a/live-tests/clientless/tests/chain_cache.rs
+++ b/live-tests/clientless/tests/chain_cache.rs
@@ -285,8 +285,8 @@ mod chain_query_interface {
     /// validator via the ephemeral passthrough.
     ///
     /// In ephemeral mode `db_height` is `0`, so the non-finalised cache retains
-    /// blocks down to `tip - MAX_NFS_DEPTH` (110). We therefore generate well
-    /// past that depth and query a height below `tip - 110`, so the reads are
+    /// blocks only down to `tip - MAX_NFS_DEPTH` (a small margin past the seam). We
+    /// therefore generate well past that and query a height below it, so the reads are
     /// genuinely served by the ephemeral *finalised* passthrough rather than the
     /// non-finalised cache. The test then:
     /// - fetches a finalised chain (indexed) block by height, re-fetches it by
@@ -306,18 +306,22 @@ mod chain_query_interface {
             create_test_manager_and_chain_index::<C, Service>(validator, None, false, false, true)
                 .await;
 
-        // Generate well past MAX_NFS_DEPTH (110) so low heights are evicted from
-        // the non-finalised cache and served by the ephemeral finalised passthrough.
+        // The finalised floor sits at `tip - seam`; the non-finalised cache retains a
+        // little past that. Generate well beyond it so low heights are evicted from the
+        // cache and served by the ephemeral finalised passthrough. `fast-test-seam`
+        // shrinks the seam to `FAST_TEST_MAX_NONFINALISED_DEPTH`, so a small chain suffices.
+        let seam = zaino_common::consensus::FAST_TEST_MAX_NONFINALISED_DEPTH;
         test_manager
-            .generate_blocks_and_wait_for_tip(150, &indexer)
+            .generate_blocks_and_wait_for_tip(seam + 50, &indexer)
             .await;
         let snapshot = indexer.snapshot_nonfinalized_state().await.unwrap();
         let chain_height: u32 = json_service.get_blockchain_info().await.unwrap().blocks.0;
 
-        // `start_height` is below `tip - 110` (evicted from the NFS cache, served
-        // by the passthrough); `end_height` is above `tip - 100` (non-finalised).
-        let start_height: u32 = chain_height - 120;
-        let end_height: u32 = chain_height - 40;
+        // `start_height` is comfortably below the retention window → evicted from the NFS
+        // cache, served by the passthrough; `end_height` is above the finalised floor
+        // (`tip - seam`) → non-finalised.
+        let start_height: u32 = chain_height - (seam + 20);
+        let end_height: u32 = chain_height - seam / 2;
         let finalised_height = Height::try_from(start_height).unwrap();
 
         // --- chain (indexed) block: fetch by height, then by its hash ---
@@ -416,9 +420,11 @@ mod chain_query_interface {
         let snapshot = indexer.snapshot_nonfinalized_state().await.unwrap();
         let chain_height = json_service.get_blockchain_info().await.unwrap().blocks.0;
 
-        let finalised_start = Height::try_from(chain_height - 150).unwrap();
-        let finalised_tip = Height::try_from(chain_height - 100).unwrap();
-        let end = Height::try_from(chain_height - 50).unwrap();
+        // Finalised floor is `tip - seam`; pick a range straddling it.
+        let seam = zaino_common::consensus::FAST_TEST_MAX_NONFINALISED_DEPTH;
+        let finalised_start = Height::try_from(chain_height - (seam + 50)).unwrap();
+        let finalised_tip = Height::try_from(chain_height - seam).unwrap();
+        let end = Height::try_from(chain_height - seam / 2).unwrap();
 
         let finalized_blocks = indexer
             .get_block_range(&snapshot, finalised_start, Some(finalised_tip))

--- a/live-tests/e2e/Cargo.toml
+++ b/live-tests/e2e/Cargo.toml
@@ -57,3 +57,9 @@ hex = { workspace = true }
 corez = { workspace = true }
 tower = { workspace = true }
 serde_json = { workspace = true }
+
+[dev-dependencies]
+# Enable the tractable seam depth (fast-test-seam) so this crate's live tests can
+# exercise finalisation/eviction at small chain heights. Dev-dependency only — the
+# feature must never reach a shipped build (see the zaino-state feature comment).
+zaino-state = { workspace = true, features = ["fast-test-seam"] }

--- a/live-tests/e2e/tests/devtool.rs
+++ b/live-tests/e2e/tests/devtool.rs
@@ -21,7 +21,7 @@
 //!
 //! Deferred, with the capability each waits on:
 //! - `send_to_transparent` (heavy / finalization) — runnable now via orchard
-//!   funding, but the load-bearing 99-block advance across the finalized /
+//!   funding, but the load-bearing seam-deep advance across the finalized /
 //!   non-finalized boundary costs a halo2 proof per block; waits on cheap
 //!   filler-block mining (round-3 spec P2).
 //! - `monitor_unverified_mempool` — unconfirmed (mempool) wallet balances;
@@ -1579,13 +1579,13 @@ async fn get_block_range_out_of_range_lower_bound() {
 /// Port of `send_to_transparent` (wallet_to_validator, heavy/finalization,
 /// zebrad): a transparent send to the recipient returns the same address txids
 /// whether served from the non-finalized chain (just mined) or after the
-/// 99-block advance pushes the send past the finalization boundary
+/// seam-deep advance pushes the send past the finalization boundary
 /// (the seam depth `FAST_TEST_MAX_NONFINALISED_DEPTH` under `fast-test-seam`).
 ///
-/// `#[ignore]`d (gated): the load-bearing 99-block advance mines orchard
+/// `#[ignore]`d (gated): the load-bearing seam-deep advance mines orchard
 /// coinbase here — the devtool faucet funds via orchard, since the original's
 /// transparent-mine + shield path needs devtool transparent-coinbase shielding
-/// (round-2 P1) — so it costs ~99 halo2 proofs, against the net-speedup
+/// (round-2 P1) — so it costs ~100 halo2 proofs, against the net-speedup
 /// criterion. The miner pool is fixed at launch and `generate_blocks` has no
 /// per-call override, so the advance can't be cheap transparent filler until
 /// per-call filler mining (round-3 P2) lands; un-ignore and mine the advance to
@@ -1616,7 +1616,9 @@ where
     // here (see #[ignore] rationale).
     test_manager
         .generate_blocks_bulk_and_wait_for_tips(
-            99,
+            // Advance past the seam so the send crosses the finalised floor
+            // (`tip - seam`); a small margin above it keeps the boundary unambiguous.
+            zaino_common::consensus::FAST_TEST_MAX_NONFINALISED_DEPTH + 5,
             test_manager.subscriber(),
             test_manager.subscriber(),
         )
@@ -2332,7 +2334,7 @@ mod zebrad {
         #[tokio::test(flavor = "multi_thread")]
         #[cfg_attr(
             not(feature = "devtool-incompatible"),
-            ignore = "heavy: 99-block orchard advance (~99 halo2 proofs); un-ignore + transparent filler when round-3 P2 lands"
+            ignore = "heavy: seam-deep orchard advance (~100 halo2 proofs); un-ignore + transparent filler when round-3 P2 lands"
         )]
         async fn send_to_transparent_finalization() {
             crate::send_to_transparent_finalization::<FetchService>().await;
@@ -2585,7 +2587,7 @@ mod zebrad {
         #[tokio::test(flavor = "multi_thread")]
         #[cfg_attr(
             not(feature = "devtool-incompatible"),
-            ignore = "heavy: 99-block orchard advance (~99 halo2 proofs); un-ignore + transparent filler when round-3 P2 lands"
+            ignore = "heavy: seam-deep orchard advance (~100 halo2 proofs); un-ignore + transparent filler when round-3 P2 lands"
         )]
         async fn send_to_transparent_finalization() {
             crate::send_to_transparent_finalization::<StateService>().await;

--- a/live-tests/e2e/tests/devtool.rs
+++ b/live-tests/e2e/tests/devtool.rs
@@ -1580,7 +1580,7 @@ async fn get_block_range_out_of_range_lower_bound() {
 /// zebrad): a transparent send to the recipient returns the same address txids
 /// whether served from the non-finalized chain (just mined) or after the
 /// 99-block advance pushes the send past the finalization boundary
-/// (NON_FINALIZED_DEPTH = 100).
+/// (the seam depth `FAST_TEST_MAX_NONFINALISED_DEPTH` under `fast-test-seam`).
 ///
 /// `#[ignore]`d (gated): the load-bearing 99-block advance mines orchard
 /// coinbase here — the devtool faucet funds via orchard, since the original's
@@ -1611,8 +1611,9 @@ where
         .await
         .unwrap();
 
-    // The load-bearing advance: 99 blocks push the send below NON_FINALIZED_DEPTH
-    // into the finalized DB. Orchard coinbase here (see #[ignore] rationale).
+    // The load-bearing advance: these blocks push the send below the seam
+    // (`FAST_TEST_MAX_NONFINALISED_DEPTH`) into the finalized DB. Orchard coinbase
+    // here (see #[ignore] rationale).
     test_manager
         .generate_blocks_bulk_and_wait_for_tips(
             99,
@@ -2066,10 +2067,13 @@ async fn get_outpoint_spenders_fetch_vs_state() {
     use zaino_state::chain_index::types::ChainScope;
     use zaino_state::ChainIndex as _;
 
-    // `NON_FINALIZED_DEPTH` is 100; mining this many blocks past a spend buries
-    // it under the finalised floor so `ChainScope::Finalised` can resolve it.
-    // A small margin above 100 keeps the boundary unambiguous.
-    const FINALITY_DEPTH: u32 = 105;
+    // Bury a spend this many blocks past its block to push it below the finalised
+    // floor (tip − seam depth) so `ChainScope::Finalised` can resolve it. This crate
+    // enables `fast-test-seam`, so the live zaino-state uses the tractable
+    // `FAST_TEST_MAX_NONFINALISED_DEPTH`; a small margin above it keeps the boundary
+    // unambiguous. (Without the feature the real seam is ~1000, impractical to mine
+    // here — see zingolabs/zaino#1352.)
+    const FINALITY_DEPTH: u32 = zaino_common::consensus::FAST_TEST_MAX_NONFINALISED_DEPTH + 5;
     const FUNDING_AMOUNT: u64 = 250_000;
 
     let mut svc = zaino_testutils::launch_state_and_fetch_services_mining_to::<Zebrad>(
@@ -2518,7 +2522,7 @@ mod zebrad {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg_attr(
         not(feature = "devtool-incompatible"),
-        ignore = "heavy: mines ~110 orchard-coinbase blocks (~110 halo2 proofs) to bury a finalised spend below NON_FINALIZED_DEPTH; un-ignore for manual / dedicated CI"
+        ignore = "heavy: mines ~105 orchard-coinbase blocks (~105 halo2 proofs) to bury a finalised spend below the seam (FAST_TEST_MAX_NONFINALISED_DEPTH); un-ignore for manual / dedicated CI"
     )]
     async fn get_outpoint_spenders_fetch_vs_state() {
         crate::get_outpoint_spenders_fetch_vs_state().await;

--- a/live-tests/e2e/tests/devtool.rs
+++ b/live-tests/e2e/tests/devtool.rs
@@ -23,16 +23,15 @@
 //! - `send_to_transparent` (heavy / finalization) — runnable now via orchard
 //!   funding, but the load-bearing seam-deep advance across the finalized /
 //!   non-finalized boundary costs a halo2 proof per block; waits on cheap
-//!   filler-block mining (round-3 spec P2).
+//!   transparent filler-block mining.
 //! - `monitor_unverified_mempool` — unconfirmed (mempool) wallet balances;
-//!   devtool sync is block-based (round-3 spec P3 — likely stays on zingolib,
-//!   the indexer-side mempool views above already cover the surface).
+//!   devtool sync is block-based (likely stays on zingolib, the indexer-side
+//!   mempool views above already cover the surface).
 //! - the zcashd matrix (`json_server`, zcashd send/query) — the devtool wallet
-//!   rejects zcashd's default regtest activation heights at construction
-//!   (round-2 spec P0); `json_server` is additionally zcashd-bound (its
-//!   reference subscriber *is* zcashd).
-//! - the `test_vectors` chain builder — transparent-coinbase shielding
-//!   (round-2 spec P1).
+//!   rejects zcashd's default regtest activation heights at construction;
+//!   `json_server` is additionally zcashd-bound (its reference subscriber *is*
+//!   zcashd).
+//! - the `test_vectors` chain builder — devtool transparent-coinbase shielding.
 //! - `get_mempool_info` — recomputes expected sizes from
 //!   `FetchServiceSubscriber` internals; low value over the mempool surfaces
 //!   already covered.
@@ -1321,8 +1320,7 @@ async fn get_address_balance_fetch_vs_state() {
 /// `launch_and_build_faucet_request`'s preamble for the faucet-taddr query
 /// tests. The faucet taddr is the abandon-art transparent receiver, which is
 /// also the zebrad miner address under transparent mining; the non-vacuity
-/// probes in the callers verify that equality empirically (devtool round-2
-/// spec P1(1)).
+/// probes in the callers verify that equality empirically.
 async fn launch_transparent_and_faucet_taddr(
     blocks: u32,
 ) -> (zaino_testutils::StateAndFetchServices<Zebrad>, String) {
@@ -1356,7 +1354,7 @@ async fn launch_transparent_and_faucet_taddr(
 /// the fetch and state indexers agree on `get_address_tx_ids` over the faucet's
 /// coinbase taddr. The non-vacuity probe (`!txids.is_empty()`) guards against a
 /// silent empty==empty pass and confirms the devtool faucet's transparent
-/// receiver equals the zebrad miner address (devtool round-2 spec P1(1)).
+/// receiver equals the zebrad miner address.
 async fn get_taddress_txids_faucet_fetch_vs_state() {
     let (mut svc, faucet_taddr) = launch_transparent_and_faucet_taddr(100).await;
 
@@ -1384,8 +1382,7 @@ async fn get_taddress_txids_faucet_fetch_vs_state() {
 /// Port of `state_service_…::get_taddress_balance` (zebrad, faucet-taddr
 /// cluster): the fetch and state indexers agree on `get_taddress_balance` over
 /// the faucet's coinbase taddr. The non-vacuity probe (`value_zat > 0`) guards
-/// against a silent 0==0 pass and confirms the address equality of round-2
-/// spec P1(1).
+/// against a silent 0==0 pass and confirms the address equality.
 async fn get_taddress_balance_faucet_fetch_vs_state() {
     let (mut svc, faucet_taddr) = launch_transparent_and_faucet_taddr(5).await;
 
@@ -1585,10 +1582,10 @@ async fn get_block_range_out_of_range_lower_bound() {
 /// `#[ignore]`d (gated): the load-bearing seam-deep advance mines orchard
 /// coinbase here — the devtool faucet funds via orchard, since the original's
 /// transparent-mine + shield path needs devtool transparent-coinbase shielding
-/// (round-2 P1) — so it costs ~100 halo2 proofs, against the net-speedup
+/// — so it costs ~100 halo2 proofs, against the net-speedup
 /// criterion. The miner pool is fixed at launch and `generate_blocks` has no
 /// per-call override, so the advance can't be cheap transparent filler until
-/// per-call filler mining (round-3 P2) lands; un-ignore and mine the advance to
+/// per-call filler mining lands; un-ignore and mine the advance to
 /// a transparent throwaway then.
 async fn send_to_transparent_finalization<Service>()
 where
@@ -2334,7 +2331,7 @@ mod zebrad {
         #[tokio::test(flavor = "multi_thread")]
         #[cfg_attr(
             not(feature = "devtool-incompatible"),
-            ignore = "heavy: seam-deep orchard advance (~100 halo2 proofs); un-ignore + transparent filler when round-3 P2 lands"
+            ignore = "heavy: seam-deep orchard advance (~100 halo2 proofs); un-ignore + transparent filler when cheap filler mining lands"
         )]
         async fn send_to_transparent_finalization() {
             crate::send_to_transparent_finalization::<FetchService>().await;
@@ -2587,7 +2584,7 @@ mod zebrad {
         #[tokio::test(flavor = "multi_thread")]
         #[cfg_attr(
             not(feature = "devtool-incompatible"),
-            ignore = "heavy: seam-deep orchard advance (~100 halo2 proofs); un-ignore + transparent filler when round-3 P2 lands"
+            ignore = "heavy: seam-deep orchard advance (~100 halo2 proofs); un-ignore + transparent filler when cheap filler mining lands"
         )]
         async fn send_to_transparent_finalization() {
             crate::send_to_transparent_finalization::<StateService>().await;

--- a/live-tests/e2e/tests/devtool_zcashd.rs
+++ b/live-tests/e2e/tests/devtool_zcashd.rs
@@ -10,8 +10,8 @@
 //!
 //! zcashd mines ORCHARD coinbase to `REG_O_ADDR_FROM_ABANDONART` (the abandon-art
 //! orchard address the devtool faucet owns), so the faucet is funded with no
-//! transparent-coinbase shielding — the zcashd matrix is NOT gated on round-2
-//! P1, only on this heights alignment.
+//! transparent-coinbase shielding — the zcashd matrix is NOT gated on devtool
+//! transparent-coinbase shielding, only on this heights alignment.
 //!
 //! If this passes, the `json_server` tests port by swapping their zingolib
 //! funding for `DevtoolClients` while keeping the zaino-vs-zcashd oracle
@@ -483,8 +483,9 @@ async fn shield_for_validator() {
 
 /// Devtool ports of `wallet_to_validator`'s `mod zcashd` send/shield/get-info
 /// column. Deferred: the heavy finalization send (`sent_to::transparent`'s
-/// seam-deep mine, round-3 P2), `sent_to::all`, and `monitor_unverified_mempool`
-/// (round-3 P3). `send_to_transparent` here is the light send, matching the
+/// seam-deep mine, waits on cheap filler mining), `sent_to::all`, and
+/// `monitor_unverified_mempool` (unconfirmed mempool balances).
+/// `send_to_transparent` here is the light send, matching the
 /// zebrad devtool port.
 mod wallet_to_validator {
     use super::*;
@@ -521,11 +522,11 @@ mod wallet_to_validator {
     /// a transparent send returns the same address txids from the non-finalized
     /// chain and after the seam-deep advance into the finalized DB. `#[ignore]`d
     /// for the same reason — the advance mines orchard coinbase (~100 halo2
-    /// proofs) until per-call cheap filler mining (round-3 P2) lands.
+    /// proofs) until per-call cheap filler mining lands.
     #[tokio::test(flavor = "multi_thread")]
     #[cfg_attr(
         not(feature = "devtool-incompatible"),
-        ignore = "heavy: seam-deep orchard advance (~100 halo2 proofs); un-ignore + transparent filler when round-3 P2 lands"
+        ignore = "heavy: seam-deep orchard advance (~100 halo2 proofs); un-ignore + transparent filler when cheap filler mining lands"
     )]
     async fn send_to_transparent_finalization() {
         let (mut test_manager, mut clients) = launch_and_fund_zcashd_faucet(1).await;
@@ -578,7 +579,7 @@ mod wallet_to_validator {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg_attr(
         not(feature = "devtool-incompatible"),
-        ignore = "heavy: seam-deep orchard advance (~100 halo2 proofs); re-port light or un-ignore with transparent filler (round-3 P2)"
+        ignore = "heavy: seam-deep orchard advance (~100 halo2 proofs); re-port light or un-ignore with transparent filler"
     )]
     async fn send_to_all() {
         let (mut test_manager, mut clients) = launch_and_fund_zcashd_faucet(3).await;

--- a/live-tests/e2e/tests/devtool_zcashd.rs
+++ b/live-tests/e2e/tests/devtool_zcashd.rs
@@ -483,7 +483,7 @@ async fn shield_for_validator() {
 
 /// Devtool ports of `wallet_to_validator`'s `mod zcashd` send/shield/get-info
 /// column. Deferred: the heavy finalization send (`sent_to::transparent`'s
-/// 99-block mine, round-3 P2), `sent_to::all`, and `monitor_unverified_mempool`
+/// seam-deep mine, round-3 P2), `sent_to::all`, and `monitor_unverified_mempool`
 /// (round-3 P3). `send_to_transparent` here is the light send, matching the
 /// zebrad devtool port.
 mod wallet_to_validator {
@@ -519,13 +519,13 @@ mod wallet_to_validator {
 
     /// zcashd analogue of devtool.rs's gated `send_to_transparent_finalization`:
     /// a transparent send returns the same address txids from the non-finalized
-    /// chain and after the 99-block advance into the finalized DB. `#[ignore]`d
-    /// for the same reason — the advance mines orchard coinbase (~99 halo2
+    /// chain and after the seam-deep advance into the finalized DB. `#[ignore]`d
+    /// for the same reason — the advance mines orchard coinbase (~100 halo2
     /// proofs) until per-call cheap filler mining (round-3 P2) lands.
     #[tokio::test(flavor = "multi_thread")]
     #[cfg_attr(
         not(feature = "devtool-incompatible"),
-        ignore = "heavy: 99-block orchard advance (~99 halo2 proofs); un-ignore + transparent filler when round-3 P2 lands"
+        ignore = "heavy: seam-deep orchard advance (~100 halo2 proofs); un-ignore + transparent filler when round-3 P2 lands"
     )]
     async fn send_to_transparent_finalization() {
         let (mut test_manager, mut clients) = launch_and_fund_zcashd_faucet(1).await;
@@ -545,7 +545,9 @@ mod wallet_to_validator {
 
         test_manager
             .generate_blocks_bulk_and_wait_for_tips(
-                99,
+                // Advance past the seam so the send crosses the finalised floor
+                // (`tip - seam`); a small margin above it keeps the boundary unambiguous.
+                zaino_common::consensus::FAST_TEST_MAX_NONFINALISED_DEPTH + 5,
                 test_manager.subscriber(),
                 test_manager.subscriber(),
             )
@@ -567,8 +569,8 @@ mod wallet_to_validator {
     }
 
     /// zcashd port of `sent_to::all` (heavy): one faucet funds a send to all
-    /// three pools, then a 100-block advance, and each recipient pool reports
-    /// 250_000. `#[ignore]`d: the 100-block advance mines orchard coinbase
+    /// three pools, then a seam-deep advance, and each recipient pool reports
+    /// 250_000. `#[ignore]`d: the seam-deep advance mines orchard coinbase
     /// (~100 halo2 proofs). The advance is faithful to the original but not
     /// load-bearing for the per-pool balance asserts (the sends confirm in one
     /// block), so this could be re-ported light (like the zebrad `send_to_all`)
@@ -576,7 +578,7 @@ mod wallet_to_validator {
     #[tokio::test(flavor = "multi_thread")]
     #[cfg_attr(
         not(feature = "devtool-incompatible"),
-        ignore = "heavy: 100-block orchard advance (~100 halo2 proofs); re-port light or un-ignore with transparent filler (round-3 P2)"
+        ignore = "heavy: seam-deep orchard advance (~100 halo2 proofs); re-port light or un-ignore with transparent filler (round-3 P2)"
     )]
     async fn send_to_all() {
         let (mut test_manager, mut clients) = launch_and_fund_zcashd_faucet(3).await;
@@ -590,7 +592,8 @@ mod wallet_to_validator {
 
         test_manager
             .generate_blocks_bulk_and_wait_for_tips(
-                100,
+                // Advance past the seam so all three pool sends cross the finalised floor.
+                zaino_common::consensus::FAST_TEST_MAX_NONFINALISED_DEPTH + 5,
                 test_manager.subscriber(),
                 test_manager.subscriber(),
             )

--- a/live-tests/e2e/tests/test_vectors.rs
+++ b/live-tests/e2e/tests/test_vectors.rs
@@ -40,7 +40,7 @@ macro_rules! expected_read_response {
 #[tokio::test(flavor = "multi_thread")]
 #[cfg_attr(
     not(feature = "devtool-incompatible"),
-    ignore = "Not a test: builds test-vector data for zaino_state::chain_index unit tests. Also funds via transparent-coinbase shielding (round-2 P1) — un-ignore to regenerate vectors once devtool can shield its own transparent coinbase (tracked by tests/devtool.rs's address_deltas)."
+    ignore = "Not a test: builds test-vector data for zaino_state::chain_index unit tests. Also funds via transparent-coinbase shielding — un-ignore to regenerate vectors once devtool can shield its own transparent coinbase (tracked by tests/devtool.rs's address_deltas)."
 )]
 #[allow(deprecated)]
 async fn create_200_block_regtest_chain_vectors() {
@@ -81,7 +81,7 @@ async fn create_200_block_regtest_chain_vectors() {
     // *** Mine past coinbase maturity, shield the first reward, and mine it in ***
     // Mature the faucet's transparent coinbase (100-block maturity) and shield
     // it. Devtool analogue of `shield_faucet_rounds`; requires the devtool wallet
-    // to spend its own transparent coinbase (round-2 P1, see #[ignore]). Mine
+    // to spend its own transparent coinbase (see #[ignore]). Mine
     // generously (150) so the earliest coinbase — a few blocks past genesis — is
     // comfortably mature before the shield, regardless of startup height.
     test_manager

--- a/packages/zaino-common/src/consensus.rs
+++ b/packages/zaino-common/src/consensus.rs
@@ -1,0 +1,25 @@
+//! Consensus-derived constants with a single source of truth.
+//!
+//! Each value derives from zebra's authoritative upstream constant; nothing else in
+//! the workspace should hard-code these — reference this module instead.
+
+/// Number of confirmations before a coinbase output becomes spendable.
+///
+/// Single source of truth, from zebra's transparent-coinbase maturity rule.
+pub const COINBASE_MATURITY: u32 = zebra_chain::transparent::MIN_TRANSPARENT_COINBASE_MATURITY;
+
+/// Distance below the best-chain tip of the finalised / non-finalised seam: a block
+/// buried deeper than this is finalised (reorg-stable).
+///
+/// Derived from zebra's protocol reorg limit (`MAX_BLOCK_REORG_HEIGHT`). The `+ 1`
+/// accounts for the tip block itself, preserving the historical seam semantics.
+pub const MAX_NONFINALISED_DEPTH: u32 =
+    zebra_chain::parameters::constants::MAX_BLOCK_REORG_HEIGHT + 1;
+
+/// A tractable one-tenth of [`MAX_NONFINALISED_DEPTH`], for fast tests that need a
+/// finalised seam without building a full ~[`MAX_NONFINALISED_DEPTH`]-block chain.
+///
+/// Integer division, so this is `100` when the real depth is `1001`. Test-only: it
+/// lets in-crate tests select a shallow seam that still derives from the single
+/// source of truth rather than a hard-coded literal.
+pub const FAST_TEST_MAX_NONFINALISED_DEPTH: u32 = MAX_NONFINALISED_DEPTH / 10;

--- a/packages/zaino-common/src/lib.rs
+++ b/packages/zaino-common/src/lib.rs
@@ -4,6 +4,7 @@
 //! and common utilities used across the Zaino blockchain indexer ecosystem.
 
 pub mod config;
+pub mod consensus;
 pub mod logging;
 pub mod net;
 pub mod probing;

--- a/packages/zaino-state/Cargo.toml
+++ b/packages/zaino-state/Cargo.toml
@@ -11,6 +11,14 @@ version = "0.3.1"
 [features]
 default = []
 
+# TEST-ONLY: shrink the finalised/non-finalised seam to the tractable
+# `FAST_TEST_MAX_NONFINALISED_DEPTH` so cross-crate live tests can exercise
+# finalisation/eviction with small chains. MUST appear only in `[dev-dependencies]`
+# of the live-test crates — never a normal/shipped dependency: resolver = "2" keeps
+# dev-dependency features out of production dependency graphs, and `default-members`
+# excludes the live-test crates from production builds.
+fast-test-seam = []
+
 # Support for connecting to a zcashd validator node. Opt-in (default off, docs/adr/0005); being
 # deprecated. Forwards to zaino-fetch. See
 # docs/adr/0001-zcashd-support-feature-gate.md.

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -73,18 +73,19 @@ mod tests;
 ///
 /// Sourced from the workspace's single source of truth,
 /// [`zaino_common::consensus`]. Production uses the real
-/// [`MAX_NONFINALISED_DEPTH`]. In-crate unit tests select the tractable
-/// [`FAST_TEST_MAX_NONFINALISED_DEPTH`] (= depth / 10) so the short mock-chain
-/// fixtures still exercise a *moving* finalised seam — at the real depth
-/// `finalized_height_floor` would saturate to genesis for the whole fixture and the
-/// eviction/seam invariants become untestable (see zingolabs/zaino#1288). Both arms
-/// derive from the same upstream reorg bound, so neither is a hard-coded literal.
+/// [`MAX_NONFINALISED_DEPTH`]. The tractable [`FAST_TEST_MAX_NONFINALISED_DEPTH`]
+/// (= depth / 10) is selected for in-crate unit tests (`cfg(test)`) *and* for
+/// cross-crate live tests that enable the `fast-test-seam` feature — so short mock
+/// fixtures and small live chains still exercise a *moving* finalised seam. At the
+/// real depth `finalized_height_floor` saturates to genesis for those fixtures and
+/// the eviction/seam invariants become untestable (see zingolabs/zaino#1288). Both
+/// arms derive from the same upstream reorg bound, so neither is a hard-coded literal.
 ///
 /// [`MAX_NONFINALISED_DEPTH`]: zaino_common::consensus::MAX_NONFINALISED_DEPTH
 /// [`FAST_TEST_MAX_NONFINALISED_DEPTH`]: zaino_common::consensus::FAST_TEST_MAX_NONFINALISED_DEPTH
-#[cfg(not(test))]
+#[cfg(not(any(test, feature = "fast-test-seam")))]
 pub(crate) const NON_FINALIZED_DEPTH: u32 = zaino_common::consensus::MAX_NONFINALISED_DEPTH;
-#[cfg(test)]
+#[cfg(any(test, feature = "fast-test-seam"))]
 pub(crate) const NON_FINALIZED_DEPTH: u32 =
     zaino_common::consensus::FAST_TEST_MAX_NONFINALISED_DEPTH;
 

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -2,7 +2,7 @@
 //!
 //! Components:
 //! - Mempool: Holds mempool transactions
-//! - NonFinalisedState: Holds block data for the top 100 blocks of all chains.
+//! - NonFinalisedState: Holds block data for the top `NON_FINALIZED_DEPTH` blocks of all chains.
 //! - FinalisedState: Holds block data for the remainder of the best chain.
 //!
 //! - Chain: Holds chain / block structs used internally by the ChainIndex.
@@ -196,7 +196,7 @@ fn branch_len_to_active_chain(
 /// The interface to the chain index.
 ///
 /// `ChainIndex` provides a unified interface for querying blockchain data from different
-/// backend sources. It combines access to both finalized state (older than 100 blocks) and
+/// backend sources. It combines access to both finalized state (older than `NON_FINALIZED_DEPTH` blocks) and
 /// non-finalized state (recent blocks that may still be reorganized).
 ///
 /// # Implementation
@@ -1621,7 +1621,7 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
     /// between the given heights.
     /// Returns None if the specified start height
     /// is greater than the snapshot's tip and greater
-    /// than the validator's finalized height (100 blocks below tip)
+    /// than the validator's finalized height (`NON_FINALIZED_DEPTH` blocks below tip)
     fn get_block_range(
         &self,
         snapshot: &Self::Snapshot,
@@ -1773,9 +1773,11 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
     ) -> Result<Option<CompactBlockStream>, Self::Error> {
         let chain_tip_height = self.best_chaintip(nonfinalized_snapshot).await?.height;
 
-        // The nonfinalized cache holds the tip block plus the previous 99 blocks (100 total),
-        // so the lowest possible cached height is `tip - 99` (saturating at 0).
-        let lowest_nonfinalized_height = types::Height(chain_tip_height.0.saturating_sub(99));
+        // The finalised state serves heights up to `finalized_height_floor(tip)`
+        // (= `tip - NON_FINALIZED_DEPTH`, saturating at genesis); the non-finalised cache serves
+        // everything above it, so the lowest non-finalised height is one past the finalised floor.
+        let lowest_nonfinalized_height =
+            types::Height(finalized_height_floor(chain_tip_height.0).0 + 1);
 
         let is_ascending = start_height <= end_height;
 

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -2,7 +2,7 @@
 //!
 //! Components:
 //! - Mempool: Holds mempool transactions
-//! - NonFinalisedState: Holds block data for the top `NON_FINALIZED_DEPTH` blocks of all chains.
+//! - NonFinalisedState: Holds block data for the top `OPERATIONAL_NFS_DEPTH` blocks of all chains.
 //! - FinalisedState: Holds block data for the remainder of the best chain.
 //!
 //! - Chain: Holds chain / block structs used internally by the ChainIndex.
@@ -53,11 +53,11 @@ use zebra_rpc::{
 use zebra_state::HashOrHeight;
 
 pub mod encoding;
-/// All state below [`NON_FINALIZED_DEPTH`] blocks of the best-known chain tip.
+/// All state below [`OPERATIONAL_NFS_DEPTH`] blocks of the best-known chain tip.
 pub mod finalised_state;
 /// State in the mempool, not yet on-chain
 pub mod mempool;
-/// State within [`NON_FINALIZED_DEPTH`] blocks of the best-known chain tip;
+/// State within [`OPERATIONAL_NFS_DEPTH`] blocks of the best-known chain tip;
 /// stored separately as it may be reorged.
 pub mod non_finalised_state;
 /// BlockchainSource
@@ -84,9 +84,9 @@ mod tests;
 /// [`MAX_NONFINALISED_DEPTH`]: zaino_common::consensus::MAX_NONFINALISED_DEPTH
 /// [`FAST_TEST_MAX_NONFINALISED_DEPTH`]: zaino_common::consensus::FAST_TEST_MAX_NONFINALISED_DEPTH
 #[cfg(not(any(test, feature = "fast-test-seam")))]
-pub(crate) const NON_FINALIZED_DEPTH: u32 = zaino_common::consensus::MAX_NONFINALISED_DEPTH;
+pub(crate) const OPERATIONAL_NFS_DEPTH: u32 = zaino_common::consensus::MAX_NONFINALISED_DEPTH;
 #[cfg(any(test, feature = "fast-test-seam"))]
-pub(crate) const NON_FINALIZED_DEPTH: u32 =
+pub(crate) const OPERATIONAL_NFS_DEPTH: u32 =
     zaino_common::consensus::FAST_TEST_MAX_NONFINALISED_DEPTH;
 
 /// Lower bound on zaino's finalized-DB tip, derived from the current
@@ -98,7 +98,7 @@ pub(crate) const NON_FINALIZED_DEPTH: u32 =
 /// `finalized_height` should account for the asymmetry
 /// (see zingolabs/zaino#1128).
 pub(crate) fn finalized_height_floor(chain_tip: u32) -> crate::Height {
-    crate::Height(chain_tip.saturating_sub(NON_FINALIZED_DEPTH))
+    crate::Height(chain_tip.saturating_sub(OPERATIONAL_NFS_DEPTH))
 }
 
 /// Current wall-clock time as a Unix timestamp in fractional seconds, for
@@ -194,7 +194,7 @@ fn branch_len_to_active_chain(
 /// The interface to the chain index.
 ///
 /// `ChainIndex` provides a unified interface for querying blockchain data from different
-/// backend sources. It combines access to both finalized state (older than `NON_FINALIZED_DEPTH` blocks) and
+/// backend sources. It combines access to both finalized state (older than `OPERATIONAL_NFS_DEPTH` blocks) and
 /// non-finalized state (recent blocks that may still be reorganized).
 ///
 /// # Implementation
@@ -937,7 +937,7 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                         Some(ref nfs) => nfs,
                         None => {
                             // Anchor the non-finalised state at `finalised_height`
-                            // (= chain tip − NON_FINALIZED_DEPTH), never at genesis: a missing
+                            // (= chain tip − OPERATIONAL_NFS_DEPTH), never at genesis: a missing
                             // anchor used to fall through to genesis and then re-anchor up to the
                             // lagging finalised tip, grinding millions of blocks one at a time
                             // (#1261). `resolve_anchor_block` serves the anchor from the finalised
@@ -1619,7 +1619,7 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
     /// between the given heights.
     /// Returns None if the specified start height
     /// is greater than the snapshot's tip and greater
-    /// than the validator's finalized height (`NON_FINALIZED_DEPTH` blocks below tip)
+    /// than the validator's finalized height (`OPERATIONAL_NFS_DEPTH` blocks below tip)
     fn get_block_range(
         &self,
         snapshot: &Self::Snapshot,
@@ -1772,7 +1772,7 @@ impl<Source: BlockchainSource> ChainIndex for NodeBackedChainIndexSubscriber<Sou
         let chain_tip_height = self.best_chaintip(nonfinalized_snapshot).await?.height;
 
         // The finalised state serves heights up to `finalized_height_floor(tip)`
-        // (= `tip - NON_FINALIZED_DEPTH`, saturating at genesis); the non-finalised cache serves
+        // (= `tip - OPERATIONAL_NFS_DEPTH`, saturating at genesis); the non-finalised cache serves
         // everything above it, so the lowest non-finalised height is one past the finalised floor.
         let lowest_nonfinalized_height =
             types::Height(finalized_height_floor(chain_tip_height.0).0 + 1);

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -68,28 +68,25 @@ pub mod types;
 #[cfg(test)]
 mod tests;
 
-/// Distance (in blocks) between the best-known chain tip and the
-/// highest block that zaino treats as part of the finalized DB.
+/// Distance (in blocks) between the best-known chain tip and the highest block that
+/// zaino treats as part of the finalised DB — the finalised / non-finalised seam.
 ///
-/// Sourced from Zebra's protocol-derived reorg bound. The `+ 1`
-/// preserves the original literal-`100` behavior; deriving the
-/// depth from an explicit wider-consensus reference is tracked in
-/// zingolabs/zaino#1130.
+/// Sourced from the workspace's single source of truth,
+/// [`zaino_common::consensus`]. Production uses the real
+/// [`MAX_NONFINALISED_DEPTH`]. In-crate unit tests select the tractable
+/// [`FAST_TEST_MAX_NONFINALISED_DEPTH`] (= depth / 10) so the short mock-chain
+/// fixtures still exercise a *moving* finalised seam — at the real depth
+/// `finalized_height_floor` would saturate to genesis for the whole fixture and the
+/// eviction/seam invariants become untestable (see zingolabs/zaino#1288). Both arms
+/// derive from the same upstream reorg bound, so neither is a hard-coded literal.
+///
+/// [`MAX_NONFINALISED_DEPTH`]: zaino_common::consensus::MAX_NONFINALISED_DEPTH
+/// [`FAST_TEST_MAX_NONFINALISED_DEPTH`]: zaino_common::consensus::FAST_TEST_MAX_NONFINALISED_DEPTH
 #[cfg(not(test))]
-pub(crate) const NON_FINALIZED_DEPTH: u32 = zebra_state::MAX_BLOCK_REORG_HEIGHT + 1;
-
-/// In-crate unit tests pin the depth at the pre-zebra-10 value (`100`).
-///
-/// Zebra 10 raised `MAX_BLOCK_REORG_HEIGHT` from 99 to 1000, so the
-/// production depth is now 1001. The 201-block mock-chain test vector is
-/// far shorter than that, so at the production depth `finalized_height_floor`
-/// saturates to genesis for the whole fixture: the finalized seam never moves
-/// off block 0 and the eviction/seam invariants become untestable (see
-/// zingolabs/zaino#1288). The eviction and seam invariants are scale-free, so
-/// exercising them at a tractable depth is sound; the production depth is
-/// covered by the clientless suite, which reaches real chain heights.
+pub(crate) const NON_FINALIZED_DEPTH: u32 = zaino_common::consensus::MAX_NONFINALISED_DEPTH;
 #[cfg(test)]
-pub(crate) const NON_FINALIZED_DEPTH: u32 = 100;
+pub(crate) const NON_FINALIZED_DEPTH: u32 =
+    zaino_common::consensus::FAST_TEST_MAX_NONFINALISED_DEPTH;
 
 /// Lower bound on zaino's finalized-DB tip, derived from the current
 /// best-known chain tip.

--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides `FinalisedState`, the *finalised* portion of the chain index.
 //!
-//! “Finalised” in this context means: All but the top `NON_FINALIZED_DEPTH` blocks in the blockchain. This
+//! “Finalised” in this context means: All but the top `OPERATIONAL_NFS_DEPTH` blocks in the blockchain. This
 //! follows Zebra's model where a reorg deeper than `MAX_BLOCK_REORG_HEIGHT` would require a complete network restart.
 //!
 //! `FinalisedState` is a facade over a `FinalisedSource` — the

--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -2,8 +2,8 @@
 //!
 //! This module provides `FinalisedState`, the *finalised* portion of the chain index.
 //!
-//! “Finalised” in this context means: All but the top 100 blocks in the blockchain. This follows
-//! Zebra's model where a reorg of depth greater than 100 would require a complete network restart.
+//! “Finalised” in this context means: All but the top `NON_FINALIZED_DEPTH` blocks in the blockchain. This
+//! follows Zebra's model where a reorg deeper than `MAX_BLOCK_REORG_HEIGHT` would require a complete network restart.
 //!
 //! `FinalisedState` is a facade over a `FinalisedSource` — the
 //! backing implementation that actually serves finalised data. That backing is **not necessarily a

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/tx_out_set_accumulator.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/tx_out_set_accumulator.rs
@@ -2161,7 +2161,7 @@ mod tests {
     /// by a small range (`write_blocks_to_height`'s steady-state branch) — must produce exactly the
     /// accumulator a full from-genesis rebuild produces at the same tip, for all five fields. This is
     /// the correctness gate for `update_tx_out_set_accumulator_for_range`: with regtest coinbase
-    /// maturity of 100, splitting the sync at height 100 guarantees the second segment spends outputs
+    /// maturity `COINBASE_MATURITY`, splitting the sync at that height guarantees the second segment spends outputs
     /// created in the first (exercising the `transactions` "Set B" decrement) as well as outputs both
     /// created and spent within the range (the XOR-cancel case).
     #[tokio::test(flavor = "multi_thread")]
@@ -2171,6 +2171,7 @@ mod tests {
         use crate::chain_index::finalised_state::capability::{
             CapabilityRequest, DbRead, TransparentHistExt,
         };
+        use zaino_common::consensus::COINBASE_MATURITY;
 
         let blocks = load_test_vectors().unwrap().blocks;
         let source = build_mockchain_source(blocks);
@@ -2190,9 +2191,12 @@ mod tests {
 
         let zaino_db = FinalisedState::spawn(config, source.clone()).await.unwrap();
 
-        // First segment builds the accumulator to height 100 (no watermark yet => full rebuild),
-        // the second advances it by a 100-block range => the incremental update path under test.
-        zaino_db.sync_to_height(Height(100), &source).await.unwrap();
+        // First segment builds the accumulator to `COINBASE_MATURITY` (no watermark yet => full
+        // rebuild), the second advances it to the fixture tip => the incremental update path under test.
+        zaino_db
+            .sync_to_height(Height(COINBASE_MATURITY), &source)
+            .await
+            .unwrap();
         // Background catch-up (>LONG_RUNNING_SYNC_THRESHOLD); wait for the persistent build + watermark.
         zaino_db.wait_until_synced().await;
 
@@ -2200,15 +2204,15 @@ mod tests {
             .backend_for_cap(CapabilityRequest::WriteCore)
             .unwrap();
 
-        // The watermark must sit at 100 here: that (together with gap 100 <= the incremental cap)
-        // pins the next sync to the incremental branch rather than a silent rebuild fallback that
-        // would make the comparison below trivial.
+        // The watermark must sit at `COINBASE_MATURITY` here: that (together with the gap to the tip
+        // <= the incremental cap) pins the next sync to the incremental branch rather than a silent
+        // rebuild fallback that would make the comparison below trivial.
         assert_eq!(
             backend
                 .read_tx_out_set_accumulator_built_height()
                 .await
                 .unwrap(),
-            Some(Height(100)),
+            Some(Height(COINBASE_MATURITY)),
             "first segment must leave the accumulator watermark at the synced tip"
         );
 

--- a/packages/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/non_finalised_state.rs
@@ -99,7 +99,7 @@ impl ChainIndexSnapshot {
 #[derive(Debug, Clone)]
 /// A snapshot of the nonfinalized state as it existed when this was created.
 pub(crate) struct NonfinalizedBlockCacheSnapshot {
-    /// the set of all known blocks < 100 blocks old
+    /// the set of all known blocks less than `NON_FINALIZED_DEPTH` blocks old
     /// this includes all blocks on-chain, as well as
     /// all blocks known to have been on-chain before being
     /// removed by a reorg. Blocks reorged away have no height.
@@ -606,7 +606,7 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
         height_to_recurse_to: Option<Height>,
     ) -> Result<(), SyncError> {
         if height_to_recurse_to
-            .is_some_and(|height| height + 100 < working_snapshot.best_tip.height)
+            .is_some_and(|height| height + MAX_NFS_DEPTH < working_snapshot.best_tip.height)
         {
             return Err(SyncError::ReorgFailure(
                 "reorg detection recursed beyond reason".to_string(),

--- a/packages/zaino-state/src/chain_index/non_finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/non_finalised_state.rs
@@ -1,7 +1,7 @@
 use super::{
     finalised_state::{reader::DbReader, FinalisedState},
     source::BlockchainSource,
-    NON_FINALIZED_DEPTH,
+    OPERATIONAL_NFS_DEPTH,
 };
 #[cfg(feature = "prometheus")]
 use crate::metric_names::*;
@@ -26,14 +26,14 @@ use zebra_state::HashOrHeight;
 /// but that height can lag far behind the tip while the finalised DB syncs in the background, and
 /// is pinned at `0` in ephemeral mode. Without an independent floor the snapshot would grow by one
 /// block per new block indefinitely. This caps retention to a fixed window regardless, a small
-/// margin above [`NON_FINALIZED_DEPTH`] so it never trims inside the reorg-possible range.
+/// margin above [`OPERATIONAL_NFS_DEPTH`] so it never trims inside the reorg-possible range.
 ///
 /// It also bounds the non-finalised ancestry walkers ([`NonFinalizedState::handle_reorg`] and
 /// [`NonFinalizedState::add_nonbest_block`]): neither should recurse further back than the window
 /// they maintain. The bound is load-bearing for `add_nonbest_block` on the state backend, where
 /// `source.get_block` serves *any* block by hash (including finalised blocks below the window), so
 /// without it a side chain rooted below the anchor would recurse to genesis and overflow the stack.
-const MAX_NFS_DEPTH: u32 = NON_FINALIZED_DEPTH + 10;
+const MAX_NFS_DEPTH: u32 = OPERATIONAL_NFS_DEPTH + 10;
 
 /// Holds the block cache
 #[derive(Debug)]
@@ -99,7 +99,7 @@ impl ChainIndexSnapshot {
 #[derive(Debug, Clone)]
 /// A snapshot of the nonfinalized state as it existed when this was created.
 pub(crate) struct NonfinalizedBlockCacheSnapshot {
-    /// the set of all known blocks less than `NON_FINALIZED_DEPTH` blocks old
+    /// the set of all known blocks less than `OPERATIONAL_NFS_DEPTH` blocks old
     /// this includes all blocks on-chain, as well as
     /// all blocks known to have been on-chain before being
     /// removed by a reorg. Blocks reorged away have no height.
@@ -433,7 +433,7 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
     ) -> Result<(), SyncError> {
         let mut initial_state = self.get_snapshot();
         let local_finalized_tip = finalized_db.to_reader().db_height().await?;
-        // Anchor floor: the non-finalised state must never start more than `NON_FINALIZED_DEPTH`
+        // Anchor floor: the non-finalised state must never start more than `OPERATIONAL_NFS_DEPTH`
         // blocks below the chain tip, even when the finalised DB tip lags far behind during
         // background catch-up. Without this floor a freshly-initialised (or genesis-fallback)
         // snapshot would try to bridge the entire gap from the finalised tip up to the chain tip one
@@ -444,7 +444,7 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
             local_finalized_tip
                 .map(|height| height.0)
                 .unwrap_or(0)
-                .max(u32::from(chain_height).saturating_sub(NON_FINALIZED_DEPTH)),
+                .max(u32::from(chain_height).saturating_sub(OPERATIONAL_NFS_DEPTH)),
         );
         if initial_state.best_tip.height.0 < anchor_height.0 {
             let anchor_block = Self::resolve_anchor_block(
@@ -520,7 +520,7 @@ impl<Source: BlockchainSource> NonFinalizedState<Source> {
                 // we need to work backwards from it and update heights_to_hashes
                 // with it and all its parents.
             }
-            if initial_state.best_tip.height + NON_FINALIZED_DEPTH
+            if initial_state.best_tip.height + OPERATIONAL_NFS_DEPTH
                 < working_snapshot.best_tip.height
             {
                 self.update(finalized_db.clone(), initial_state, working_snapshot)

--- a/packages/zaino-state/src/chain_index/tests/proptest_blockgen.rs
+++ b/packages/zaino-state/src/chain_index/tests/proptest_blockgen.rs
@@ -31,7 +31,7 @@ use crate::{
         source::{BlockchainSourceResult, GetTransactionLocation},
         tests::{init_tracing, poll::poll_until, proptest_blockgen::proptest_helpers::add_segment},
         types::BestChainLocation,
-        NonFinalizedSnapshot, NON_FINALIZED_DEPTH,
+        NonFinalizedSnapshot, OPERATIONAL_NFS_DEPTH,
     },
     BlockHash, BlockchainSource, ChainIndex, ChainIndexConfig, NodeBackedChainIndex,
     NodeBackedChainIndexSubscriber, TransactionHash,
@@ -52,7 +52,7 @@ fn passthrough_test(
     init_tracing();
     let network = Network::Regtest(ActivationHeights::default());
     // Long enough to have some finalized blocks to play with
-    let segment_length = NON_FINALIZED_DEPTH as usize + 20;
+    let segment_length = OPERATIONAL_NFS_DEPTH as usize + 20;
     // No need to worry about non-best chains for this test
     let branch_count = 1;
 


### PR DESCRIPTION
Multiple instances of "magic" values meant to represent the NFS depth drifted when the upstream value bumped from 100 to 1_000.  This PR is meant to remedy those bugs, and eliminate that "magic" value drift for at least some consts.

This PR proposes a single place for const declaration in zaino-common, and places several consts there.