### PR TITLE
Bump crate versions for 0.5.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,15 +138,15 @@ tempfile = "3.2"
 # no longer need `default-features = false` to drop it: their default feature
 # set is already empty. Enable zcashd end-to-end with `--features zcashd_support`.
 zainod = { path = "packages/zainod" }
-zaino-common = { path = "packages/zaino-common", version = "0.2.0" }
+zaino-common = { path = "packages/zaino-common", version = "0.3.0" }
 # default-features = false so the default-on `zcashd_support` feature can be
 # dropped end-to-end via `--no-default-features`; each consumer re-enables it
 # by forwarding `zcashd_support` in its own `default`. See
 # docs/adr/0001-zcashd-support-feature-gate.md.
-zaino-fetch = { path = "packages/zaino-fetch", version = "0.2.1", default-features = false }
+zaino-fetch = { path = "packages/zaino-fetch", version = "0.3.0", default-features = false }
 zaino-proto = { path = "packages/zaino-proto", version = "0.1.3" }
-zaino-state = { path = "packages/zaino-state", version = "0.3.1", default-features = false }
-zaino-serve = { path = "packages/zaino-serve", version = "0.3.1", default-features = false }
+zaino-state = { path = "packages/zaino-state", version = "0.4.0", default-features = false }
+zaino-serve = { path = "packages/zaino-serve", version = "0.4.0", default-features = false }
 zaino-testutils = { path = "live-tests/zaino-testutils" }
 
 # Zingo-infra (validator launcher driving the live tests; not a prod dep).

--- a/packages/zaino-common/Cargo.toml
+++ b/packages/zaino-common/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.0"
+version = "0.3.0"
 
 [dependencies]
 # Zebra

--- a/packages/zaino-fetch/Cargo.toml
+++ b/packages/zaino-fetch/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.1"
+version = "0.3.0"
 
 [features]
 default = []

--- a/packages/zaino-serve/Cargo.toml
+++ b/packages/zaino-serve/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.1"
+version = "0.4.0"
 
 [features]
 default = []

--- a/packages/zaino-state/Cargo.toml
+++ b/packages/zaino-state/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.1"
+version = "0.4.0"
 
 [features]
 default = []

--- a/packages/zainod/Cargo.toml
+++ b/packages/zainod/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.2"
+version = "0.5.0"
 
 [[bin]]
 name = "zainod"


### PR DESCRIPTION
## Summary

- Bump all published crate versions for the 0.5.0 release, based on semver analysis of changes since the last stable (0.4.2)

| Crate | Old | New | Rationale |
|---|---|---|---|
| **zainod** | 0.4.2 | **0.5.0** | Release anchor. New `zcashd_support` + `test_dependencies` features, config changes. |
| **zaino-state** | 0.3.1 | **0.4.0** | Breaking: removed `async-trait` for native AFIT, renamed `BlockCacheConfig` → `ChainIndexConfig`, new public types, `zcashd_support` gate. |
| **zaino-common** | 0.2.0 | **0.3.0** | Breaking: `sync_write_batch_bytes` replaced by `SyncWriteBatchSize` newtype, new config fields, `deny_unknown_fields`. |
| **zaino-serve** | 0.3.1 | **0.4.0** | New `spawn_from_listener`, bind refactor, `zcashd_support` gate. |
| **zaino-fetch** | 0.2.1 | **0.3.0** | New `raw_transaction` module, breaking feature-gated types. |
| **zaino-proto** | 0.1.3 | **0.1.3** | No changes. |

All crates are pre-1.0, so minor bumps (0.x → 0.(x+1)) represent breaking changes per semver convention.