### PR TITLE
build: bump crate versions for 0.6.0-rc.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5885,7 +5885,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-common"
-version = "0.2.0"
+version = "0.4.0-rc.3"
 dependencies = [
  "rustls",
  "serde",
@@ -5898,7 +5898,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-fetch"
-version = "0.2.1"
+version = "0.4.0-rc.3"
 dependencies = [
  "base64",
  "derive_more",
@@ -5925,7 +5925,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-proto"
-version = "0.1.3"
+version = "0.2.0-rc.3"
 dependencies = [
  "prost",
  "tonic",
@@ -5938,7 +5938,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-serve"
-version = "0.3.1"
+version = "0.5.0-rc.3"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -5959,7 +5959,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-state"
-version = "0.3.1"
+version = "0.5.0-rc.3"
 dependencies = [
  "arc-swap",
  "bitflags 2.13.0",
@@ -6031,7 +6031,7 @@ dependencies = [
 
 [[package]]
 name = "zainod"
-version = "0.4.3-ironwood.1"
+version = "0.6.0-rc.3"
 dependencies = [
  "clap",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,15 +122,15 @@ tempfile = "3.2"
 # no longer need `default-features = false` to drop it: their default feature
 # set is already empty. Enable zcashd end-to-end with `--features zcashd_support`.
 zainod = { path = "packages/zainod" }
-zaino-common = { path = "packages/zaino-common", version = "0.2.0" }
+zaino-common = { path = "packages/zaino-common", version = "0.4.0-rc.3" }
 # default-features = false so the default-on `zcashd_support` feature can be
 # dropped end-to-end via `--no-default-features`; each consumer re-enables it
 # by forwarding `zcashd_support` in its own `default`. See
 # docs/adr/0001-zcashd-support-feature-gate.md.
-zaino-fetch = { path = "packages/zaino-fetch", version = "0.2.1", default-features = false }
-zaino-proto = { path = "packages/zaino-proto", version = "0.1.3" }
-zaino-state = { path = "packages/zaino-state", version = "0.3.1", default-features = false }
-zaino-serve = { path = "packages/zaino-serve", version = "0.3.1", default-features = false }
+zaino-fetch = { path = "packages/zaino-fetch", version = "0.4.0-rc.3", default-features = false }
+zaino-proto = { path = "packages/zaino-proto", version = "0.2.0-rc.3" }
+zaino-state = { path = "packages/zaino-state", version = "0.5.0-rc.3", default-features = false }
+zaino-serve = { path = "packages/zaino-serve", version = "0.5.0-rc.3", default-features = false }
 zaino-testutils = { path = "live-tests/zaino-testutils" }
 
 # Zingo-infra (validator launcher driving the live tests; not a prod dep).

--- a/packages/zaino-common/Cargo.toml
+++ b/packages/zaino-common/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.0"
+version = "0.4.0-rc.3"
 
 [dependencies]
 # Zebra

--- a/packages/zaino-fetch/Cargo.toml
+++ b/packages/zaino-fetch/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.2.1"
+version = "0.4.0-rc.3"
 
 [features]
 default = []

--- a/packages/zaino-proto/Cargo.toml
+++ b/packages/zaino-proto/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.3"
+version = "0.2.0-rc.3"
 
 [features]
 default = ["heavy"]

--- a/packages/zaino-serve/Cargo.toml
+++ b/packages/zaino-serve/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.1"
+version = "0.5.0-rc.3"
 
 [features]
 default = []

--- a/packages/zaino-state/Cargo.toml
+++ b/packages/zaino-state/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.1"
+version = "0.5.0-rc.3"
 
 [features]
 default = []

--- a/packages/zainod/Cargo.toml
+++ b/packages/zainod/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.3-ironwood.1"
+version = "0.6.0-rc.3"
 
 [[bin]]
 name = "zainod"


### PR DESCRIPTION
## Summary

Bump all publishable crate versions for the 0.6.0-rc.3 pre-release.

| Crate | From | To |
|---|---|---|
| zaino-common | 0.2.0 | 0.4.0-rc.3 |
| zaino-fetch | 0.2.1 | 0.4.0-rc.3 |
| zaino-proto | 0.1.3 | 0.2.0-rc.3 |
| zaino-serve | 0.3.1 | 0.5.0-rc.3 |
| zaino-state | 0.3.1 | 0.5.0-rc.3 |
| zainod | 0.4.3-ironwood.1 | 0.6.0-rc.3 |

Workspace dependency version pins updated to match.

Once merged, the existing `0.6.0-rc.3` tag needs to be moved to the new tip (it was auto-created on the unbumped merge commit). Then PR `rc/0.6.0` → `stable`, fix versions to drop the `-rc.3` suffix, and tag `0.6.0`.