### PR TITLE
Fix: ironwood db migration

### DIFF
--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -543,12 +543,25 @@ impl<T: BlockchainSource> FinalisedState<T> {
                         source: migration_source,
                     };
 
-                    if let Err(error) = migration_manager.migrate().await {
-                        tracing::error!("FinalisedState migration failed: {error}");
+                    match migration_manager.migrate().await {
+                        Ok(()) => {
+                            // Start the background validator only now that every migration has
+                            // finished: its initial scan reads tables a migration populates (e.g.
+                            // `commitment_tree_data_1_3_0`), so starting it earlier would race the
+                            // migration and fail on a not-yet-written row.
+                            migration_router.primary_backend().start_validator();
+                        }
+                        Err(error) => {
+                            tracing::error!("FinalisedState migration failed: {error}");
 
-                        migration_router.store_primary_status(StatusType::CriticalError);
+                            migration_router.store_primary_status(StatusType::CriticalError);
+                        }
                     }
                 });
+            } else {
+                // No migration to run, so the on-disk tables the validator scans are already at the
+                // current schema: start it immediately.
+                router.primary_backend().start_validator();
             }
 
             Ok(Self { db: router, cfg })
@@ -1053,6 +1066,14 @@ impl<T: BlockchainSource> FinalisedState<T> {
             migration_manager.migrate().await?;
         }
 
+        // This test helper builds a fixture at an arbitrary (often intermediate) version for
+        // inspection, so it deliberately does NOT start the validator: the validator only validates
+        // against the current schema and would fail on an intermediate-version database. The
+        // foreground migration is already complete, so mark the primary `Ready` directly (as
+        // `spawn_v1_0_0` does) to give callers a settled backend. Validation is exercised through
+        // the production `FinalisedState::spawn` path, which always targets the current schema.
+        router.store_primary_status(StatusType::Ready);
+
         let metadata = router.get_metadata().await?;
         if metadata.version() != target_version {
             return Err(FinalisedStateError::Custom(format!(
@@ -1084,7 +1105,6 @@ impl<T: BlockchainSource> FinalisedState<T> {
         source: T,
     ) -> Result<FinalisedSource<T>, FinalisedStateError> {
         let db = FinalisedSource::spawn_v1_0_0(cfg).await?;
-        db.wait_until_ready().await;
 
         let tip = source.get_best_block_height().await?.ok_or_else(|| {
             FinalisedStateError::BlockchainSourceError(BlockchainSourceError::Unrecoverable(

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source.rs
@@ -380,6 +380,12 @@ impl<T: BlockchainSource> FinalisedSource<T> {
             .require_v1("v1 commitment_tree_data db")?
             .commitment_tree_data_db())
     }
+
+    /// Provides access to the (v1.3.0) `ironwood` table, required for Migration1_2_1To1_3_0 to
+    /// backfill ironwood rows from validator-fetched block data.
+    pub(crate) fn ironwood_db(&self) -> Result<Database, FinalisedStateError> {
+        Ok(self.require_v1("v1 ironwood db")?.ironwood_db())
+    }
 }
 
 impl<T: BlockchainSource> From<DbV1> for FinalisedSource<T> {

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source.rs
@@ -283,6 +283,18 @@ impl<T: BlockchainSource> FinalisedSource<T> {
         }
     }
 
+    /// Start the background validator on the primary v1 backend (no-op for the ephemeral
+    /// passthrough).
+    ///
+    /// Called by the orchestrator only once all pending migrations have completed, so the
+    /// validator never races a migration that populates the tables its initial scan reads.
+    pub(crate) fn start_validator(&self) {
+        match self {
+            Self::V1(db) => db.start_validator(),
+            Self::Ephemeral(_) => {}
+        }
+    }
+
     /// Stores a new runtime status in the concrete backend.
     ///
     /// This is used by router-level background orchestration, for example to report an asynchronous

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
@@ -405,15 +405,14 @@ pub(crate) struct DbV1 {
 /// - validated read fetchers used by the capability trait implementations, and
 /// - internal validation / indexing helpers.
 impl DbV1 {
-    /// Spawns a new [`DbV1`] and opens (or creates) the LMDB environment for the configured network.
+    /// Opens (and heals) the v1 database for the configured network **without** starting the
+    /// background validator.
     ///
     /// This method:
     /// - chooses a versioned path suffix (`.../<network>/v1`),
     /// - configures LMDB map size and reader slots,
-    /// - opens or creates all V1 named databases,
-    /// - validates or initializes the `"metadata"` record (schema hash + version), and
-    /// - spawns the background validator / maintenance task.
-    /// Opens (and heals) the v1 database **without** starting the background validator.
+    /// - opens or creates all V1 named databases, and
+    /// - validates or initializes the `"metadata"` record (schema hash + version).
     ///
     /// The validator is started separately via [`DbV1::start_validator`]. This split exists so the
     /// orchestrator can guarantee that any pending schema migration finishes *before* validation
@@ -849,6 +848,12 @@ impl DbV1 {
     /// Migration1_2_1To1_3_0 to write the rebuilt commitment rows.
     pub(crate) fn commitment_tree_data_db(&self) -> Database {
         self.commitment_tree_data
+    }
+
+    /// Provides access to the (v1.3.0) `ironwood` table, required for Migration1_2_1To1_3_0 to
+    /// backfill ironwood rows for post-NU6.3 blocks from validator-fetched block data.
+    pub(crate) fn ironwood_db(&self) -> Database {
+        self.ironwood
     }
 
     /// Provudes access to the spent DB table, required for Migration1_1_0To1_2_0.

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
@@ -413,8 +413,15 @@ impl DbV1 {
     /// - opens or creates all V1 named databases,
     /// - validates or initializes the `"metadata"` record (schema hash + version), and
     /// - spawns the background validator / maintenance task.
+    /// Opens (and heals) the v1 database **without** starting the background validator.
+    ///
+    /// The validator is started separately via [`DbV1::start_validator`]. This split exists so the
+    /// orchestrator can guarantee that any pending schema migration finishes *before* validation
+    /// runs: the validator's `initial_block_scan` reads tables (e.g. `commitment_tree_data_1_3_0`)
+    /// that a migration populates, so starting it concurrently with a migration races the migration
+    /// and can fail on a not-yet-written row.
     pub(crate) async fn spawn(config: &ChainIndexConfig) -> Result<Self, FinalisedStateError> {
-        let mut zaino_db = Self::open_env_and_dbs(config).await?;
+        let zaino_db = Self::open_env_and_dbs(config).await?;
 
         // Validate (or initialise) the metadata entry before we touch any tables.
         zaino_db.check_schema_version().await?;
@@ -423,9 +430,6 @@ impl DbV1 {
         // `txid_location` index unbuilt. Runs before the background validator starts so it operates
         // on a quiescent database.
         zaino_db.reconcile_alpha_txid_location_index().await?;
-
-        // Spawn handler task to perform background validation and trailing tx cleanup.
-        zaino_db.spawn_handler().await?;
 
         Ok(zaino_db)
     }
@@ -598,7 +602,12 @@ impl DbV1 {
     ///   `initial_block_scan`).
     /// - **Steady state:** periodically attempts to validate the next height after `validated_tip`.
     ///   Separately, it performs periodic trailing-reader cleanup via `clean_trailing()`.
-    async fn spawn_handler(&mut self) -> Result<(), FinalisedStateError> {
+    ///
+    /// Kept separate from [`DbV1::spawn`] so the orchestrator starts it only once all pending
+    /// migrations have finished (the validator reads tables a migration populates). Takes `&self`
+    /// (the join handle lives behind a `Mutex`) so it can be driven through the shared
+    /// `Arc<FinalisedSource>` the router holds after spawn.
+    pub(crate) fn start_validator(&self) {
         // Clone everything the task needs so we can move it into the async block.
         let zaino_db = self.detached_handle();
 
@@ -700,7 +709,6 @@ impl DbV1 {
         });
 
         *self.db_handler.lock().expect("db_handler mutex poisoned") = Some(handle);
-        Ok(())
     }
 
     /// Validates every stored spent-outpoint entry (`Outpoint` -> `TxLocation`) by checksum.
@@ -1016,9 +1024,16 @@ impl DbV1 {
         // (see the method doc) — that is the behavioural difference from `spawn`.
         zaino_db.write_v1_0_0_metadata()?;
 
-        // Spawn handler task to perform background validation and trailing tx cleanup.
-        let mut zaino_db = zaino_db;
-        zaino_db.spawn_handler().await?;
+        // Deliberately does NOT start the background validator. This builds a *pre-migration*
+        // v1.0.0 fixture; the validator validates against the current (v1.3.0) schema — it reads
+        // `commitment_tree_data_1_3_0` and the `ironwood` table — so it must run only after the
+        // database has been migrated to the newest schema. Callers build the fixture with direct
+        // v1.0.0 writes, shut it down, then reopen through `FinalisedState::spawn`, which migrates
+        // first and starts the validator afterwards.
+        //
+        // With no validator to advance it, mark the empty fixture `Ready` directly so callers see a
+        // settled backend.
+        zaino_db.status.store(StatusType::Ready);
 
         Ok(zaino_db)
     }

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
@@ -188,11 +188,33 @@ fn build_block_row_entries(
         ),
         sapling_entry: StoredEntryVar::new(block_height_bytes, SaplingTxList::new(sapling)),
         orchard_entry: StoredEntryVar::new(block_height_bytes, OrchardTxList::new(orchard)),
-        ironwood_entry: ironwood
-            .iter()
-            .any(Option::is_some)
-            .then(|| StoredEntryVar::new(block_height_bytes, OrchardTxList::new(ironwood))),
+        ironwood_entry: ironwood_entry(ironwood, block_height_bytes),
     }
+}
+
+/// Builds the sparse ironwood row entry for a block's per-transaction ironwood list: `Some` only
+/// when at least one transaction carries ironwood data, so a block with none stores no ironwood row
+/// (readers treat an absent row as "no ironwood data").
+fn ironwood_entry(
+    ironwood: Vec<Option<OrchardCompactTx>>,
+    block_height_bytes: &[u8],
+) -> Option<StoredEntryVar<OrchardTxList>> {
+    ironwood
+        .iter()
+        .any(Option::is_some)
+        .then(|| StoredEntryVar::new(block_height_bytes, OrchardTxList::new(ironwood)))
+}
+
+/// Builds the sparse ironwood row entry for `block` (the same value the write path stores). Used by
+/// the v1.2.1 → v1.3.0 migration to backfill the ironwood table from validator-fetched blocks.
+pub(crate) fn build_block_ironwood_entry(
+    block: &IndexedBlock,
+    block_height_bytes: &[u8],
+) -> Result<Option<StoredEntryVar<OrchardTxList>>, FinalisedStateError> {
+    Ok(ironwood_entry(
+        extract_block_pool_lists(block)?.ironwood,
+        block_height_bytes,
+    ))
 }
 
 impl DbWrite for DbV1 {

--- a/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/migrations.rs
@@ -1017,27 +1017,28 @@ impl<T: BlockchainSource> Migration<T> for Migration1_2_0To1_2_1 {
 /// Minor migration: v1.2.1 → v1.3.0.
 ///
 /// Introduces the Ironwood (NU6.3) shielded pool to the finalised state:
-/// - a new per-height `ironwood` table (`ironwood_1_3_0`), created empty by `DbV1::spawn`; new
-///   blocks populate it via the write path. No backfill is needed because every block already on
-///   disk predates NU6.3 (see the guard below).
+/// - a new per-height `ironwood` table (`ironwood_1_3_0`), created empty by `DbV1::spawn`. New
+///   blocks populate it via the write path; here it is backfilled for any stored block at or above
+///   NU6.3 activation (see below).
 /// - the `commitment_tree_data` table is rebuilt from the legacy fixed-length
 ///   `StoredEntryFixed<CommitmentTreeData>` (V1) rows into the variable-length
 ///   `StoredEntryVar<CommitmentTreeData>` (V2) layout, which carries the optional Ironwood root and
-///   size. The rebuild reads the legacy `commitment_tree_data_1_0_0` table and writes the new
-///   `commitment_tree_data_1_3_0` table (opened as the primary's `commitment_tree_data` handle),
-///   then clears the legacy table.
+///   size. The new rows are written to `commitment_tree_data_1_3_0` (the primary's
+///   `commitment_tree_data` handle), then the legacy table is cleared.
 ///
-/// This is a **rebuild from existing on-disk data** (no validator refetch), correct only while every
-/// stored block predates Ironwood. The migration therefore asserts the database tip is below NU6.3
-/// activation before running; a database already synced past NU6.3 under the old schema would be
-/// missing ironwood data that cannot be reconstructed from existing rows and must be re-indexed from
-/// the validator instead.
+/// Per-height rebuild strategy, branching on NU6.3 activation:
+/// - **Below activation:** rebuilt in place from the legacy on-disk commitment row (Ironwood
+///   root/size default to `None`/`0` via `CommitmentTreeData` V1 decode). No validator access.
+/// - **At or above activation:** the legacy data predates Ironwood, so both the commitment row
+///   (now carrying the Ironwood root/size) and the sparse ironwood row are rebuilt from
+///   validator-fetched block data via [`build_indexed_block_from_source`]. This lets the migration
+///   run on a database already synced past NU6.3, rather than forcing a full re-index.
 ///
 /// Safety and resumability:
-/// - Deterministic: each rebuilt row is derived only from the matching legacy row (Ironwood
-///   root/size default to `None`/`0` via `CommitmentTreeData` V1 decode).
+/// - Deterministic: a below-activation row is derived only from its legacy row; an at/above-activation
+///   row is refetched from immutable finalised history, so a resumed rebuild reproduces the same bytes.
 /// - Resumable: the next height to rebuild is stored in the metadata DB under a temporary key.
-/// - Crash-safe: each height's rebuilt row and the progress update commit in the same transaction;
+/// - Crash-safe: each height's rebuilt rows and the progress update commit in the same transaction;
 ///   idempotent on resume (`NO_OVERWRITE` + verify-match).
 struct Migration1_2_1To1_3_0;
 
@@ -1062,9 +1063,15 @@ impl<T: BlockchainSource> Migration<T> for Migration1_2_1To1_3_0 {
         &self,
         router: Arc<Router<T>>,
         cfg: ChainIndexConfig,
-        _source: T,
+        source: T,
     ) -> Result<(), FinalisedStateError> {
         use lmdb::DatabaseFlags;
+
+        use crate::chain_index::finalised_state::{
+            build_indexed_block_from_source,
+            finalised_source::v1::write_core::build_block_ironwood_entry,
+        };
+        use crate::chain_index::ShieldedPool;
 
         // Temporary metadata entry recording the next height to rebuild, removed on completion.
         const MIGRATION_CTD_PROGRESS_KEY: &[u8] =
@@ -1077,8 +1084,10 @@ impl<T: BlockchainSource> Migration<T> for Migration1_2_1To1_3_0 {
         let backend = router.primary_backend();
         let env = backend.env()?;
         let metadata_db = backend.metadata_db()?;
-        // The primary's `commitment_tree_data` handle is the new `commitment_tree_data_1_3_0` table.
+        // The primary's `commitment_tree_data` handle is the new `commitment_tree_data_1_3_0` table;
+        // `ironwood_db` is the new (v1.3.0) sparse ironwood table backfilled below.
         let new_ctd_db = backend.commitment_tree_data_db()?;
+        let ironwood_db = backend.ironwood_db()?;
 
         // Open the legacy fixed-length commitment table by name. On a pre-v1.3.0 database it already
         // exists; `open_or_create_db` creating it empty on an unexpected fresh DB is harmless (the
@@ -1091,10 +1100,19 @@ impl<T: BlockchainSource> Migration<T> for Migration1_2_1To1_3_0 {
             )
             .await?;
 
-        // Guard: Ironwood data is only expected from NU6.3 activation. A rebuild-from-existing-data
-        // migration cannot reconstruct ironwood roots/sizes for post-NU6.3 blocks.
-        let zebra_network = cfg.network.to_zebra_network();
-        let nu6_3_activation_height = crate::chain_index::ShieldedPool::Ironwood
+        // Network-upgrade activation heights (mirrors `write_blocks_to_height`). Blocks at or above
+        // NU6.3 have their ironwood root/size and ironwood tx list rebuilt from the validator (the
+        // legacy on-disk data predates ironwood); blocks below it are rebuilt in place from the
+        // legacy commitment row, with no ironwood.
+        let network = cfg.network;
+        let zebra_network = network.to_zebra_network();
+        let sapling_activation_height = ShieldedPool::Sapling
+            .activation_upgrade()
+            .activation_height(&zebra_network);
+        let nu5_activation_height = ShieldedPool::Orchard
+            .activation_upgrade()
+            .activation_height(&zebra_network);
+        let nu6_3_activation_height = ShieldedPool::Ironwood
             .activation_upgrade()
             .activation_height(&zebra_network);
 
@@ -1133,17 +1151,6 @@ impl<T: BlockchainSource> Migration<T> for Migration1_2_1To1_3_0 {
         if let Some(db_tip) = backend.db_height().await? {
             let db_tip = db_tip.0;
 
-            if let Some(activation) = nu6_3_activation_height {
-                if db_tip >= activation.0 {
-                    return Err(FinalisedStateError::Custom(format!(
-                        "cannot migrate finalised state to v1.3.0: tip {db_tip} is at or above NU6.3 \
-                         activation {} but was built without Ironwood data; wipe and re-index the \
-                         finalised state from the validator",
-                        activation.0
-                    )));
-                }
-            }
-
             let mut next_height =
                 read_progress(MIGRATION_CTD_PROGRESS_KEY)?.unwrap_or(GENESIS_HEIGHT.0);
 
@@ -1154,58 +1161,116 @@ impl<T: BlockchainSource> Migration<T> for Migration1_2_1To1_3_0 {
             );
             let started = std::time::Instant::now();
 
+            // Idempotent write: on resume an already-written row must match byte-for-byte (the
+            // legacy rebuild is deterministic and the validator refetch is over immutable history).
+            fn put_idempotent(
+                txn: &mut lmdb::RwTransaction<'_>,
+                db: lmdb::Database,
+                key: &[u8],
+                value: &[u8],
+                what: &str,
+            ) -> Result<(), FinalisedStateError> {
+                match txn.put(db, &key, &value, WriteFlags::NO_OVERWRITE) {
+                    Ok(()) => Ok(()),
+                    Err(lmdb::Error::KeyExist) => {
+                        let existing = txn.get(db, &key).map_err(FinalisedStateError::LmdbError)?;
+                        if existing != value {
+                            return Err(FinalisedStateError::Custom(format!(
+                                "conflicting rebuilt {what}"
+                            )));
+                        }
+                        Ok(())
+                    }
+                    Err(error) => Err(FinalisedStateError::LmdbError(error)),
+                }
+            }
+
             while next_height <= db_tip {
                 let height = Height::try_from(next_height)
                     .map_err(|error| FinalisedStateError::Custom(error.to_string()))?;
                 let height_bytes = height.to_bytes()?;
 
-                // Read + verify the legacy fixed-length row.
-                let commitment_tree_data: CommitmentTreeData = {
-                    let txn = env.begin_ro_txn()?;
-                    let raw = txn
-                        .get(legacy_ctd_db, &height_bytes)
-                        .map_err(FinalisedStateError::LmdbError)?;
-                    let entry = StoredEntryFixed::<CommitmentTreeData>::from_bytes(raw).map_err(
-                        |error| {
-                            FinalisedStateError::Custom(format!(
-                                "legacy commitment_tree_data corrupt data: {error}"
-                            ))
-                        },
-                    )?;
-                    if !entry.verify(&height_bytes) {
-                        return Err(FinalisedStateError::Custom(
-                            "legacy commitment_tree_data checksum mismatch".to_string(),
-                        ));
-                    }
-                    *entry.inner()
-                };
+                let ironwood_active =
+                    nu6_3_activation_height.is_some_and(|activation| next_height >= activation.0);
 
-                // Re-wrap in the V2 `StoredEntryVar` layout and advance progress atomically.
-                let new_entry_bytes =
-                    StoredEntryVar::new(&height_bytes, commitment_tree_data).to_bytes()?;
+                // Prepare the rows to write. Reads / validator fetches happen before the write txn
+                // so the commit stays short.
+                let commitment_bytes: Vec<u8>;
+                let ironwood_bytes: Option<Vec<u8>>;
 
+                if ironwood_active {
+                    // Post-NU6.3: the legacy row carries no ironwood root/size and the ironwood
+                    // table has no row, so rebuild both from validator-fetched block data.
+                    let sapling_activation_height = sapling_activation_height.ok_or_else(|| {
+                        FinalisedStateError::Custom(
+                            "Sapling activation height must be set to backfill ironwood"
+                                .to_string(),
+                        )
+                    })?;
+                    let block = build_indexed_block_from_source(
+                        &source,
+                        network,
+                        sapling_activation_height,
+                        nu5_activation_height,
+                        nu6_3_activation_height,
+                        next_height,
+                        // Chainwork is irrelevant here: only the commitment-tree and ironwood rows
+                        // are extracted, and neither depends on it.
+                        None,
+                    )
+                    .await?;
+
+                    commitment_bytes =
+                        StoredEntryVar::new(&height_bytes, *block.commitment_tree_data())
+                            .to_bytes()?;
+                    ironwood_bytes = match build_block_ironwood_entry(&block, &height_bytes)? {
+                        Some(entry) => Some(entry.to_bytes()?),
+                        None => None,
+                    };
+                } else {
+                    // Pre-NU6.3: rebuild the commitment row in place from the legacy fixed-length
+                    // row (ironwood defaults to none).
+                    let commitment_tree_data: CommitmentTreeData = {
+                        let txn = env.begin_ro_txn()?;
+                        let raw = txn
+                            .get(legacy_ctd_db, &height_bytes)
+                            .map_err(FinalisedStateError::LmdbError)?;
+                        let entry = StoredEntryFixed::<CommitmentTreeData>::from_bytes(raw)
+                            .map_err(|error| {
+                                FinalisedStateError::Custom(format!(
+                                    "legacy commitment_tree_data corrupt data: {error}"
+                                ))
+                            })?;
+                        if !entry.verify(&height_bytes) {
+                            return Err(FinalisedStateError::Custom(
+                                "legacy commitment_tree_data checksum mismatch".to_string(),
+                            ));
+                        }
+                        *entry.inner()
+                    };
+                    commitment_bytes =
+                        StoredEntryVar::new(&height_bytes, commitment_tree_data).to_bytes()?;
+                    ironwood_bytes = None;
+                }
+
+                // Write commitment (+ ironwood) and advance progress atomically.
                 {
                     let mut txn = env.begin_rw_txn()?;
-                    match txn.put(
+                    put_idempotent(
+                        &mut txn,
                         new_ctd_db,
                         &height_bytes,
-                        &new_entry_bytes,
-                        WriteFlags::NO_OVERWRITE,
-                    ) {
-                        Ok(()) => {}
-                        // Idempotent on resume: an existing rebuilt row must match exactly.
-                        Err(lmdb::Error::KeyExist) => {
-                            let existing = txn
-                                .get(new_ctd_db, &height_bytes)
-                                .map_err(FinalisedStateError::LmdbError)?;
-                            if existing != new_entry_bytes.as_slice() {
-                                return Err(FinalisedStateError::Custom(format!(
-                                    "conflicting rebuilt commitment_tree_data at height {}",
-                                    height.0
-                                )));
-                            }
-                        }
-                        Err(error) => return Err(FinalisedStateError::LmdbError(error)),
+                        &commitment_bytes,
+                        &format!("commitment_tree_data at height {}", height.0),
+                    )?;
+                    if let Some(bytes) = &ironwood_bytes {
+                        put_idempotent(
+                            &mut txn,
+                            ironwood_db,
+                            &height_bytes,
+                            bytes,
+                            &format!("ironwood at height {}", height.0),
+                        )?;
                     }
 
                     let progress = StoredEntryFixed::new(MIGRATION_CTD_PROGRESS_KEY, height + 1);

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/migrations.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/migrations.rs
@@ -10,3 +10,5 @@
 mod v1_0_to_v1_1;
 #[cfg(not(feature = "transparent_address_history_experimental"))]
 mod v1_1_to_v1_2;
+#[cfg(not(feature = "transparent_address_history_experimental"))]
+mod v1_2_to_v1_3;

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/migrations/v1_2_to_v1_3.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/migrations/v1_2_to_v1_3.rs
@@ -1,0 +1,99 @@
+//! V1.2.1 to V1.3.0 migration tests.
+//!
+//! Coverage note: these tests use `ActivationHeights::default()`, whose NU6.3 activation is `None`,
+//! so the migration takes the below-activation branch (rebuild each commitment row in place from the
+//! legacy fixed-length table, no ironwood). The at/above-activation *ironwood backfill* branch —
+//! which refetches block data from the validator — cannot be exercised yet: `MockchainSource`
+//! serves no ironwood commitment roots (see its `get_commitment_tree_roots` TODO) and the test
+//! vectors carry no ironwood actions, so building a post-NU6.3 block would fail resolving the
+//! (required) ironwood root. That path needs ironwood-capable test vectors before it can be tested.
+
+use std::path::PathBuf;
+use tempfile::TempDir;
+use zaino_common::network::ActivationHeights;
+use zaino_common::{DatabaseConfig, Network, StorageConfig};
+
+use crate::chain_index::finalised_state::capability::{DbVersion, MigrationStatus};
+use crate::chain_index::finalised_state::finalised_source::v1::DB_VERSION_V1;
+use crate::chain_index::finalised_state::FinalisedState;
+use crate::chain_index::tests::init_tracing;
+use crate::chain_index::tests::vectors::{
+    build_active_mockchain_source, load_test_vectors, TestVectorData,
+};
+use crate::{ChainIndexConfig, Height, StatusType};
+
+fn v1_2_1() -> DbVersion {
+    DbVersion {
+        major: 1,
+        minor: 2,
+        patch: 1,
+    }
+}
+
+/// Regression test for the startup ordering bug: opening a pre-1.3.0 cache used to start the
+/// background validator concurrently with the v1.2.1 → v1.3.0 migration. The validator's
+/// `initial_block_scan` read the freshly-created-empty `commitment_tree_data_1_3_0` table before the
+/// migration rebuilt it, failing with `MDB_NOTFOUND` ("block scan") and latching `CriticalError`.
+///
+/// The fix defers the validator until every migration finishes. This test builds an on-disk v1.2.1
+/// database, then reopens it through the production `FinalisedState::spawn` path (which migrates to
+/// the current schema and only then starts the validator) and asserts it reaches `Ready` — i.e. the
+/// migration completed *before* validation, and validation then passed.
+#[tokio::test(flavor = "multi_thread")]
+async fn v1_2_1_cache_migrates_to_current_then_validates() {
+    init_tracing();
+
+    let TestVectorData { blocks, .. } = load_test_vectors().unwrap();
+    let active_height = Height(150);
+
+    let temporary_directory: TempDir = tempfile::tempdir().unwrap();
+    let database_path: PathBuf = temporary_directory.path().to_path_buf();
+
+    let database_config = ChainIndexConfig {
+        storage: StorageConfig {
+            database: DatabaseConfig {
+                path: database_path,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ephemeral: false,
+        db_version: 1,
+        network: Network::Regtest(ActivationHeights::default()),
+    };
+
+    let source = build_active_mockchain_source(active_height.0, blocks.clone());
+
+    // Build an on-disk v1.2.1 database (the pre-1.3.0 cache shape), then release it.
+    let old_database =
+        FinalisedState::build_db_to_version(database_config.clone(), source.clone(), v1_2_1())
+            .await
+            .unwrap();
+    old_database.wait_until_synced().await;
+    assert_eq!(old_database.get_metadata().await.unwrap().version, v1_2_1());
+    old_database.shutdown().await.unwrap();
+    drop(old_database);
+
+    // Reopen through the production spawn path: it runs the v1.2.1 → v1.3.0 migration and only then
+    // starts the validator. Before the ordering fix this raced the migration and latched
+    // `CriticalError`; now it must migrate first and validate cleanly.
+    let migrated_database = FinalisedState::spawn(database_config.clone(), source.clone())
+        .await
+        .unwrap();
+    migrated_database.wait_until_synced().await;
+
+    assert_eq!(
+        migrated_database.status(),
+        StatusType::Ready,
+        "the validator must run only after the migration completes, and then reach Ready"
+    );
+
+    let migrated_metadata = migrated_database.get_metadata().await.unwrap();
+    assert_eq!(migrated_metadata.version, DB_VERSION_V1);
+    assert_eq!(migrated_metadata.migration_status, MigrationStatus::Empty);
+
+    let migrated_height = migrated_database.db_height().await.unwrap().unwrap();
+    assert_eq!(migrated_height, active_height);
+
+    migrated_database.shutdown().await.unwrap();
+}


### PR DESCRIPTION
- Closes https://github.com/zingolabs/zaino/issues/1374

Fixes: Fixes zainod startup failure on pre-v1.3.0 caches (Ironwood migration)

Opening an old testnet cache failed with MDB_NOTFOUND: "block scan" → ChainIndex initial sync failed. Two independent defects, one per commit.

### 5e4d45e7 — make persistent db validation wait on migration

The finalised-state background validator was started in DbV1::spawn, concurrently with the migration that FinalisedState::spawn kicks off afterward. Its initial block scan read the freshly-created-but-empty commitment_tree_data_1_3_0 table before the migration populated it → MDB_NOTFOUND → permanent CriticalError.

- Split "open/heal DB" from "start validator": DbV1::spawn now opens + heals only; the old spawn_handler becomes start_validator(&self), exposed via FinalisedSource::start_validator.
- FinalisedState::spawn starts the validator only after migrate() returns Ok (or immediately when no migration is pending), so validation always runs against a fully-migrated, current-schema DB.
- Test-only fixtures never validate a pre-migration DB: spawn_v1_0_0 marks the empty fixture Ready directly; spawn_with_target_version marks Ready after its migration without validating — no version-comparison, robust across future schema bumps.

###  b1551012 — fixed ironwood migration

The v1.2.1 → v1.3.0 migration hard-refused when the chain tip was at/above NU6.3 activation, because it could only rebuild commitment rows from legacy on-disk data. It now backfills the missing ironwood data from the backing validator.

- Dropped the NU6.3 guard; the migration now uses its source.
- Per height: below NU6.3 → in-place rebuild of the commitment row from the legacy fixed-length table (ironwood None); at/above NU6.3 → refetch via build_indexed_block_from_source and write both the commitment row (with ironwood root/size) and the sparse ironwood row (new shared build_block_ironwood_entry helper + ironwood_db() accessor).
- Preserves resumability, checkpoint fsync, idempotent (NO_OVERWRITE + verify-match) writes, and version-bump finalisation.
- Adds migrations/v1_2_to_v1_3.rs regression test: builds a v1.2.1 cache, reopens through the production spawn path, and asserts it migrates to the current schema and reaches Ready (i.e. migration completed before validation).

Caveats: the at/above-activation ironwood backfill path is verified by review + compilation but not integration-tested — MockchainSource serves no ironwood roots and the vectors carry no ironwood actions (see the test-file note). For an on-disk cache already past NU6.3, the operator's validator source must be able to serve that height range.
