### PR TITLE
fix: expose wrapped errors via source() in Method and StatusError variants

### DIFF
--- a/packages/zaino-fetch/src/jsonrpsee/connector.rs
+++ b/packages/zaino-fetch/src/jsonrpsee/connector.rs
@@ -165,8 +165,13 @@ pub enum RpcRequestError<MethodError> {
     Transport(#[from] TransportError),
 
     /// Error variant for errors related to the JSON-RPC method being called.
-    #[error("Method error: {0:?}")]
-    Method(MethodError),
+    ///
+    /// The payload is `#[source]` for the same reason as
+    /// [`RpcRequestError::UnexpectedErrorResponse`]'s: the typed rejection
+    /// must stay reachable through `source()` chains for the serving
+    /// surfaces' downcast walks (zingolabs/zaino#1408).
+    #[error("Method error: {0}")]
+    Method(#[source] MethodError),
 
     /// The provided input failed to serialize.
     #[error("request input failed to serialize: {0:?}")]
@@ -1104,6 +1109,25 @@ mod tests {
         assert_eq!(
             rpc_error.code,
             zebra_rpc::server::error::LegacyCode::Verify as i64
+        );
+    }
+
+    /// `Method` carries the typed method-specific rejection, so — like
+    /// `UnexpectedErrorResponse` — its payload must stay reachable through
+    /// `source()` for the serving surfaces' downcast walks to attribute the
+    /// rejection (zingolabs/zaino#1408).
+    #[test]
+    fn method_exposes_method_error_via_source() {
+        use crate::jsonrpsee::response::SendTransactionError;
+
+        let error: RpcRequestError<SendTransactionError> =
+            RpcRequestError::Method(SendTransactionError::MissingInputs);
+
+        let source = std::error::Error::source(&error)
+            .expect("the method error must be exposed via source()");
+        assert!(
+            source.downcast_ref::<SendTransactionError>().is_some(),
+            "the source must downcast to the typed method error"
         );
     }
 

--- a/packages/zaino-state/src/error.rs
+++ b/packages/zaino-state/src/error.rs
@@ -269,7 +269,7 @@ pub enum MempoolError {
 
     /// Unexpected status-related error.
     #[error("Status error: {0:?}")]
-    StatusError(StatusError),
+    StatusError(#[source] StatusError),
 }
 
 /// Errors related to the `BlockCache`.
@@ -337,7 +337,7 @@ pub enum NonFinalisedStateError {
 
     /// Unexpected status-related error.
     #[error("Status error: {0:?}")]
-    StatusError(StatusError),
+    StatusError(#[source] StatusError),
 }
 
 /// These aren't the best conversions, but the NonFinalizedStateError should go away
@@ -427,7 +427,7 @@ pub enum FinalisedStateError {
 
     /// Unexpected status-related error.
     #[error("Status error: {0:?}")]
-    StatusError(StatusError),
+    StatusError(#[source] StatusError),
 
     /// Error from JsonRpcConnector.
     // TODO: Remove when FinalisedState replaces legacy finalised state.
@@ -660,6 +660,45 @@ impl From<MempoolError> for ChainIndexError {
             message,
             source: Some(Box::new(value)),
         }
+    }
+}
+
+#[cfg(test)]
+mod status_error_wrappers {
+    use super::*;
+
+    fn status_error() -> StatusError {
+        StatusError {
+            server_status: crate::status::StatusType::CriticalError,
+        }
+    }
+
+    /// Asserts `error` exposes a [`StatusError`] via `source()`, the link the
+    /// serving surfaces' downcast walks need for attribution
+    /// (zingolabs/zaino#1408).
+    fn assert_status_error_reachable(error: &(dyn std::error::Error + 'static)) {
+        let source = error
+            .source()
+            .expect("the wrapped StatusError must be exposed via source()");
+        assert!(
+            source.downcast_ref::<StatusError>().is_some(),
+            "the source must downcast to the typed StatusError"
+        );
+    }
+
+    #[test]
+    fn mempool_error_exposes_status_error_via_source() {
+        assert_status_error_reachable(&MempoolError::StatusError(status_error()));
+    }
+
+    #[test]
+    fn non_finalised_state_error_exposes_status_error_via_source() {
+        assert_status_error_reachable(&NonFinalisedStateError::StatusError(status_error()));
+    }
+
+    #[test]
+    fn finalised_state_error_exposes_status_error_via_source() {
+        assert_status_error_reachable(&FinalisedStateError::StatusError(status_error()));
     }
 }
 


### PR DESCRIPTION
Closes #1408. **Stacked on #1405** — the base branch is `fix/1404-send-rejection-masking`; retarget to `dev` after #1405 merges. Only the top commit (`fix: expose wrapped errors via source() in Method and StatusError variants`) belongs to this PR.

## Problem

#1404 was caused in part by an error-enum variant carrying its cause in a plain field without `#[source]`, silently severing the `source()` chain that the serving surfaces downcast-walk to attribute node rejections. PR #1405 fixed the variant that bit (`RpcRequestError::UnexpectedErrorResponse`); the follow-up audit (#1408) found the same latent pattern in four more places:

- `RpcRequestError::Method(MethodError)` in `packages/zaino-fetch/src/jsonrpsee/connector.rs` — a typed method-specific rejection (and anything it wraps) was unreachable from `source()` walks.
- The three `StatusError(StatusError)` wrapper variants in `packages/zaino-state/src/error.rs` (`MempoolError`, `NonFinalisedStateError`, `FinalisedStateError`).

## Fix

All four variants now mark their payload `#[source]`, preserving the invariant #1405 documented: any variant that wraps another error must expose it via `source()`, or downstream attribution silently degrades to a generic wrapper message.

The change is smaller than the issue predicted. The issue anticipated bounding the generic (`MethodError: std::error::Error`), but thiserror infers the required trait bounds per generated impl, so no signature changes were needed anywhere — the whole workspace compiles unchanged.

One deliberate behavior change: because a `#[source]` payload is a real error with a real message, `Method`'s display switches from `Debug` to `Display` formatting (`Method error: MissingInputs` → `Method error: Missing inputs`). Nothing in the tree matches on the old format.

## Tests (written first, confirmed red, now green)

1. `method_exposes_method_error_via_source` (zaino-fetch) pins that `Method` exposes its payload via `source()` with the typed method error downcastable.
2. Three tests in a new `status_error_wrappers` module (zaino-state), one per wrapper enum, each asserting the wrapped `StatusError` is reachable and downcastable via `source()`.

All four failed before the fix with `source()` returning `None` at the severed link.

Verified with `cargo check --workspace --all-targets`, `cargo clippy --workspace --all-targets` (exit zero; only pre-existing live-test warnings), `cargo fmt --all`, and `cargo nextest run` on the production set (370/370 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
