### PR TITLE
fix(state): read getblockchaininfo through the source port on boot

### DIFF
--- a/packages/zaino-source-zebra-rpc/src/parse.rs
+++ b/packages/zaino-source-zebra-rpc/src/parse.rs
@@ -1351,6 +1351,54 @@ mod tests {
         assert_eq!(u64::from(info.chain_supply.chain_value), 1_000);
     }
 
+    /// The wire reports each pool balance twice — an exact `chainValueZat` and a
+    /// ZEC `chainValue` float. A large mainnet balance has a `chainValue` that
+    /// does not round-trip to a whole zatoshi: real sapling `529544.04149098`
+    /// gives `529544.04149098 * 1e8 = 52954404149097.99`, off by a fraction of a
+    /// zatoshi. The domain must read the exact integer and never the float.
+    ///
+    /// Regression gate for the mainnet-boot crash: `adopt_network` bypassed this
+    /// parser and deserialized into zebra's `Zec`-typed response, whose
+    /// `try_from = "f64"` rejected exactly this value with "floating point had
+    /// fractional zatoshis". Reading `chainValueZat` here is what makes the
+    /// domain immune, so if this ever flips to the float, boot breaks again.
+    #[test]
+    fn a_value_pool_reads_the_exact_zatoshi_over_a_lossy_zec_float() {
+        // A real mainnet sapling balance, reported both ways. The ZEC float does
+        // not round-trip: `SAPLING_ZEC * 1e8 = 52954404149097.99`, a fractional
+        // zatoshi. Reading SAPLING_ZAT is what keeps the domain immune.
+        const SAPLING_ZAT: u64 = 52_954_404_149_098;
+        const SAPLING_ZEC: f64 = 529_544.04149098;
+
+        let info = parse_blockchain_info(&serde_json::json!({
+            "chain": "main",
+            "blocks": 3_451_543,
+            "headers": 3_451_543,
+            "estimatedheight": 3_451_544,
+            "bestblockhash": "00".repeat(32),
+            "difficulty": 1.0,
+            "verificationprogress": 1.0,
+            "chainwork": "00",
+            "chainSupply": { "chainValue": 16_882_668.9155448, "chainValueZat": 1_688_266_891_554_480u64 },
+            "valuePools": [
+                { "id": "sapling", "chainValue": SAPLING_ZEC, "chainValueZat": SAPLING_ZAT },
+            ],
+            "consensus": { "chaintip": "00000000", "nextblock": "00000000" },
+        }))
+        .expect("a getblockchaininfo with lossy value-pool floats must still parse");
+
+        let sapling = info
+            .value_pools
+            .iter()
+            .find(|pool| pool.id == "sapling")
+            .expect("sapling pool present");
+        assert_eq!(
+            u64::from(sapling.chain_value),
+            SAPLING_ZAT,
+            "must read the exact chainValueZat, not the lossy chainValue float"
+        );
+    }
+
     /// A validator that reports no pools at all is not an error: the field is
     /// optional, and an empty list says exactly that.
     #[test]

--- a/packages/zaino-state/src/chain_index/network_adoption.rs
+++ b/packages/zaino-state/src/chain_index/network_adoption.rs
@@ -5,26 +5,28 @@
 //! `Network` from it — so an indexer and its validator cannot disagree about
 //! where an upgrade activates, which would silently corrupt the index.
 //!
-//! # Still off the ports, deliberately
+//! # On the source ports
 //!
-//! This module asks the validator for `getblockchaininfo` over the raw
-//! JSON-RPC transport and reads the answer as zebra's own type, rather than
-//! going through the `zaino-source` ports.
+//! This module reads `getblockchaininfo` through the `zaino-source`
+//! [`GetBlockchainInfo`] port, so it never deserializes the validator's own
+//! response shape — in particular it never parses the value pools, whose ZEC
+//! `chainValue` float zebra's own type rejects when it does not round-trip to a
+//! whole zatoshi (the mainnet-boot crash this replaced).
 //!
-//! Porting it is not mechanical. The ports report upgrades keyed by consensus
-//! branch id — the protocol-defined identity — whereas this code needs zebra's
-//! `NetworkUpgrade` enum to index activation slots. Elsewhere that lookup goes
-//! through `network.full_activation_list()`, which is unavailable here: this
-//! code is what *determines* the network, so on the regtest arm there is no
-//! network to look up against yet. Resolving that belongs with the PR that owns
-//! activation heights, not with the source rewire.
+//! The port yields the domain upgrade schedule keyed by consensus branch id —
+//! the protocol-defined identity. Each branch id is translated to zebra's
+//! `NetworkUpgrade` locally, only where a zebra `Network` must be built. A
+//! branch id this build does not recognise is a validator ahead of Zaino: it is
+//! skipped, never rejected, so a newer validator cannot fail adoption.
 
-use indexmap::IndexMap;
 use tracing::info;
-use zebra_rpc::methods::{ConsensusBranchIdHex, NetworkUpgradeInfo};
+use zaino_primitives::types::NetworkUpgradeInfo;
+use zaino_source::GetBlockchainInfo;
 
 use crate::chain_index::source::BlockchainSourceError;
 use crate::config::CommonBackendConfig;
+
+mod zebra_bridge;
 
 /// Constructs the runtime network at first contact with the validator.
 ///
@@ -45,33 +47,25 @@ use crate::config::CommonBackendConfig;
 /// without being re-detected here.
 pub(crate) async fn adopt_network(
     common: &CommonBackendConfig,
-    rpc_client: &zaino_rpc::RpcClient,
+    source: &impl GetBlockchainInfo,
 ) -> Result<zebra_chain::parameters::Network, BlockchainSourceError> {
-    let raw = rpc_client
-        .call("getblockchaininfo", Vec::new())
-        .await
-        .map_err(|error| {
-            BlockchainSourceError::Unrecoverable(format!(
-                "cannot fetch activation heights from the validator at {}: {error}",
-                common.validator_rpc_address
-            ))
-        })?;
-
-    // Read as zebra's own response type rather than the domain's: the
-    // activation slots below are keyed by zebra's `NetworkUpgrade` enum, which
-    // the domain deliberately does not carry — see the module docs.
-    let blockchain_info: zebra_rpc::methods::GetBlockchainInfoResponse =
-        serde_json::from_value(raw).map_err(|error| {
-            BlockchainSourceError::Unrecoverable(format!(
-                "the validator at {} returned an unreadable getblockchaininfo: {error}",
-                common.validator_rpc_address
-            ))
-        })?;
+    // Read the schedule through the source port: the domain `BlockchainInfo`,
+    // not the validator's own response shape. This never parses the value pools
+    // (whose ZEC float zebra's type rejects when it does not round-trip to a
+    // whole zatoshi — the mainnet-boot crash this replaced); only the upgrade
+    // schedule below is used.
+    let blockchain_info = source.get_blockchain_info().await.map_err(|error| {
+        BlockchainSourceError::Unrecoverable(format!(
+            "cannot fetch activation heights from the validator at {}: {error}",
+            common.validator_rpc_address
+        ))
+    })?;
+    let upgrades = &blockchain_info.upgrades;
 
     // Shared by the Mainnet / The Public Testnet arms: the compiled network is only
     // trusted after the validator's report agrees with it.
     let verified = |network: zebra_chain::parameters::Network| {
-        verify_reported_upgrades(&network, blockchain_info.upgrades()).map_err(|reason| {
+        verify_reported_upgrades(&network, upgrades).map_err(|reason| {
             BlockchainSourceError::Unrecoverable(format!(
                 "the validator at {} disagrees with the compiled {network} parameters: {reason}",
                 common.validator_rpc_address
@@ -86,13 +80,12 @@ pub(crate) async fn adopt_network(
             verified(zebra_chain::parameters::Network::new_default_testnet())
         }
         zaino_common::Network::Regtest => {
-            let heights =
-                activation_heights_from_upgrades(blockchain_info.upgrades()).map_err(|reason| {
-                    BlockchainSourceError::Unrecoverable(format!(
-                        "cannot adopt activation heights from the validator at {}: {reason}",
-                        common.validator_rpc_address
-                    ))
-                })?;
+            let heights = activation_heights_from_upgrades(upgrades).map_err(|reason| {
+                BlockchainSourceError::Unrecoverable(format!(
+                    "cannot adopt activation heights from the validator at {}: {reason}",
+                    common.validator_rpc_address
+                ))
+            })?;
             info!(?heights, "Adopted activation heights from the validator");
             Ok(heights.to_regtest_network())
         }
@@ -102,22 +95,25 @@ pub(crate) async fn adopt_network(
 /// Checks every `(upgrade, height)` the validator reports against `network`'s
 /// compiled activation schedule, rejecting the first disagreement.
 ///
-/// Only reported entries are checked — the report's *completeness* is not:
-/// the map is keyed by consensus branch ID, so upgrades zebra considers
-/// unconfigured are simply absent, and an older validator may not know the
-/// newest upgrades yet.
+/// Only reported entries are checked — the report's *completeness* is not, and
+/// an upgrade whose branch id this build does not know is skipped (see
+/// [`zebra_bridge::network_upgrade`]), so a validator ahead of Zaino is never
+/// rejected here.
 fn verify_reported_upgrades(
     network: &zebra_chain::parameters::Network,
-    upgrades: &IndexMap<ConsensusBranchIdHex, NetworkUpgradeInfo>,
+    upgrades: &[NetworkUpgradeInfo],
 ) -> Result<(), String> {
-    for upgrade_info in upgrades.values() {
-        let (upgrade, height, _status) = upgrade_info.into_parts();
+    for upgrade_info in upgrades {
+        let Some(upgrade) = zebra_bridge::network_upgrade(upgrade_info) else {
+            continue;
+        };
+        let reported = zebra_bridge::height(upgrade_info.activation_height);
         let compiled = upgrade.activation_height(network);
-        if compiled != Some(height) {
+        if compiled != Some(reported) {
             return Err(format!(
                 "the validator reports {upgrade:?} activating at height {}, \
                  but the compiled parameters say {:?}",
-                height.0,
+                reported.0,
                 compiled.map(|compiled_height| compiled_height.0)
             ));
         }
@@ -136,64 +132,94 @@ fn verify_reported_upgrades(
 /// The Public Testnet use zebra's compiled parameters and never take this
 /// path.
 ///
-/// `before_overwinter` is always `None` here: the map is keyed by consensus
+/// `before_overwinter` is always `None` here: entries are keyed by consensus
 /// branch ID, which `BeforeOverwinter` does not have, so it can never appear
 /// in the report. Correctness relies on zebra's `new_regtest` supplying its
 /// own `BeforeOverwinter` handling when `to_regtest_network` builds the
 /// runtime network from these heights.
 fn activation_heights_from_upgrades(
-    upgrades: &IndexMap<ConsensusBranchIdHex, NetworkUpgradeInfo>,
+    upgrades: &[NetworkUpgradeInfo],
 ) -> Result<zaino_common::config::network::ActivationHeights, String> {
     let mut heights = zaino_common::config::network::ActivationHeights::NEVER_ACTIVATED;
-    for upgrade_info in upgrades.values() {
-        let (upgrade, height, _status) = upgrade_info.into_parts();
+    for upgrade_info in upgrades {
+        // A branch id this build does not know has no configuration slot.
+        let Some(upgrade) = zebra_bridge::network_upgrade(upgrade_info) else {
+            continue;
+        };
         // Genesis is height 0 by definition; it has no configuration slot.
         let Some(slot) = heights.slot_mut(upgrade) else {
             continue;
         };
-        if slot.replace(height.0).is_some() {
+        if slot
+            .replace(u32::from(upgrade_info.activation_height))
+            .is_some()
+        {
             return Err(format!("validator reported {upgrade:?} twice"));
         }
     }
     Ok(heights)
 }
 
+/// Shared fixtures for the adoption tests: the consensus branch ids the code
+/// keys on, named so tests read as schedules rather than hex, plus the builder.
+#[cfg(test)]
+mod test_upgrades {
+    use zaino_primitives::types::{
+        ConsensusBranchId, Height, NetworkUpgradeInfo, NetworkUpgradeStatus,
+    };
+
+    pub(super) const OVERWINTER: u32 = 0x5ba8_1b19;
+    pub(super) const SAPLING: u32 = 0x76b8_09bb;
+    pub(super) const BLOSSOM: u32 = 0x2bb4_0e60;
+    pub(super) const HEARTWOOD: u32 = 0xf5b9_230b;
+    pub(super) const CANOPY: u32 = 0xe9ff_75a6;
+    pub(super) const NU5: u32 = 0xc2d6_d0b4;
+    pub(super) const NU6: u32 = 0xc8e7_1055;
+    pub(super) const NU6_1: u32 = 0x4dec_4df0;
+    pub(super) const NU6_2: u32 = 0x5437_f330;
+    pub(super) const NU6_3: u32 = 0x37a5_165b;
+
+    /// zebra's placeholder branch for NU7 (the real `0x77190ad8` is still a TODO
+    /// in zebra-chain): resolvable, and disabled on Mainnet.
+    pub(super) const NU7: u32 = 0xffff_fffe;
+
+    /// A branch id no build knows.
+    pub(super) const UNKNOWN_BRANCH: u32 = 0x0bad_0bad;
+
+    /// Sapling's compiled Mainnet activation height.
+    pub(super) const SAPLING_MAINNET_HEIGHT: u32 = 419_200;
+
+    /// An upgrade entry. Only the branch id and height matter to the code under
+    /// test, so the name and status are fixed.
+    pub(super) fn upgrade(branch_id: u32, activation_height: u32) -> NetworkUpgradeInfo {
+        NetworkUpgradeInfo {
+            branch_id: ConsensusBranchId::new(branch_id),
+            name: String::new(),
+            activation_height: Height::try_from(activation_height).expect("height within range"),
+            status: NetworkUpgradeStatus::Active,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::test_upgrades::*;
     use zaino_common::config::network::ActivationHeights;
+    use zaino_primitives::types::NetworkUpgradeInfo;
 
     /// All-`None` heights: the starting point adoption fills from the
-    /// validator's map, and the expected value for every absent upgrade.
+    /// validator's report, and the expected value for every absent upgrade.
     const NEVER_ACTIVATED: ActivationHeights = ActivationHeights::NEVER_ACTIVATED;
 
-    fn upgrades_map(
-        json: &str,
-    ) -> indexmap::IndexMap<
-        zebra_rpc::methods::ConsensusBranchIdHex,
-        zebra_rpc::methods::NetworkUpgradeInfo,
-    > {
-        serde_json::from_str(json).expect("upgrades fixture parses")
-    }
-
-    fn adopted_heights(
-        upgrades: &indexmap::IndexMap<
-            zebra_rpc::methods::ConsensusBranchIdHex,
-            zebra_rpc::methods::NetworkUpgradeInfo,
-        >,
-    ) -> ActivationHeights {
+    fn adopted_heights(upgrades: &[NetworkUpgradeInfo]) -> ActivationHeights {
         super::activation_heights_from_upgrades(upgrades).expect("valid schedule")
     }
 
-    /// An upgrade absent from the validator's map is never-activated —
+    /// An upgrade absent from the validator's report is never-activated —
     /// nothing is backfilled from any default schedule.
     #[test]
     fn regtest_network_from_upgrades_leaves_absent_upgrades_never_activated() {
-        let upgrades = upgrades_map(
-            r#"{
-                "c2d6d0b4": { "name": "NU5", "activationheight": 2, "status": "active" },
-                "c8e71055": { "name": "NU6", "activationheight": 2, "status": "active" }
-            }"#,
-        );
+        let upgrades = [upgrade(NU5, 2), upgrade(NU6, 2)];
 
         assert_eq!(
             adopted_heights(&upgrades),
@@ -210,20 +236,18 @@ mod tests {
     /// launch validators with.
     #[test]
     fn regtest_network_from_upgrades_reads_a_transition_schedule() {
-        let upgrades = upgrades_map(
-            r#"{
-                "5ba81b19": { "name": "Overwinter", "activationheight": 1, "status": "active" },
-                "76b809bb": { "name": "Sapling", "activationheight": 1, "status": "active" },
-                "2bb40e60": { "name": "Blossom", "activationheight": 1, "status": "active" },
-                "f5b9230b": { "name": "Heartwood", "activationheight": 1, "status": "active" },
-                "e9ff75a6": { "name": "Canopy", "activationheight": 1, "status": "active" },
-                "c2d6d0b4": { "name": "NU5", "activationheight": 2, "status": "active" },
-                "c8e71055": { "name": "NU6", "activationheight": 2, "status": "active" },
-                "4dec4df0": { "name": "NU6.1", "activationheight": 2, "status": "active" },
-                "5437f330": { "name": "NU6.2", "activationheight": 2, "status": "active" },
-                "37a5165b": { "name": "NU6.3", "activationheight": 6, "status": "pending" }
-            }"#,
-        );
+        let upgrades = [
+            upgrade(OVERWINTER, 1),
+            upgrade(SAPLING, 1),
+            upgrade(BLOSSOM, 1),
+            upgrade(HEARTWOOD, 1),
+            upgrade(CANOPY, 1),
+            upgrade(NU5, 2),
+            upgrade(NU6, 2),
+            upgrade(NU6_1, 2),
+            upgrade(NU6_2, 2),
+            upgrade(NU6_3, 6),
+        ];
 
         assert_eq!(
             adopted_heights(&upgrades),
@@ -243,16 +267,12 @@ mod tests {
         );
     }
 
-    /// A validator reporting the same upgrade twice is nonsense; adoption
-    /// must fail loudly rather than pick a height.
+    /// A validator reporting the same upgrade twice is nonsense; adoption must
+    /// fail loudly rather than pick a height. Entries are keyed by branch id,
+    /// so a duplicate is the *same* branch id, not merely a repeated name.
     #[test]
     fn regtest_network_from_upgrades_rejects_a_duplicate_upgrade() {
-        let upgrades = upgrades_map(
-            r#"{
-                "c2d6d0b4": { "name": "NU5", "activationheight": 2, "status": "active" },
-                "c8e71055": { "name": "NU5", "activationheight": 3, "status": "pending" }
-            }"#,
-        );
+        let upgrades = [upgrade(NU5, 2), upgrade(NU5, 3)];
 
         let reason =
             super::activation_heights_from_upgrades(&upgrades).expect_err("duplicate must fail");
@@ -261,60 +281,57 @@ mod tests {
             "error should name the duplication, got: {reason}"
         );
     }
+
+    /// An upgrade whose branch id this build does not recognise is a validator
+    /// ahead of Zaino: skipped, neither adopted nor an error.
+    #[test]
+    fn regtest_network_from_upgrades_skips_an_unknown_branch() {
+        let upgrades = [upgrade(NU5, 2), upgrade(UNKNOWN_BRANCH, 9)];
+
+        assert_eq!(
+            adopted_heights(&upgrades),
+            ActivationHeights {
+                nu5: Some(2),
+                ..NEVER_ACTIVATED
+            }
+        );
+    }
 }
 
 #[cfg(test)]
 mod verify_reported_upgrades {
-    fn upgrades_map(
-        json: &str,
-    ) -> indexmap::IndexMap<
-        zebra_rpc::methods::ConsensusBranchIdHex,
-        zebra_rpc::methods::NetworkUpgradeInfo,
-    > {
-        serde_json::from_str(json).expect("upgrades fixture parses")
-    }
+    use super::test_upgrades::*;
 
     /// A report agreeing with the compiled schedule passes.
     #[test]
     fn accepts_a_report_matching_the_compiled_schedule() {
-        let upgrades = upgrades_map(
-            r#"{
-                "76b809bb": { "name": "Sapling", "activationheight": 419200, "status": "active" }
-            }"#,
-        );
+        let upgrades = [upgrade(SAPLING, SAPLING_MAINNET_HEIGHT)];
 
         super::verify_reported_upgrades(&zebra_chain::parameters::Network::Mainnet, &upgrades)
-            .expect("mainnet Sapling at 419200 matches the compiled parameters");
+            .expect("mainnet Sapling at its compiled height matches");
     }
 
     /// A reported height disagreeing with the compiled schedule fails loud —
     /// the wrong-schedule / wrong-network drift class.
     #[test]
     fn rejects_a_mismatched_height() {
-        let upgrades = upgrades_map(
-            r#"{
-                "76b809bb": { "name": "Sapling", "activationheight": 419201, "status": "active" }
-            }"#,
-        );
+        let reported = SAPLING_MAINNET_HEIGHT + 1;
+        let upgrades = [upgrade(SAPLING, reported)];
 
         let reason =
             super::verify_reported_upgrades(&zebra_chain::parameters::Network::Mainnet, &upgrades)
                 .expect_err("a wrong Sapling height must be rejected");
         assert!(
-            reason.contains("419201"),
+            reason.contains(&reported.to_string()),
             "error should name the reported height, got: {reason}"
         );
     }
 
-    /// An upgrade the compiled schedule never activates must also be
+    /// An upgrade the compiled schedule disables on this network must be
     /// rejected when the validator reports a height for it.
     #[test]
     fn rejects_an_upgrade_the_compiled_schedule_lacks() {
-        let upgrades = upgrades_map(
-            r#"{
-                "77190ad8": { "name": "NU7", "activationheight": 123, "status": "pending" }
-            }"#,
-        );
+        let upgrades = [upgrade(NU7, 123)];
 
         let reason =
             super::verify_reported_upgrades(&zebra_chain::parameters::Network::Mainnet, &upgrades)
@@ -323,5 +340,15 @@ mod verify_reported_upgrades {
             reason.contains("None"),
             "error should show the compiled schedule has no height, got: {reason}"
         );
+    }
+
+    /// A branch id no build knows is skipped, not rejected — forward-compat for
+    /// a validator ahead of Zaino.
+    #[test]
+    fn skips_an_unknown_branch() {
+        let upgrades = [upgrade(UNKNOWN_BRANCH, 123)];
+
+        super::verify_reported_upgrades(&zebra_chain::parameters::Network::Mainnet, &upgrades)
+            .expect("an unknown branch id must be skipped, not rejected");
     }
 }

--- a/packages/zaino-state/src/chain_index/network_adoption/zebra_bridge.rs
+++ b/packages/zaino-state/src/chain_index/network_adoption/zebra_bridge.rs
@@ -1,0 +1,32 @@
+//! Temporary owned → zebra translation.
+//!
+//! This module exists only while [`adopt_network`](super::adopt_network) must
+//! return a `zebra_chain::parameters::Network`: the runtime consensus-parameters
+//! type is still zebra's, consumed throughout `chain_index`, so the adopted
+//! schedule — owned, keyed by consensus branch id — has to be spoken back in
+//! zebra's `NetworkUpgrade` vocabulary to build and verify that `Network`.
+//!
+//! It is deliberately self-contained: the entire zebra surface that
+//! `network_adoption` depends on is these two functions. When the runtime
+//! network is domain-ized (a source-neutral consensus-parameters type),
+//! nothing here is needed — delete the module and its `mod` declaration.
+//!
+//! TODO: remove once `chain_index` no longer consumes zebra's `Network` for
+//! consensus parameters.
+
+use zaino_primitives::types::{Height, NetworkUpgradeInfo};
+
+/// The zebra `NetworkUpgrade` for an owned upgrade's branch id, or `None` when
+/// this build does not know that branch — a validator ahead of Zaino, which
+/// adoption skips rather than fails on. `branch_id` is the protocol identity;
+/// zebra owns the branch-id → upgrade table, so the lookup lives here.
+pub(super) fn network_upgrade(
+    info: &NetworkUpgradeInfo,
+) -> Option<zebra_chain::parameters::NetworkUpgrade> {
+    zebra_chain::parameters::NetworkUpgrade::try_from(u32::from(info.branch_id)).ok()
+}
+
+/// An owned height as zebra's block height.
+pub(super) fn height(height: Height) -> zebra_chain::block::Height {
+    zebra_chain::block::Height(u32::from(height))
+}

--- a/packages/zaino-state/src/chain_index/validator_source.rs
+++ b/packages/zaino-state/src/chain_index/validator_source.rs
@@ -1108,7 +1108,7 @@ impl ZebraValidatorSource {
 
         // Adopted before anything consumes a `Network`, so the index and its
         // validator cannot disagree about where an upgrade activates.
-        let network = super::network_adoption::adopt_network(common, &rpc_client(common)?).await?;
+        let network = super::network_adoption::adopt_network(common, &rpc_adapter(common)?).await?;
 
         let validator = zaino_source_zebra::ZebraValidator::rpc_only(adapter);
 
@@ -1141,7 +1141,7 @@ impl ZebraValidatorSource {
             .await
             .map_err(err)?;
 
-        let network = super::network_adoption::adopt_network(common, &rpc_client(common)?).await?;
+        let network = super::network_adoption::adopt_network(common, &rpc_adapter(common)?).await?;
 
         tracing::info!(
             grpc_address = %direct.validator_grpc_address,


### PR DESCRIPTION
Fixes #1455.

## Problem

`adopt_network` deserialized `getblockchaininfo` into zebra's
`GetBlockchainInfoResponse`, whose value-pool balances parse the ZEC `chainValue`
float and reject any value that does not round-trip to a whole zatoshi. On
mainnet that crashes the node at startup, even though adoption only needs the
upgrade schedule. See the issue for the full root cause / why-now.

## Change

- Read `getblockchaininfo` through the `zaino-source` `GetBlockchainInfo` port,
  yielding the domain `BlockchainInfo` (value pools as exact zatoshis from
  `chainValueZat`, never the float).
- The two adoption helpers now consume the owned `Vec<NetworkUpgradeInfo>`, keyed
  by consensus branch id. An unknown branch id (a validator ahead of this build)
  is skipped rather than failing adoption — which also removes the latent crash
  on an upgrade *name* this build does not yet know.
- The domain→zebra translation needed only because `adopt_network` must still
  return a zebra `Network` is isolated in a self-contained
  `network_adoption::zebra_bridge` module, to delete once the runtime network
  parameters are domain-ized.

This forwards the 0.8.0 primitives / source-stack migration rather than patching
the call site in place.

## Tests

- New regression gate in `zaino-source-zebra-rpc` `parse.rs`: a value pool with a
  lossy `chainValue` float and an exact `chainValueZat` is read as the integer.
- `adopt_network`'s helper tests moved onto the owned types, plus new
  skip-unknown-branch cases. All green; `clippy` clean.

## Deployment / verification

First hit on a live **mainnet** ephemeral (zebra 6.3.0, post-Ironwood), where the
unfixed rc crash-looped on `getblockchaininfo`. This branch builds via the
`deploy-ephemeral` `ref=` path (BuildKit → `zingodevops/zaino:<hash>`).
End-to-end boot verification against the post-Ironwood mainnet snapshot is
pending a cluster-egress outage on the build node; the fix is otherwise complete
and locally verified.
