### PR TITLE
fix(ci): skip integration-test dispatch on fork pull requests

### DIFF
--- a/.github/workflows/trigger-integration-tests.yml
+++ b/.github/workflows/trigger-integration-tests.yml
@@ -29,6 +29,17 @@ jobs:
   trigger-integration:
     name: Trigger integration tests
     runs-on: ubuntu-latest
+    # Pull requests from a fork receive no repository secrets, so the app-token
+    # step below is handed empty `app-id` / `private-key` inputs and the job dies
+    # at its first step — failing every external contribution, which CONTRIBUTING.md
+    # asks to be made from a personal fork. Dispatching the integration suite is a
+    # zingolabs-internal action, not a gate on contributor code, so skip it on
+    # forks instead. The `push` clause is required: `github.event.pull_request` is
+    # null outside pull-request events, which would otherwise disable the
+    # merge-to-`dev` dispatch as well. See issue #991.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Generate app token
         id: app-token

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ Documentation should be clear and accurate to your latest commit. This includes 
 
 Contributions must be [GitHub pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests). New contributors should make PRs _from a personal fork_ of the project, _to this repo, zingolabs/zaino_. Generally pull requests will be against `dev`, the development branch.
 
+Pull requests opened from a fork do not dispatch the `zcash/integration-tests` suite: GitHub withholds repository secrets from fork pull requests, so the workflow cannot authenticate. The `Trigger integration tests` check is skipped on those PRs rather than failing them, and a maintainer runs the suite from a `zingolabs/zaino` branch before merging.
+
 When code or documentation is still being developed and is not intended for review, the PR should be in the `Draft` state.
 `Draft` pull requests cannot be merged: an `Open` PR is a PR that is "ready for review." The `Draft` state should be set as a default when working with GitHub on the web, and can be changed to `Open` status later, marking the PR as ready for review.
 


### PR DESCRIPTION
Fixes #991. Pull requests opened from a fork currently fail CI unconditionally. This adds a job-level guard so the integration-test dispatch is skipped on forks instead of failing them.

## Root cause

`.github/workflows/trigger-integration-tests.yml` begins by minting a GitHub App token:

```yaml
- name: Generate app token
  uses: actions/create-github-app-token@bcd2ba49…
  with:
    app-id: ${{ secrets.DISPATCH_APP_ID }}
    private-key: ${{ secrets.DISPATCH_APP_PRIVATE_KEY }}
```

GitHub withholds repository secrets from workflows triggered by `pull_request` from a fork. Both inputs arrive empty, the action rejects them, and the job dies at its first step, before checkout, before any build.

Per-step conclusions from PR #1173 (run `26863441956`):

```
JOB: Trigger integration tests   conclusion=failure
  [1] success   Set up job
  [2] failure   Generate app token      ← dies here
  [3] skipped   Get requested test branch, if any
  [4] skipped   Trigger integration tests
```

Three seconds, start to finish.

The workflow's paths filter (`**/*.rs`, `**/Cargo.toml`, `**/Cargo.lock`, `.cargo/config.toml`) means this catches essentially every substantive contribution. Four open fork PRs show the pattern cleanly, the discriminator is the paths filter, not the contributor:

| PR | Files changed | Trigger check | Outcome |
|---|---|---|---|
| #1173 | 8 × `.rs` | ran | **failure** |
| #1239 | `.rs` + `Cargo.toml`/`lock` | ran | **failure** |
| #1165 | only `.github/workflows/release.yaml` | not triggered | green |
| #1272 | only `tools/.DS_Store` | not triggered | green |

## Why this is a bug and not a deliberate exclusion

The workflow was introduced twice on the same day. #910 was opened from `nuttycom/zaino`,  a fork, and closed unmerged 28 minutes later. #911 carried identical content from an org-owned branch, and says so in its body:

> "same as #910, opening as a zingolabs owned branch PR so the workflow has access to repo secrets"

The fork-secrets limitation was understood at the moment the workflow landed; the response was to move that one PR onto an org branch rather than guard the workflow. Every fork contributor since has hit the wall the authors stepped around.

Nothing in `CONTRIBUTING.md`, `CLAUDE.md`, `docs/`, or the workflow itself documents excluding forks, and `CONTRIBUTING.md` explicitly asks new contributors to PR *from a personal fork*, which is precisely the failing path.

## The fix

A job-level guard on `trigger-integration`:

```yaml
if: >-
  github.event_name == 'push' ||
  github.event.pull_request.head.repo.full_name == github.repository
```

On a fork, `head.repo.full_name` never equals the base repo, so the job is skipped rather than failed. On an org branch it matches and behaviour is unchanged. The `push` clause is required: `github.event.pull_request` is null outside pull-request events, so the comparison alone would also disable the merge-to-`dev` dispatch.

This uses only the `github` context, which is unambiguously available in a job-level `if`.

## Verification

Run locally against the real action with [`act`](https://github.com/nektos/act), using synthetic event payloads:

```
PASS  fork PR       -> skip  (expected skip)
PASS  org-branch PR -> run   (expected run)
PASS  push to dev   -> run   (expected run)
```

The two positive cases matter as much as the first, they confirm the guard does not over-match and silently disable the real dispatch, which would be a worse regression than the bug being fixed. Before the change, the fork payload produced `❌ Failure - Main Generate app token` and exit 1; after, the job is skipped and the run exits 0.

I also checked the public branch-rules endpoint for `dev`: the active rules are `deletion`, `non_fast_forward`, and `pull_request`; no `required_status_checks`, so a skipped check cannot block a merge. (That endpoint reports rulesets only; if classic branch protection is also configured on `dev`, someone with admin access should confirm.)

## Trade-off

Fork PRs now receive no integration-test dispatch. That is strictly better than today, where they receive none *and* a red X , but it does mean a maintainer must run the suite from a `zingolabs/zaino` branch before merging a fork PR. The `CONTRIBUTING.md` change documents this so it is not silent.

## Out of scope

Fork PRs will now be green, but green still means "lints and formatting passed",  the compiling jobs in `ci.yml` carry `if: github.event_name != 'pull_request'` and are skipped on every PR, fork or not. That is a separate and larger problem, tracked separately.

Also unchanged here: `actions/create-github-app-token` reports `app-id` as deprecated in favour of `client-id`. It works while non-empty, so it is not this bug.
