### PR TITLE
Rename `makers test` set `package` -> `packages`

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -93,7 +93,7 @@ script.main = 'source "./tools/scripts/push-image.sh"'
 
 [tasks.container-test]
 clear = true
-description = "Engine: run nextest in the local CI container, forwarding args (zcashd_support OFF by default; --with-zcashd adds --features zcashd_support). Devs use `makers test [package|e2e|clientless|live|all]`; live-clientless / live-e2e and the `test` front door call this."
+description = "Engine: run nextest in the local CI container, forwarding args (zcashd_support OFF by default; --with-zcashd adds --features zcashd_support). Devs use `makers test [packages|e2e|clientless|live|all]`; live-clientless / live-e2e and the `test` front door call this."
 # This task runs tests inside the container built from live-tests/test_environment.
 # The entrypoint.sh script in the container sets up test binaries (zcashd, zebrad, zcash-cli)
 # by creating symlinks from /home/container_user/artifacts to the expected live-tests/test_binaries/bins location.
@@ -132,16 +132,16 @@ script.main = 'source "./tools/scripts/container-nextest-workspace.sh"'
 # ===================================================================
 # Developer-facing test front door: a single `makers test [SET]` task.
 #
-#   makers test                packaged (the default)
-#   makers test package        packages/* production-crate tests (no validator)
+#   makers test                packages (the default)
+#   makers test packages       packages/* production-crate tests (no validator)
 #   makers test e2e            the e2e live partition
 #   makers test clientless     the clientless live partition
 #   makers test live           both live partitions + combined summary
-#   makers test all            package then live (everything)
+#   makers test all            packages then live (everything)
 #
-# SET names mirror the crate/dir names (`e2e`, `clientless`); `package`,
-# `live`, and `all` are the groupings. `live` = all non-package tests; `all`
-# = `package` + `live` (see live-tests/CONTEXT.md). Each set delegates to an
+# SET names mirror the crate/dir names (`e2e`, `clientless`); `packages`,
+# `live`, and `all` are the groupings. `live` = all non-packages tests; `all`
+# = `packages` + `live` (see live-tests/CONTEXT.md). Each set delegates to an
 # existing engine rather than re-implementing a run. `--with-zcashd` (handled
 # by the engines) adds the zcashd-backed tests to any set.
 # ===================================================================
@@ -150,33 +150,33 @@ script.main = 'source "./tools/scripts/container-nextest-workspace.sh"'
 # clear = true fully replaces cargo-make's built-in `test` task (which runs
 # `cargo test`); without it our `script` would merge with the builtin `command`.
 clear = true
-description = "Run a test set: `makers test [package|e2e|clientless|live|all]` (default: package). Pass --with-zcashd for the zcashd-backed tests."
+description = "Run a test set: `makers test [packages|e2e|clientless|live|all]` (default: packages). Pass --with-zcashd for the zcashd-backed tests."
 script_runner = "bash"
 script = '''
 set -uo pipefail
 
 usage() {
-  echo "usage: makers test [package|e2e|clientless|live|all] [-- nextest args]" >&2
-  echo "  package (default)  packages/* tests, no live validator" >&2
+  echo "usage: makers test [packages|e2e|clientless|live|all] [-- nextest args]" >&2
+  echo "  packages (default) packages/* tests, no live validator" >&2
   echo "  e2e | clientless   that single live partition" >&2
   echo "  live               both live partitions + combined summary" >&2
-  echo "  all                package then live (everything)" >&2
+  echo "  all                packages then live (everything)" >&2
 }
 
 # A non-flag first arg selects the set and must be a known name; a flag first
-# arg (or none) keeps the default `package` and is forwarded to nextest. So
-# `makers test --with-zcashd` runs package with the flag, while a mistyped set
+# arg (or none) keeps the default `packages` and is forwarded to nextest. So
+# `makers test --with-zcashd` runs packages with the flag, while a mistyped set
 # name errors instead of silently running the default.
-set="package"
+set="packages"
 if [ "$#" -gt 0 ] && [ "${1#-}" = "$1" ]; then
   case "$1" in
-    package|e2e|clientless|live|all) set="$1"; shift ;;
+    packages|e2e|clientless|live|all) set="$1"; shift ;;
     *) echo "makers test: unknown set '$1'" >&2; usage; exit 2 ;;
   esac
 fi
 
 case "$set" in
-  package)    exec makers container-test "$@" ;;
+  packages)   exec makers container-test "$@" ;;
   e2e)        exec makers live-e2e "$@" ;;
   clientless) exec makers live-clientless "$@" ;;
   live)       exec cargo run -q --manifest-path tools/test-runner/Cargo.toml --bin live-summary -- "$@" ;;

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The test suites run inside a **podman** container via `makers` (cargo-make):
 ```sh
 makers test            # packages/* tests that need no live validator (default)
 makers test live       # both live partitions (clientless + e2e) + combined summary
-makers test all        # everything: package then live
+makers test all        # everything: packages then live
 ```
 
 zcashd-backed tests are **off by default**; add `--with-zcashd` to include them

--- a/docs/adr/0004-rename-integration-partition-to-clientless.md
+++ b/docs/adr/0004-rename-integration-partition-to-clientless.md
@@ -50,3 +50,6 @@ unchanged.
   "clientless" is no longer avoided.
 - ADR-0003's naming bullet and its three-front-door task surface are superseded;
   its two-crate split and the `live` umbrella decision still stand.
+
+> **Later note:** the `package` set was renamed `packages` (plural, matching the
+> `packages/` dir); `makers test package` now errors. See `live-tests/CONTEXT.md`.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -26,14 +26,14 @@ The `makers` tasks below build and run the test suites inside a **podman**
 container, so you don't need the validator binaries on your host `$PATH`. The
 container image is built or pulled automatically on first run.
 
-The single front door is `makers test [SET]`, where `SET` defaults to `package`:
+The single front door is `makers test [SET]`, where `SET` defaults to `packages`:
 
-- `makers test` (or `makers test package`) — the **package** set: the
+- `makers test` (or `makers test packages`) — the **packages** set: the
   `packages/*` production-crate tests that need no live validator.
 - `makers test e2e` / `makers test clientless` — one live partition.
 - `makers test live` — both live partitions (`clientless` then `e2e`) against a
   live validator, with a combined pass/fail summary.
-- `makers test all` — the whole suite: package then live.
+- `makers test all` — the whole suite: packages then live.
 
 (`container-test`, `live-clientless`, and `live-e2e` are the internal engines
 the `test` front door delegates to; invoke them directly only when you need to

--- a/live-tests/CONTEXT.md
+++ b/live-tests/CONTEXT.md
@@ -40,15 +40,17 @@ owns shared fixtures and the feature-forwarding surface (`zcashd_support`,
 `transparent_address_history_experimental`).
 _Avoid_: test helpers, testlib.
 
-**package (test set)**:
+**packages (test set)**:
 The tests of the `packages/*` production crates — the workspace
 `default-members`, exercised by bare `cargo nextest run` and by `makers test`
-(the default with no argument, equivalently `makers test package`). Named for
+(the default with no argument, equivalently `makers test packages`). Named for
 where the crates live (`packages/`); the functional reason they run apart from
 the live partitions is that they need **no** live validator. They are *not*
 network-free, though: e.g. zaino-serve's gRPC `spawn` regression test binds a
 loopback socket and stands up a tonic server. The absent ingredient is a
 validator, not the network.
-_Avoid_: offline (overclaims "no network" — these tests bind loopback sockets);
-unit test (the set includes crate-level integration tests); container test
-(names the run mechanism, which the live suite shares).
+_Avoid_: package (singular — the set is plural, matching the `packages/` dir;
+`makers test package` now errors with `unknown set`); offline (overclaims "no
+network" — these tests bind loopback sockets); unit test (the set includes
+crate-level integration tests); container test (names the run mechanism, which
+the live suite shares).

--- a/tools/scripts/help.sh
+++ b/tools/scripts/help.sh
@@ -12,7 +12,7 @@ echo ""
 echo "Common usage:"
 echo "  makers test            # packages/* tests, no live validator (default)"
 echo "  makers test live       # both live partitions + combined summary"
-echo "  makers test all        # everything: package then live"
+echo "  makers test all        # everything: packages then live"
 echo ""
 echo "If you modify '.env.testing-artifacts', the test command will \
 automatically:"
@@ -21,15 +21,15 @@ echo "  - Build a new local container image if needed"
 echo ""
 echo "Available commands:"
 echo ""
-echo "  test [SET]                 Front door. SET = package (default) | e2e | \
+echo "  test [SET]                 Front door. SET = packages (default) | e2e | \
 clientless | live | all"
-echo "                               package    packages/* tests, no live \
+echo "                               packages   packages/* tests, no live \
 validator"
 echo "                               e2e        the e2e live partition"
 echo "                               clientless the clientless live partition"
 echo "                               live       both live partitions + \
 combined summary"
-echo "                               all        package then live (everything)"
+echo "                               all        packages then live (everything)"
 echo "  container-test             Engine: run nextest in the container \
 (used by the front door; invoke directly to forward engine flags)"
 echo "  live-clientless            Engine: run the clientless live-test \


### PR DESCRIPTION
Builds on #1354 merge that first.

## What

Renames the `makers test` front-door test set from `package` (singular) to `packages` (plural). The set is named for the `packages/` directory whose crates it runs, so the plural is the faithful name.

Hard-cut, no alias: `makers test package` now errors with `unknown set` (the `case` matcher already fails loudly on unknown sets), rather than silently aliasing. No CI invokes the set name, so nothing automated breaks.

## Changes

- **`Makefile.toml`** — `test` task default (`set="packages"`), `case` matcher, dispatch arm, both task descriptions, usage text, and the comment/groupings block.
- **`tools/scripts/help.sh`** — the `Common usage` line and the `test [SET]` menu.
- **`docs/testing.md`**, **`README.md`** — front-door prose.
- **`live-tests/CONTEXT.md`** — glossary term `package (test set)` → `packages (test set)`; the retired singular is now recorded under `_Avoid_` with a note that it errors.
- **`docs/adr/0004`** — one-line supersession footer; historical text preserved.

## Out of scope

The `PACKAGE` / `PACKAGE_DESC` env vars in `live-clientless` / `live-e2e` hold *partition* names, not the test-set name — a pre-existing naming collision left untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)