### PR TITLE
ci: add GitHub-hosted build and test lane for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,62 @@ jobs:
           # failures (e.g. RUSTSEC-2022-0001 lmdb) handled separately.
           command: check bans
 
+  hosted-clippy:
+    name: Clippy (hosted)
+    # GitHub-hosted, so it runs on every pull request including from forks.
+    # The arc-sh-runners lane below has had no runner assigned since ~2026-03-19
+    # (jobs queue until GitHub's 24h timeout and are cancelled), so it currently
+    # provides no signal at all. This job is purely additive: the self-hosted
+    # jobs are untouched and resume covering the tree if that pool returns.
+    runs-on: ubuntu-latest
+    # Drafts are excluded to conserve runner minutes, matching the draft check
+    # on the self-hosted jobs. `github.event.pull_request` is null outside
+    # pull-request events, so push / workflow_call runs are unaffected.
+    if: github.event.pull_request.draft != true
+    timeout-minutes: 45
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      # Caches ~/.cargo and target/. Fork pull requests cannot write to the
+      # base repository's cache but can restore from it, so forks get the warm
+      # path too. A distinct key from the test job: clippy and nextest build
+      # under different profiles, and one shared key would thrash.
+      - name: Cache cargo registry and build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: hosted-clippy
+
+      # No protoc step: zaino-proto's build script no-ops when protoc is absent
+      # and uses the generated sources committed under src/proto/.
+      - name: Clippy
+        run: cargo clippy --no-default-features --all-targets -- -D warnings
+
+  hosted-test:
+    name: Tests (hosted)
+    # The production test set only — `cargo nextest run` without `--workspace`
+    # resolves to `default-members`, which excludes the validator-backed
+    # live-tests crates (docs/adr/0002). Equivalent to `makers test packages`.
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft != true
+    # Measured cold on a 2-core box: ~37 min, of which only ~100s is running
+    # tests — the lane is compile-bound, so a warm cache dominates the cost.
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Cache cargo registry and build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: hosted-test
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Run tests
+        run: cargo nextest run --no-default-features --no-fail-fast
+
   compute-tag:
     uses: ./.github/workflows/compute-tag.yml
 


### PR DESCRIPTION
 ## Summary

  Adds two GitHub-hosted jobs to `ci.yml`, `Clippy (hosted)` and `Tests (hosted)`, so pull requests get build and test signal. Purely additive: the existing `arc-sh-runners` jobs are unmodified.

  Addresses part 2 of #1420.

  ## Background: PRs currently have no build or test coverage

  Full evidence is in #1420. In brief: every compiling and testing job in the tree targets `arc-sh-runners`, and no job with that label has been assigned a runner since roughly **2026-03-19**, they queue until GitHub's 24-hour timeout and are cancelled. Roughly 130 consecutive nightly runs. The last nightly that *passed* was 2026-01-16.

  Of the last 100 `CI - PR` runs, 89 succeeded in 0–1 minutes: lint-only. A green PR today means "rustfmt, hadolint, cargo-deny and the repo guards passed". It does not mean the tree builds.

  The PR-side guard (`if: github.event_name != 'pull_request'`) is deliberate and documented in-file, "skipped on PRs until a self-hosted runner is available", and was a sound trade-off **while the nightly was the safety net**. The nightly stopped running in March.

  ## Assumptions this change rests on

  Stating these explicitly, because a maintainer with infrastructure access may know better and should feel free to correct any of them:

  1. **We cannot determine *why* no runner is assigned.** The API shows only that none ever is. Scaled to zero, decommissioned, a label mismatch, or a runner-group permission change that dropped this repository would all produce identical symptoms. We have no org admin access.
  2. **We therefore assume the self-hosted lane cannot be relied on in the near term**, but deliberately do not assume it is gone for good. This is why the change is additive rather than a migration: if the pool returns, those jobs resume with no further action, and the hosted jobs become redundant coverage that can be trimmed or kept as the fork-safe lane.
  3. **We assume fork PRs should never run on self-hosted runners anyway**, on the standard public-repo security grounds. So even in the best case where ARC returns, a GitHub-hosted lane remains the right home for external contributions.
  4. **We assume local verification predicts hosted-runner behaviour.** Same Linux, same pinned toolchain (`rust-toolchain.toml` 1.96.0), no `protoc` requirement, and all native dependencies (`librocksdb-sys`, `aws-lc-sys`, `lmdb-sys`, `ring`) build against toolchains preinstalled on `ubuntu-latest`. Verified locally, not yet on a hosted runner, see Verification.

  If assumption 1 or 2 is wrong and the runners are returning imminently, this is still safe to merge: it costs runner minutes and provides duplicate coverage, nothing more.

  ## The change

  ```yaml
  hosted-clippy:   # ubuntu-latest, cargo clippy --no-default-features --all-targets -- -D warnings
  hosted-test:     # ubuntu-latest, cargo nextest run --no-default-features --no-fail-fast
  ```

  Both use `Swatinem/rust-cache@v2` with distinct keys, skip draft PRs, and carry `timeout-minutes`.

  Scope is the production test set only: `cargo nextest run` without `--workspace` resolves to `default-members`, excluding the validator-backed live-test crates (docs/adr/0002). Equivalent to `makers test packages`. No validator, no live suite, no `zcashd_support`.

  No `protoc` step: `zaino-proto`'s build script no-ops when protoc is absent and uses the generated sources committed under `src/proto/`.

  ## Why it should work, verification

  Both commands were run cold on a 2-core / 7 GB box (at or below a hosted runner) *before* the workflow was written:

  | Phase | Result | Cold time |
  |---|---|---|
  | `cargo fetch --locked` | rc=0 | 12s |
  | `cargo clippy --no-default-features --all-targets -- -D warnings` | **rc=0** | 14m 46s |
  | `cargo nextest run --no-default-features --no-fail-fast` | **rc=0** | 36m 44s |

  ```
  Starting 363 tests across 7 binaries (3 tests skipped)
  Summary [99.769s] 363 tests run: 363 passed, 3 skipped
  ```


- **Cache size.** `target/` reached 7.8 GB locally against GitHub's 10 GB per-repo cache limit. `rust-cache` prunes workspace artifacts and compresses, so two keys should fit comfortably, but if they begin evicting each other, merging both steps into a single job is the fix.


## Out of scope

- The `arc-sh-runners` pool itself. This does not fix it, diagnose it, or remove dependence on it, that is part 1 of #1420 and needs org admin access.
- The e2e and clientless live partitions (#1308, #1312), those need a validator and are a separate capacity question.
- `cargo doc`, `cargo-hack`, and the whitespace check, which exist only in the nightly.
