### PR TITLE
build: bump crate versions for 0.8.0

### DIFF
--- a/.env.testing-artifacts
+++ b/.env.testing-artifacts
@@ -5,7 +5,7 @@
 # zcashd Git tag (https://github.com/zcash/zcash/releases)
 ZCASH_VERSION=6.20.0
 
-ZEBRA_VERSION=6.0.0
+ZEBRA_VERSION=6.3.0
 
 # zcash-devtool git ref (https://github.com/zingolabs/zcash-devtool) —
 # the wallet client driven by wallet-tests via zcash_local_net, built

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5907,7 +5907,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-common"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "rustls",
  "serde",
@@ -5976,7 +5976,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-proto"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "prost",
  "tonic",
@@ -6003,7 +6003,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-serve"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "futures",
  "hex",
@@ -6088,7 +6088,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-state"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arc-swap",
  "bitflags 2.13.0",
@@ -6186,7 +6186,7 @@ dependencies = [
 
 [[package]]
 name = "zainod"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "clap",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,10 +173,10 @@ zaino-source-zebra-readstate = { path = "packages/zaino-source-zebra-readstate",
 # Composite over the two adapters: capability decides what each can answer,
 # this decides which to ask.
 zaino-source-zebra = { path = "packages/zaino-source-zebra", version = "0.1.0" }
-zaino-common = { path = "packages/zaino-common", version = "0.4.0" }
-zaino-proto = { path = "packages/zaino-proto", version = "0.3.0" }
-zaino-state = { path = "packages/zaino-state", version = "0.6.0", default-features = false }
-zaino-serve = { path = "packages/zaino-serve", version = "0.5.1", default-features = false }
+zaino-common = { path = "packages/zaino-common", version = "0.5.0" }
+zaino-proto = { path = "packages/zaino-proto", version = "0.4.0" }
+zaino-state = { path = "packages/zaino-state", version = "0.7.0", default-features = false }
+zaino-serve = { path = "packages/zaino-serve", version = "0.6.0", default-features = false }
 zaino-testutils = { path = "live-tests/zaino-testutils" }
 
 # Zingo-infra (validator launcher driving the live tests; not a prod dep).

--- a/packages/zaino-common/CHANGELOG.md
+++ b/packages/zaino-common/CHANGELOG.md
@@ -8,6 +8,14 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.5.0] - 2026-08-14
+
+### Added
 - `consensus::validate_raw_transaction_hex` / `validate_raw_transaction_bytes`,
   `RawTransactionError` and `MAX_BLOCK_BYTES` — moved from `zaino-fetch`. This
   is a consensus-limit check, which is what this module exists for; the

--- a/packages/zaino-common/Cargo.toml
+++ b/packages/zaino-common/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies]
 # Zebra

--- a/packages/zaino-primitives/Cargo.toml
+++ b/packages/zaino-primitives/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "zaino-primitives"
+description = "Zero-dependency Zcash chain-level domain types (heights, hashes, blocks, transactions) for the Zaino indexer."
 version = "0.1.0"
 edition.workspace = true
 authors.workspace = true

--- a/packages/zaino-proto/CHANGELOG.md
+++ b/packages/zaino-proto/CHANGELOG.md
@@ -13,6 +13,14 @@ and this library adheres to Rust's notion of
 ### Removed
 ### Fixed
 
+## [0.4.0] - 2026-08-14
+
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
 ## [0.3.0] - 2026-08-04
 
 ### Added

--- a/packages/zaino-proto/Cargo.toml
+++ b/packages/zaino-proto/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.3.0"
+version = "0.4.0"
 
 [features]
 default = ["heavy"]

--- a/packages/zaino-serve/CHANGELOG.md
+++ b/packages/zaino-serve/CHANGELOG.md
@@ -8,6 +8,14 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.6.0] - 2026-08-14
+
+### Added
 - `rpc::jsonrpc::wire` — **this crate now owns the served JSON schema**
   (ADR-0009). Serde structs carrying zcashd's exact field names, one module per
   response family (`address`, `address_deltas`, `address_queries`,

--- a/packages/zaino-serve/Cargo.toml
+++ b/packages/zaino-serve/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.5.1"
+version = "0.6.0"
 
 [features]
 default = []

--- a/packages/zaino-source/Cargo.toml
+++ b/packages/zaino-source/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "zaino-source"
+description = "Driven-port traits for Zcash validator access, backing the Zaino indexer's source adapters."
 version = "0.1.0"
 edition.workspace = true
 authors.workspace = true

--- a/packages/zaino-state/CHANGELOG.md
+++ b/packages/zaino-state/CHANGELOG.md
@@ -13,6 +13,14 @@ and this library adheres to Rust's notion of
 ### Removed
 ### Fixed
 
+## [0.7.0] - 2026-08-14
+
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
 ## [0.6.0] - 2026-08-04
 
 ### Added

--- a/packages/zaino-state/Cargo.toml
+++ b/packages/zaino-state/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.6.0"
+version = "0.7.0"
 
 [features]
 default = []

--- a/packages/zainod/CHANGELOG.md
+++ b/packages/zainod/CHANGELOG.md
@@ -9,6 +9,14 @@ and this crate adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.8.0] - 2026-08-14
+
+### Added
 - `zaino.mempool.coherence_frozen_seconds` metric description: how long
   tip-coherent mempool reads have been frozen. Brief spikes are normal tip
   transitions; a sustained non-zero value means the validator tip and Zaino's

--- a/packages/zainod/Cargo.toml
+++ b/packages/zainod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zainod"
-version = "0.7.0"
+version = "0.8.0"
 description = "Crate containing the Zaino Indexer binary."
 authors = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
Release-prep for 0.8.0, landing on `rc/0.8.0` so the eventual `rc/0.8.0 → stable` PR is clean rather than carrying a TODO list.

## Version bumps (minor, above the crates.io floor)

All five changed crates carry `**Breaking**` changelog entries from the source-port / mempool restructure, so under 0.x this is a minor bump each:

| crate | 0.7.0 line | → 0.8.0 line |
|---|---|---|
| zainod | 0.7.0 | **0.8.0** |
| zaino-state | 0.6.0 | **0.7.0** |
| zaino-serve | 0.5.1 | **0.6.0** |
| zaino-common | 0.4.0 | **0.5.0** |
| zaino-proto | 0.3.0 | **0.4.0** |

Applied with `cargo set-version` (crate version + `workspace.dependencies` requirement + lockfile, all in sync). The 12 new crates stay at **0.1.0** (first crates.io publish).

## Also here

- **crates.io publish fix**: `zaino-primitives` and `zaino-source` were missing `description` (which `cargo publish` requires).
- **Changelogs**: each bumped crate's `[Unreleased]` rolled into a dated release section.
- **Test env**: `ZEBRA_VERSION` 6.0.0 → 6.3.0 to match the zebra-chain 12.0 / zebra-rpc 16.0 deps (0.8.0 can't parse `getblockchaininfo` from a 6.0.0 node — this bit the first RC deploy).

## Known gap (not fixed here)

`zaino-proto` and `zaino-state` changed substantially in the restructure but have **no `[Unreleased]` changelog entries** — a pre-existing dev-side gap. I recorded the version sections but did not invent content; worth the authors backfilling.

Publish dry-run CI is advisory for `rc/**` targets (versions are correct post-bump). Bookkeeping only — no test plan.