### PR TITLE
Bump zaino-proto 0.1.3 → 0.1.4 for crates.io publish chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6045,7 +6045,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-proto"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "prost",
  "tonic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ zaino-common = { path = "packages/zaino-common", version = "0.3.0" }
 # by forwarding `zcashd_support` in its own `default`. See
 # docs/adr/0001-zcashd-support-feature-gate.md.
 zaino-fetch = { path = "packages/zaino-fetch", version = "0.3.0", default-features = false }
-zaino-proto = { path = "packages/zaino-proto", version = "0.1.3" }
+zaino-proto = { path = "packages/zaino-proto", version = "0.1.4" }
 zaino-state = { path = "packages/zaino-state", version = "0.4.1", default-features = false }
 zaino-serve = { path = "packages/zaino-serve", version = "0.4.0", default-features = false }
 zaino-testutils = { path = "live-tests/zaino-testutils" }

--- a/packages/zaino-proto/Cargo.toml
+++ b/packages/zaino-proto/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.3"
+version = "0.1.4"
 
 [features]
 default = ["heavy"]


### PR DESCRIPTION
## Summary

- Bumps `zaino-proto` from 0.1.3 to 0.1.4 — no code changes, only the version number.
- The published `zaino-proto 0.1.3` on crates.io carries `zebra-state = "8.0.0"` behind its default `heavy` feature. When `cargo publish -p zaino-state` verifies the tarball, it resolves `zaino-proto` from crates.io — pulling `zebra-state 8.0.0` alongside `zaino-state`'s own `zebra-state ^9.0`, causing a type conflict. Publishing `zaino-proto 0.1.4` (with the workspace-resolved `zebra-state ^9.0`) first unblocks the rest of the publish chain.

## Publish order (after merge)

1. `zaino-proto` 0.1.4 — dry-run verified
2. `zaino-state` 0.4.1
3. `zaino-serve` 0.4.0
4. `zainod` 0.5.1

Follows #1364 (drop unreleased zebra git patch).