### PR TITLE
fix(docker): make the production image buildable from a clean checkout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,12 @@
 # RUST_VERSION must be supplied via --build-arg. Canonical source is
 # rust-toolchain.toml's `channel`, surfaced by the workbench get-rust-version bin
 # — no default is set so a stale literal cannot drift from the workspace's
-# pinned toolchain. See README for the recommended build invocation.
+# pinned toolchain.
+#
+# Omitting it expands this to `rust:-bookworm` and fails with "invalid reference
+# format", which does not name the missing argument (issue #468). Prefer
+# `makers build-zainod-image`, which supplies the pin; see docs/docker.md
+# ("Building the image") for the raw docker invocation.
 ARG RUST_VERSION
 ARG UID=1000
 ARG GID=1000
@@ -37,7 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       cmake=3.25.1-1 \
       make=4.3-4.1 \
       ca-certificates=20230311+deb12u1 \
-      protobuf-compiler=3.21.12-3 \
+      protobuf-compiler=3.21.12-3+deb12u1 \
   && rm -rf /var/lib/apt/lists/*
 
 # Copy entire workspace (prevents missing members)

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -81,6 +81,18 @@ script.main = 'source "./tools/scripts/build-image.sh"'
 
 # -------------------------------------------------------------------
 
+[tasks.build-zainod-image]
+description = "Build the zainod production image (repo-root Dockerfile), supplying the pinned RUST_VERSION"
+# Distinct from `build-image`, which builds the CI/test image from
+# live-tests/test_environment. This builds the shipped zainod image and is the
+# documented local equivalent of the release workflow's docker/build-push-action
+# step, which passes the same RUST_VERSION build arg. Without it a bare
+# `docker buildx build .` fails on the argument-less ARG (issue #468).
+script_runner = "bash"
+script = { file = "tools/scripts/build-zainod-image.sh" }
+
+# -------------------------------------------------------------------
+
 [tasks.push-image]
 description = "Push image if running in CI"
 # condition = { env_set = ["CI"] }

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -133,6 +133,46 @@ The image includes a health check:
 docker inspect --format='{{.State.Health.Status}}' <container>
 ```
 
+## Building the image
+
+```bash
+makers build-zainod-image
+```
+
+This is the only invocation that works out of the box. The Dockerfile declares
+`ARG RUST_VERSION` with no default — deliberately, so a literal cannot drift
+from `rust-toolchain.toml`'s `channel` — and the task supplies the pin from that
+single source of truth, exactly as the release workflow does.
+
+A bare `docker buildx build .` therefore **fails**, expanding the builder stage
+to `rust:-bookworm`:
+
+```
+ERROR: failed to solve: failed to parse stage name
+       "docker.io/library/rust:-bookworm": invalid reference format
+```
+
+The error does not mention the missing argument, so it is easy to misread as a
+broken Dockerfile. To build with `docker` directly, pass the pin yourself:
+
+```bash
+docker buildx build \
+  --build-arg "RUST_VERSION=$(cargo run -q --manifest-path tools/workbench/Cargo.toml --bin get-rust-version)" \
+  --tag zaino:latest .
+```
+
+Extra arguments are forwarded, so the no-TLS variant is:
+
+```bash
+makers build-zainod-image -- --build-arg NO_TLS=true
+```
+
+Override the tag with `ZAINOD_IMAGE`, e.g. `ZAINOD_IMAGE=zaino:dev makers
+build-zainod-image`.
+
+Note this is distinct from `makers build-image`, which builds the **CI/test**
+image from `live-tests/test_environment`, not the shipped zainod image.
+
 ## Local Testing
 
 Permission handling can be tested locally:

--- a/tools/scripts/build-zainod-image.sh
+++ b/tools/scripts/build-zainod-image.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Build the zainod production container image from the repo-root Dockerfile.
+#
+# The Dockerfile declares `ARG RUST_VERSION` with no default, deliberately: a
+# literal there could drift from rust-toolchain.toml's `channel` unnoticed. The
+# cost is that a bare `docker buildx build .` expands the builder stage to
+# `rust:-bookworm` and dies with "invalid reference format" — an error that says
+# nothing about the missing argument (issue #468).
+#
+# This script supplies the pin from the same single source of truth CI uses:
+# Makefile.toml's [env] RUST_VERSION, derived from the workbench
+# get-rust-version binary.
+#
+# Run via `makers build-zainod-image`. Extra arguments are forwarded to
+# `docker buildx build`, so a no-TLS image is:
+#
+#   makers build-zainod-image -- --build-arg NO_TLS=true
+
+set -euo pipefail
+
+if [ -z "${RUST_VERSION:-}" ]; then
+  echo "RUST_VERSION is unset; run this through 'makers build-zainod-image' so" >&2
+  echo "Makefile.toml's [env] can derive it from rust-toolchain.toml." >&2
+  exit 1
+fi
+
+IMAGE="${ZAINOD_IMAGE:-zaino:latest}"
+
+echo "Building ${IMAGE} (RUST_VERSION=${RUST_VERSION})"
+
+docker buildx build \
+  --build-arg "RUST_VERSION=${RUST_VERSION}" \
+  --tag "${IMAGE}" \
+  "$@" \
+  .
+
+echo "Built ${IMAGE}"

--- a/tools/scripts/help.sh
+++ b/tools/scripts/help.sh
@@ -40,8 +40,10 @@ echo "  container-test-save-failures    Run tests, save failures to \
 .failed-tests"
 echo "  container-test-retry-failures   Rerun only the previously failed \
 tests"
-echo "  build-image                Build the container image with current \
-artifact versions"
+echo "  build-image                Build the CI/test container image with \
+current artifact versions"
+echo "  build-zainod-image         Build the zainod production image \
+(repo-root Dockerfile; see docs/docker.md)"
 echo "  push-image                 Push the image (used in CI, can be used \
 manually)"
 echo "  compute-image-tag          Compute the tag for the container image \


### PR DESCRIPTION
Fixes #468. `docker buildx build .` still fails on a clean checkout, for two causes, neither of which is the one originally reported.

## The original failure is already gone

The issue quotes `--mount=type=bind,source=zaino-serve` and `--features disable_tls_unencrypted_traffic_mode`, top-level crate paths from before the `packages/` reorganisation, and a since-renamed feature. That Dockerfile no longer exists; the builder is now `COPY . .` plus `cargo install --path packages/zainod`. The `exit code: 101` in the report is not reproducible.

The headline claim, however, still holds.

## Cause 1, the required build arg is documented nowhere

```
ERROR: failed to solve: failed to parse stage name
       "docker.io/library/rust:-bookworm": invalid reference format
```

`ARG RUST_VERSION` has no default *on purpose*, so a literal cannot drift from `rust-toolchain.toml`'s `channel`. That is a good decision and this PR keeps it. The problem is discoverability: the Dockerfile said *"See README for the recommended build invocation"*, and the README contains no build instructions. Neither did `docs/docker.md`, whose "Local Testing" section assumes a `zaino:latest` image exists without saying how to produce one. Only `release.yaml` knew, via `build-args: RUST_VERSION=…`.

The error names neither the argument nor the fix, so it reads as a broken Dockerfile.

**Fixed by** a `makers build-zainod-image` task that supplies the pin from the same single source of truth CI uses (`Makefile.toml` `[env]` → workbench `get-rust-version`), a real "Building the image" section in `docs/docker.md` including the raw `docker` invocation, and a Dockerfile comment that names the failure mode and points somewhere real.

## Cause 2, a stale apt pin

Only visible *after* cause 1 is fixed:

```
E: Version '3.21.12-3' for 'protobuf-compiler' was not found
```

A bookworm point release superseded it (`3.21.12-3` → `3.21.12-3+deb12u1`). Same class as `2f3541a4` ("refresh the trixie apt pins the point release superseded"), now recurring on bookworm.

apt reports only the first failure, so rather than fix that one and rediscover the next, I queried the current candidate for **every** pinned package in both stages inside the exact base images. `protobuf-compiler` is the only drift; the other seven still match.

## Verification

Built and ran the image end to end:

- `makers build-zainod-image` → `zaino:latest`, 182 MB, exit 0
- `zainod --version` inside the image → `zainod 0.4.3-ironwood.1`, exit 0, the same command `HEALTHCHECK` runs
- `id` inside the image → `uid=1000(container_user)`, non-root as intended
- **hadolint**, exit 0 on the exact CI invocation, both Dockerfiles
- **shellcheck**, 29 scripts pass, including the new one
- `makers --list-all-steps` and `makers help` both show the new task

A bare `docker buildx build .` still fails, correctly. The fix is not to paper over it with a default that could drift; it is that a working, documented command now exists.

## Review notes

- **`build-zainod-image` is deliberately distinct from `build-image`**, which builds the CI/test image from `live-tests/test_environment`. `help.sh` now disambiguates both.
- **Extra args are forwarded**, so the no-TLS variant is `makers build-zainod-image -- --build-arg NO_TLS=true`; the tag is overridable via `ZAINOD_IMAGE`.
- **Unrelated bug found while verifying:** `tools/scripts/lint-shell.sh` exits **0** when `shellcheck` is not installed, so the shell lint silently passes on any machine lacking it. Not fixed here, it deserves its own issue.
- **`Dockerfile.deterministic`** and the CI `Containerfile` pin no apt versions, so this drift class is confined to the root `Dockerfile`.

---