### PR TITLE
fix: carry the zebra 6.3.0 update into the image pin and the error text

### DIFF
--- a/.env.testing-artifacts
+++ b/.env.testing-artifacts
@@ -5,7 +5,7 @@
 # zcashd Git tag (https://github.com/zcash/zcash/releases)
 ZCASH_VERSION=6.20.0
 
-ZEBRA_VERSION=6.0.0
+ZEBRA_VERSION=6.3.0
 
 # zcash-devtool git ref (https://github.com/zingolabs/zcash-devtool) —
 # the wallet client driven by wallet-tests via zcash_local_net, built

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ and this library adheres to Rust's notion of
   cadence and exclude-list caps operator-configurable.
 
 ### Changed
+- **The live test image now runs zebrad 6.3.0**, the release whose dependency
+  set matches the Zebra libraries Zaino links. The libraries moved to that set,
+  but the image tag stayed on 6.0.0, so the live suite exercised a pairing no
+  release ships.
+- **`getrawtransaction` reports an unknown transaction with the message
+  `Transaction not found in mempool or best chain`**, the text zebrad itself
+  now returns. The error code is unchanged. A client that matches on the old
+  message text must be updated.
 - **The mempool no longer stalls across a tip transition.** `getrawmempool`,
   `getmempoolinfo` and `GetMempoolTx` are served from a tip-agnostic set that
   never clears; the old mempool wiped its whole map on every tip change and

--- a/packages/zaino-state/src/chain_index/tests/proptest_blockgen.rs
+++ b/packages/zaino-state/src/chain_index/tests/proptest_blockgen.rs
@@ -507,10 +507,10 @@ const ORCHARD_ONLY_HEIGHTS: ActivationHeights = ActivationHeights {
     nu7: None,
 };
 
-/// Orchard-only era (NU6.3 never activates): fake Orchard content from height 2, and —
-/// since the stock strategy's V6 arm is reachable only from an NU6.3/NU7 ledger state,
-/// which `nu6_3: None` never produces — ironwood provably never appears anywhere in the
-/// chain or the served form.
+/// Orchard-only era: ironwood never appears in the chain or the served form, because the
+/// stock strategy reaches its V6 arm only through a `transaction_version_override` of 6 or
+/// an NU6.3/NU7 ledger state, and this harness leaves the override `None` and never
+/// activates `nu6_3`.
 #[test]
 fn passthrough_metadata_consistency_orchard_only() {
     metadata_consistency_for_era(ORCHARD_ONLY_HEIGHTS, None, false)

--- a/packages/zaino-state/src/indexer/node_backed_indexer.rs
+++ b/packages/zaino-state/src/indexer/node_backed_indexer.rs
@@ -1079,7 +1079,7 @@ impl<Source: BlockchainSource> ZcashIndexer for NodeBackedIndexerServiceSubscrib
         let not_found_error = || {
             NodeBackedIndexerServiceError::RpcError(crate::error::LegacyRpcError::new(
                 zebra_rpc::server::error::LegacyCode::InvalidAddressOrKey,
-                "No such mempool or main chain transaction",
+                "Transaction not found in mempool or best chain",
             ))
         };
 


### PR DESCRIPTION
Pull request #1441 moved the Zebra libraries to the set that zebrad 6.3.0
pins. It left three consequences of that move unapplied. This pull request
applies them. It is a follow-up, because #1441 already merged.

## The test image ran the wrong zebrad

`.env.testing-artifacts` pinned `ZEBRA_VERSION=6.0.0`. The live test image
builds from `zfnd/zebra:${ZEBRA_VERSION}`. The suite therefore ran a Zaino
built against the 6.3.0 libraries against a 6.0.0 server. No release ships
that pairing. This pull request advances the pin to 6.3.0.

The two values have moved together before. Commit `46c5e93a` bumped the
libraries. Commit `1e255d08` advanced `ZEBRA_VERSION` fourteen minutes later.

The `check-matching-zebras` task did not catch the drift. Its crates.io
branch only asserts that `ZEBRA_VERSION` is non-empty. It compares values
only for git `rev=` pins. Closing that gap needs a way to map a library
version to its zebrad release. That work is not in this pull request.

## `getrawtransaction` returned a stale message

zebra-rpc 16.0.0 changed the not-found message to `Transaction not found in
mempool or best chain`. Zaino still returned the older text. One condition
therefore produced two different messages. The message depended on whether
the client asked Zaino or the node behind it. The error code was already
correct and is unchanged.

**This is observable.** A client that matches on the old message text must
be updated. The CHANGELOG records it.

## A doc comment stated half a reason

The doc comment on `passthrough_metadata_consistency_orchard_only` credited
an unactivated `nu6_3` for excluding version 6 transactions. That is one of
two doors. `Transaction::arbitrary_with` consults
`transaction_version_override` before it consults the network upgrade. An
override of 6 therefore reaches the version 6 arm from any ledger state. The
harness leaves that override `None`. The sentence now says so.

## Verification

Every claim above was checked against the vendored crate sources, not
against version numbers. `cargo fmt --all --check` is clean.
`cargo check --package zaino-state --tests` succeeds. The `zfnd/zebra:6.3.0`
tag exists on Docker Hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
