### PR TITLE
add fs ephemeral and txoutset build logging

### DIFF
--- a/packages/zaino-state/CHANGELOG.md
+++ b/packages/zaino-state/CHANGELOG.md
@@ -8,10 +8,49 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+- Progress logging for the from-genesis txout-set accumulator rebuild. The
+  rebuild previously logged two lines up front and nothing again until it
+  committed, so a multi-shard full-chain scan — tens of minutes on a
+  mainnet-sized database — was indistinguishable from a hang. It now reports
+  the spent-entry count pass, each shard's start, spent-set size and
+  completion, and intra-shard height progress, all throttled to one line per
+  10s so output stays bounded regardless of shard count. A shard that exceeds
+  its memory budget and has to be bisected now logs a **warning** naming
+  `storage.database.accumulator_rebuild_memory_size`, since each bisect adds a
+  further full-chain pass.
+- Progress logging for the startup `spent` table integrity check and for the
+  incremental accumulator update.
+- `FinalisedStateMode` (`EphemeralConfigured` / `EphemeralRouted` /
+  `Persistent`) and `NodeBackedChainIndex::finalised_state_mode`, reporting
+  which backend currently answers finalised-state reads. `StatusType` cannot
+  express this: an ephemeral passthrough tracks the backing validator and
+  reports `Ready` exactly like a fully synced persistent database, so a caller
+  gating on `Ready` alone could not tell whether it was querying the real
+  on-disk index or a passthrough standing in for one during sync or migration.
+- Logging for every finalised-state routing transition: passthrough install,
+  mode escalation, downgrade, hand-back to the persistent database, and
+  teardown at shutdown. A one-shot "finalised state online" line marks the
+  first time reads are served from disk, covering both the post-sync/migration
+  edge and a restart against an already-current database.
+- A startup banner naming the finalised-state mode. A process configured with
+  `ephemeral_finalised_state = true` previously started completely silently
+  about it; it now warns, since a test suite believing it is exercising the
+  on-disk index while every read is served by the validator is nearly always a
+  misconfiguration.
+- A log line when a background migration completes; previously only the failure
+  path logged, so a finished migration looked identical to one still running.
+- `zaino.db.finalised_ephemeral`, `zaino.db.accumulator_built_height` and
+  `zaino.db.accumulator_rebuild_active` metric names (emitted under the
+  `prometheus` feature).
+
 ### Changed
 ### Deprecated
 ### Removed
 ### Fixed
+- `zaino.chain.tip_height` was emitted twice per sync iteration — once through a
+  hard-coded string literal and once through the `CHAIN_TIP_HEIGHT` constant,
+  with the same value. The redundant literal emission is removed, leaving the
+  constant as the single source of truth for the metric name.
 
 ## [0.7.0] - 2026-08-14
 

--- a/packages/zaino-state/src/chain_index.rs
+++ b/packages/zaino-state/src/chain_index.rs
@@ -11,6 +11,7 @@
 //!     - b. Build trasparent tx indexes efficiently
 //!   - NOTE: Full transaction and block data is served from the backend finalizer.
 
+use crate::chain_index::finalised_state::router::FinalisedStateMode;
 use crate::chain_index::non_finalised_state::ChainIndexSnapshot;
 use crate::chain_index::source::GetTransactionLocation;
 use crate::chain_index::types::db::metadata::MempoolInfo;
@@ -952,6 +953,14 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
         self.coherence.subscriber().frozen_for()
     }
 
+    /// Returns which backend is currently answering finalised-state reads.
+    ///
+    /// Companion to [`NodeBackedChainIndex::status`], which cannot express this: an ephemeral
+    /// passthrough reports [`StatusType::Ready`] identically to a synced persistent database.
+    pub fn finalised_state_mode(&self) -> FinalisedStateMode {
+        self.finalized_db.finalised_state_mode()
+    }
+
     /// Displays the status of the chain_index
     pub fn status(&self) -> StatusType {
         let finalized_status = self.finalized_db.status();
@@ -1035,8 +1044,6 @@ impl<Source: BlockchainSource> NodeBackedChainIndex<Source> {
                                 "node returned no best block height",
                             ))
                         })?;
-                    #[cfg(feature = "prometheus")]
-                    metrics::gauge!("zaino.chain.tip_height").set(chain_height.0 as f64);
                     let finalised_height = finalized_height_floor(chain_height.0);
                     #[cfg(feature = "prometheus")]
                     {

--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -229,9 +229,15 @@ use router::Router;
 use tracing::{info, instrument};
 use zebra_chain::parameters::NetworkKind;
 
+#[cfg(feature = "prometheus")]
+use crate::metric_names::*;
+
 use crate::{
     chain_index::{
-        finalised_state::{finalised_source::v1::DB_VERSION_V1, router::EphemeralMode},
+        finalised_state::{
+            finalised_source::v1::DB_VERSION_V1,
+            router::{EphemeralMode, FinalisedStateMode},
+        },
         source::BlockchainSourceError,
         types::GENESIS_HEIGHT,
     },
@@ -489,6 +495,15 @@ impl<T: BlockchainSource> FinalisedState<T> {
         source: T,
     ) -> Result<Self, FinalisedStateError> {
         if cfg.ephemeral {
+            // WARN, not INFO: this branch previously returned silently, and a run that serves every
+            // finalised-state read from the validator while a test suite believes it is exercising
+            // the on-disk index is nearly always a misconfiguration worth surfacing loudly.
+            tracing::warn!(
+                mode = %FinalisedStateMode::EphemeralConfigured,
+                "finalised state running in EPHEMERAL mode (ephemeral_finalised_state = true): no \
+                 persistent database will be opened or written, and all finalised-state reads are \
+                 served from the backing validator"
+            );
             return Ok(Self {
                 db: Arc::new(Router::new(Arc::new(FinalisedSource::ephemeral(
                     source,
@@ -498,6 +513,11 @@ impl<T: BlockchainSource> FinalisedState<T> {
                 cfg,
             });
         } else {
+            info!(
+                mode = %FinalisedStateMode::Persistent,
+                path = %cfg.storage.database.path.display(),
+                "finalised state running in PERSISTENT mode"
+            );
             let version_opt = Self::try_find_current_db_version(&cfg).await;
 
             let target_version = match cfg.db_version {
@@ -573,6 +593,13 @@ impl<T: BlockchainSource> FinalisedState<T> {
 
                     match migration_manager.migrate().await {
                         Ok(()) => {
+                            // Previously only the failure path logged, so a successful migration was
+                            // indistinguishable from one still running.
+                            info!(
+                                from_version = %current_version,
+                                to_version = %target_version,
+                                "FinalisedState migration complete"
+                            );
                             // Start the background validator only now that every migration has
                             // finished: its initial scan reads tables a migration populates (e.g.
                             // `commitment_tree_data_1_3_0`), so starting it earlier would race the
@@ -614,7 +641,40 @@ impl<T: BlockchainSource> FinalisedState<T> {
     /// migrations, the router determines which backend serves `READ_CORE`, and the status reflects
     /// that routing decision.
     pub(crate) fn status(&self) -> StatusType {
-        self.db.status()
+        let status = self.db.status();
+
+        // The reliable production hook for the one-shot "online" announcement. The ephemeral-release
+        // edge in `Router::release_ephemeral_reference` covers a first sync or a migration, but a
+        // restart against an already-current database never installs a passthrough at all
+        // (`sync_is_long_running` is false), so that edge never fires and nothing would mark the
+        // finalised state as live. `Indexer::log_status` polls this every ~10s, and
+        // `note_persistent_online` is latched, so the announcement lands exactly once either way.
+        //
+        // Deliberately not hooked to `wait_until_ready`: despite its name it has no production
+        // caller — only tests and the `reader` wrapper use it.
+        let mode = self.db.finalised_state_mode();
+
+        #[cfg(feature = "prometheus")]
+        metrics::gauge!(FINALISED_EPHEMERAL).set(if mode == FinalisedStateMode::Persistent {
+            0.0
+        } else {
+            1.0
+        });
+
+        if status == StatusType::Ready && mode == FinalisedStateMode::Persistent {
+            self.db.note_persistent_online();
+        }
+
+        status
+    }
+
+    /// Returns which backend is currently answering finalised-state reads.
+    ///
+    /// Distinct from [`FinalisedState::status`]: an ephemeral passthrough reports
+    /// [`StatusType::Ready`] just like a synced persistent database, so `status` alone cannot tell a
+    /// caller whether the finalised state it is querying is the real on-disk index.
+    pub(crate) fn finalised_state_mode(&self) -> FinalisedStateMode {
+        self.db.finalised_state_mode()
     }
 
     /// Waits until the database reports [`StatusType::Ready`].
@@ -1017,6 +1077,16 @@ impl<T: BlockchainSource> FinalisedState<T> {
     /// Production code should use the public `FinalisedState` API instead of depending on the router
     /// directly.
     pub(crate) fn router(&self) -> &Router<T> {
+        &self.db
+    }
+
+    /// Shared handle to the router, for tests that need to drive ephemeral routing transitions
+    /// directly (`init_or_take_ephemeral` takes `&Arc<Router<T>>`).
+    ///
+    /// Exercising those transitions through `sync_to_height` instead would race the spawned
+    /// background task, so the deterministic routing tests reach for this.
+    #[cfg(test)]
+    pub(crate) fn router_arc(&self) -> &Arc<Router<T>> {
         &self.db
     }
 

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
@@ -195,6 +195,17 @@ pub(crate) const ACCUMULATOR_BUILD_MAX_SHARDS: u16 = 256;
 /// budget, and over-counting only adds shards (less memory per shard), it never under-bounds.
 pub(crate) const SPENT_SET_ENTRY_BYTES_ESTIMATE: u64 = 256;
 
+/// Minimum wall-clock interval between successive progress logs emitted by a long-running
+/// finalised-state scan (bulk sync, the txout-set accumulator rebuild, and the startup `spent`
+/// integrity check).
+///
+/// Throttling on *time* rather than on a height/entry modulus keeps the output bounded no matter
+/// how the underlying work is partitioned. The accumulator rebuild in particular scans the whole
+/// chain once per shard, and the shard count scales with how little memory the host has (up to
+/// [`ACCUMULATOR_BUILD_MAX_SHARDS`]), so a per-height modulus would emit orders of magnitude more
+/// lines on exactly the constrained deployments where logs are most expensive.
+pub(super) const PROGRESS_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Number of committed block writes / migration heights between explicit
 /// `env.sync(true)` durability checkpoints.
 ///
@@ -735,7 +746,21 @@ impl DbV1 {
             // error propagates cleanly and the scan only ends on a genuine end-of-table `NotFound`.
             let mut entry_index: u64 = 0;
             let mut op = lmdb_sys::MDB_FIRST;
+            // This checksums every `spent` entry before the node serves anything, so on a
+            // mainnet-sized table it is the first long silence of every boot. Report progress so it
+            // reads as work rather than a hang.
+            let started = std::time::Instant::now();
+            let mut last_progress_log = started;
             loop {
+                if last_progress_log.elapsed() >= PROGRESS_LOG_INTERVAL {
+                    info!(
+                        verified = entry_index,
+                        elapsed = ?started.elapsed(),
+                        "finalised-state spent table integrity check in progress"
+                    );
+                    last_progress_log = std::time::Instant::now();
+                }
+
                 let (key_bytes, val_bytes) = match cursor.get(None, None, op) {
                     Ok((Some(key), value)) => (key, value),
                     // `MDB_FIRST`/`MDB_NEXT` always report the key; treat a missing key as end-of-data.
@@ -767,7 +792,11 @@ impl DbV1 {
                 entry_index += 1;
             }
 
-            info!("finalised-state spent table integrity check passed ({entry_index} entries)");
+            info!(
+                entries = entry_index,
+                elapsed = ?started.elapsed(),
+                "finalised-state spent table integrity check passed"
+            );
             Ok(())
         })
         .await

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/tx_out_set_accumulator.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/tx_out_set_accumulator.rs
@@ -14,6 +14,8 @@ use crate::chain_index::types::db::metadata::{
     is_unspendable_tx_out, tx_out_set_entry_digest, FinalisedTxOutSetInfoAccumulator,
     ZAINO_TXOUTSET_ENTRY_LEN,
 };
+#[cfg(feature = "prometheus")]
+use crate::metric_names::*;
 
 /// Direction of an accumulator update.
 ///
@@ -845,7 +847,12 @@ impl DbV1 {
             db_tip.0
         );
 
-        tokio::task::block_in_place(|| {
+        let started = std::time::Instant::now();
+
+        #[cfg(feature = "prometheus")]
+        metrics::gauge!(ACCUMULATOR_REBUILD_ACTIVE).set(1.0);
+
+        let result = tokio::task::block_in_place(|| {
             let accumulator =
                 self.build_tx_out_set_accumulator_blocking(db_tip, shards, max_spent_entries)?;
 
@@ -858,7 +865,28 @@ impl DbV1 {
             self.env.sync(true)?;
 
             Ok::<_, FinalisedStateError>(())
-        })
+        });
+
+        #[cfg(feature = "prometheus")]
+        {
+            metrics::gauge!(ACCUMULATOR_REBUILD_ACTIVE).set(0.0);
+            if result.is_ok() {
+                metrics::gauge!(ACCUMULATOR_BUILT_HEIGHT).set(db_tip.0 as f64);
+            }
+        }
+
+        // The commit is the only durable evidence the rebuild happened; without this line the sole
+        // sign of completion is the absence of further output.
+        if result.is_ok() {
+            info!(
+                db_tip = db_tip.0,
+                shards,
+                elapsed = ?started.elapsed(),
+                "txout-set accumulator rebuild complete and committed"
+            );
+        }
+
+        result
     }
 
     /// Chooses the number of [`DbV1::build_tx_out_set_accumulator_blocking`] shards so the per-shard
@@ -910,6 +938,11 @@ impl DbV1 {
             // yields references into the mmap), so this is O(1) heap regardless of table size.
             let mut count: u64 = 0;
             let mut op = lmdb_sys::MDB_FIRST;
+            // On a mainnet-sized `spent` table this walk is a multi-gigabyte sequential scan that
+            // sits between the two `rebuild_tx_out_set_accumulator` log lines. Report progress so it
+            // is distinguishable from a stall.
+            let started = std::time::Instant::now();
+            let mut last_progress_log = started;
             loop {
                 match cursor.get(None, None, op) {
                     Ok(_) => {
@@ -917,12 +950,26 @@ impl DbV1 {
                         if count >= max_useful_entries {
                             break;
                         }
+                        if last_progress_log.elapsed() >= PROGRESS_LOG_INTERVAL {
+                            info!(
+                                counted = count,
+                                elapsed = ?started.elapsed(),
+                                "txout-set accumulator rebuild: sizing shards, counting spent entries"
+                            );
+                            last_progress_log = std::time::Instant::now();
+                        }
                     }
                     Err(lmdb::Error::NotFound) => break,
                     Err(error) => return Err(FinalisedStateError::LmdbError(error)),
                 }
                 op = lmdb_sys::MDB_NEXT;
             }
+
+            info!(
+                spent_entries = count,
+                elapsed = ?started.elapsed(),
+                "txout-set accumulator rebuild: spent-entry count complete"
+            );
 
             Ok(count.saturating_mul(SPENT_SET_ENTRY_BYTES_ESTIMATE))
         })
@@ -971,11 +1018,45 @@ impl DbV1 {
             })
             .collect();
 
+        let started = std::time::Instant::now();
+        let planned = pending.len();
+        let mut completed: usize = 0;
+
         while let Some((lo, hi)) = pending.pop() {
-            match self.accumulate_tx_out_set_shard_blocking(db_tip, lo, hi, max_spent_entries)? {
-                Some(shard_acc) => total
-                    .combine(&shard_acc)
-                    .map_err(|error| FinalisedStateError::Custom(error.to_string()))?,
+            let shard_ordinal = completed + 1;
+            info!(
+                shard = shard_ordinal,
+                planned,
+                lo,
+                hi,
+                remaining = pending.len(),
+                db_tip = db_tip.0,
+                elapsed = ?started.elapsed(),
+                "txout-set accumulator rebuild: starting shard"
+            );
+
+            match self.accumulate_tx_out_set_shard_blocking(
+                db_tip,
+                lo,
+                hi,
+                max_spent_entries,
+                shard_ordinal,
+                planned,
+            )? {
+                Some(shard_acc) => {
+                    completed += 1;
+                    info!(
+                        shard = shard_ordinal,
+                        planned,
+                        lo,
+                        hi,
+                        elapsed = ?started.elapsed(),
+                        "txout-set accumulator rebuild: shard complete"
+                    );
+                    total
+                        .combine(&shard_acc)
+                        .map_err(|error| FinalisedStateError::Custom(error.to_string()))?
+                }
                 None => {
                     if hi - lo <= 1 {
                         // A single creating-txid first-byte value cannot be split further. Fail with
@@ -988,11 +1069,33 @@ impl DbV1 {
                         )));
                     }
                     let mid = lo + (hi - lo) / 2;
+                    // WARN, not INFO: a bisect means the shard-count estimate under-provisioned for
+                    // this txid distribution, and every split adds a further full-chain block scan.
+                    // This is the actionable signal that `accumulator_rebuild_memory_size` is too
+                    // low for the host, so it should survive a default log filter.
+                    warn!(
+                        lo,
+                        hi,
+                        mid,
+                        max_spent_entries,
+                        planned,
+                        "txout-set accumulator rebuild: shard exceeded the spent-set budget, \
+                         bisecting (raise storage.database.accumulator_rebuild_memory_size to \
+                         avoid the extra full-chain pass)"
+                    );
                     pending.push((lo, mid));
                     pending.push((mid, hi));
                 }
             }
         }
+
+        info!(
+            planned,
+            completed,
+            db_tip = db_tip.0,
+            elapsed = ?started.elapsed(),
+            "txout-set accumulator rebuild: all shards complete"
+        );
 
         Ok(total)
     }
@@ -1004,17 +1107,25 @@ impl DbV1 {
     /// Aborting *during* the spent load (before the limit is exceeded, dropping the partial set) is
     /// what makes the per-shard memory a hard cap rather than an estimate. An aborted shard does no
     /// block-table work, so a split wastes only a bounded partial spent scan.
+    ///
+    /// `shard_ordinal` / `shard_total` are carried for progress logging only — they name this pass
+    /// in the operator-visible output and have no effect on the computed partial.
     fn accumulate_tx_out_set_shard_blocking(
         &self,
         db_tip: Height,
         lo: u16,
         hi: u16,
         max_spent_entries: u64,
+        shard_ordinal: usize,
+        shard_total: usize,
     ) -> Result<Option<FinalisedTxOutSetInfoAccumulator>, FinalisedStateError> {
         let in_shard = |first_byte: u8| -> bool {
             let b = first_byte as u16;
             b >= lo && b < hi
         };
+
+        // Covers both phases below: the spent-set load and the full-chain block scan.
+        let started = std::time::Instant::now();
 
         // One read snapshot for the whole shard pass (subsumes the per-lookup RO-txn churn the old
         // per-block path incurred).
@@ -1071,9 +1182,22 @@ impl DbV1 {
             }
         }
 
+        // The number that decides whether this shard fitted the budget, and the best predictor of
+        // whether the next one will: worth a line even though the scan below dominates wall-clock.
+        info!(
+            shard = shard_ordinal,
+            shard_total,
+            lo,
+            hi,
+            spent_outpoints = spent_set.len(),
+            elapsed = ?started.elapsed(),
+            "txout-set accumulator rebuild: shard spent set loaded"
+        );
+
         // (2) Sequential pass over block transparent data, height-ascending.
         let mut shard_acc = FinalisedTxOutSetInfoAccumulator::empty();
         let mut height = GENESIS_HEIGHT.0;
+        let mut last_progress_log = std::time::Instant::now();
         while height <= db_tip.0 {
             let block_height = Height::try_from(height)
                 .map_err(|error| FinalisedStateError::Custom(error.to_string()))?;
@@ -1154,6 +1278,20 @@ impl DbV1 {
                             )
                         })?;
                 }
+            }
+
+            if last_progress_log.elapsed() >= PROGRESS_LOG_INTERVAL {
+                info!(
+                    shard = shard_ordinal,
+                    shard_total,
+                    lo,
+                    hi,
+                    height,
+                    db_tip = db_tip.0,
+                    elapsed = ?started.elapsed(),
+                    "txout-set accumulator rebuild: progress"
+                );
+                last_progress_log = std::time::Instant::now();
             }
 
             height += 1;
@@ -1262,6 +1400,10 @@ impl DbV1 {
             let mut spends: Vec<Outpoint> = Vec::new();
 
             let mut height = built.0 + 1;
+            // Bounded by `ACCUMULATOR_INCREMENTAL_MAX_GAP`, but that is still up to a thousand
+            // heights of random prev-output resolution — slow enough on cold storage to be worth
+            // reporting rather than leaving as a silent gap before the commit line.
+            let mut last_progress_log = std::time::Instant::now();
             while height <= tip.0 {
                 let height_bytes = Height(height).to_bytes()?;
 
@@ -1326,6 +1468,16 @@ impl DbV1 {
                     }
 
                     spends.extend(transparent_tx.spent_outpoints());
+                }
+
+                if last_progress_log.elapsed() >= PROGRESS_LOG_INTERVAL {
+                    info!(
+                        height,
+                        from = built.0 + 1,
+                        target = tip.0,
+                        "txout-set accumulator incremental update: progress"
+                    );
+                    last_progress_log = std::time::Instant::now();
                 }
 
                 height += 1;
@@ -1434,7 +1586,12 @@ impl DbV1 {
             self.env.sync(true)?;
 
             Ok::<_, FinalisedStateError>(())
-        })
+        })?;
+
+        #[cfg(feature = "prometheus")]
+        metrics::gauge!(ACCUMULATOR_BUILT_HEIGHT).set(tip.0 as f64);
+
+        Ok(())
     }
 
     /// `true` iff `outpoint` is absent from the `spent` table (read through `txn`).

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
@@ -33,10 +33,6 @@ fn approx_indexed_block_bytes(block: &IndexedBlock) -> u64 {
 #[cfg(not(feature = "transparent_address_history_experimental"))]
 const SYNC_WRITE_BATCH_MAX_BLOCKS: usize = 100_000;
 
-/// Interval between in-flight "syncing height" progress logs during bulk sync.
-#[cfg(not(feature = "transparent_address_history_experimental"))]
-const SYNC_PROGRESS_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
-
 #[cfg(test)]
 use crate::version;
 
@@ -344,7 +340,7 @@ impl DbWrite for DbV1 {
 
                     // In-flight progress: the block being fetched, throttled by time. (The committed
                     // tip is reported by the per-batch commit log below.)
-                    if last_progress_log.elapsed() >= SYNC_PROGRESS_LOG_INTERVAL {
+                    if last_progress_log.elapsed() >= PROGRESS_LOG_INTERVAL {
                         #[cfg(feature = "prometheus")]
                         {
                             metrics::gauge!(SYNC_FINALIZED_HEIGHT).set((next - 1) as f64);

--- a/packages/zaino-state/src/chain_index/finalised_state/router.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/router.rs
@@ -128,10 +128,47 @@ use zaino_status::StatusType;
 
 use arc_swap::{ArcSwap, ArcSwapOption};
 use std::sync::{
-    atomic::{AtomicU32, AtomicUsize, Ordering},
+    atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering},
     Arc, Mutex,
 };
 use tokio::runtime::Handle;
+use tracing::info;
+
+/// Which backend is currently answering finalised-state reads, as an operator-facing fact.
+///
+/// [`StatusType`] cannot express this: an ephemeral passthrough tracks the backing validator and
+/// reports [`StatusType::Ready`] exactly like a fully synced persistent database, so a caller
+/// waiting on `Ready` cannot tell whether the finalised state it is about to query is the real
+/// on-disk index or a passthrough standing in for one while sync or a migration runs.
+///
+/// The two ephemeral cases are kept distinct deliberately. Conflating a deliberate configuration
+/// choice with a transient sync state is the ambiguity this type exists to remove.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FinalisedStateMode {
+    /// `ephemeral_finalised_state = true`: this process has no persistent finalised-state database
+    /// at all, and never will. A permanent property of the run, fixed at startup.
+    EphemeralConfigured,
+
+    /// A persistent database exists but is not currently serving reads — an ephemeral passthrough is
+    /// installed while initial sync or a migration runs. Transient: reads become `Persistent` once
+    /// the work completes.
+    EphemeralRouted,
+
+    /// Reads are served by the persistent on-disk database. This is the steady state, and the only
+    /// mode in which a test asserting on finalised-state behaviour is exercising the real index.
+    Persistent,
+}
+
+impl std::fmt::Display for FinalisedStateMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let name = match self {
+            FinalisedStateMode::EphemeralConfigured => "ephemeral(configured)",
+            FinalisedStateMode::EphemeralRouted => "ephemeral(syncing)",
+            FinalisedStateMode::Persistent => "persistent",
+        };
+        f.write_str(name)
+    }
+}
 
 /// Ephemeral routing policy used when installing or reusing the ephemeral backend.
 ///
@@ -331,6 +368,13 @@ pub(crate) struct Router<T: BlockchainSource> {
     /// [`FinalisedState::wait_until_synced`], which waits for finalised-state sync/migration to finish
     /// without conflating it with serving-readiness ([`StatusType::Ready`]).
     background_ops: AtomicUsize,
+
+    /// Latch: has this router ever been observed serving reads from the persistent database?
+    ///
+    /// Purely an observability aid — it gates the one-shot "finalised state online" log in
+    /// [`Router::note_persistent_online`] so the transition is announced exactly once per process
+    /// rather than on every status poll. Nothing reads it to make a routing decision.
+    has_been_persistent: AtomicBool,
 }
 
 /// Database capability router.
@@ -362,6 +406,41 @@ impl<T: BlockchainSource> Router<T> {
             primary_mask: AtomicU32::new(cap.bits()),
             ephemeral_mask: AtomicU32::new(0),
             background_ops: AtomicUsize::new(0),
+            has_been_persistent: AtomicBool::new(false),
+        }
+    }
+
+    // ***** Observability *****
+
+    /// Returns which backend is currently answering finalised-state reads.
+    ///
+    /// Read-only; derived from the same state [`Router::backend`] routes on, so it cannot disagree
+    /// with where a read would actually land.
+    pub(crate) fn finalised_state_mode(&self) -> FinalisedStateMode {
+        if self.primary_is_ephemeral() {
+            FinalisedStateMode::EphemeralConfigured
+        } else if self.ephemeral_mask.load(Ordering::Acquire) != 0 {
+            FinalisedStateMode::EphemeralRouted
+        } else {
+            FinalisedStateMode::Persistent
+        }
+    }
+
+    /// Announces, exactly once per process, that the persistent finalised state has come online.
+    ///
+    /// Idempotent via a `compare_exchange` on the latch, so it is safe to call from both the
+    /// ephemeral-release edge and the status poll — the two paths cover different startup shapes
+    /// (see the call sites) and whichever fires first wins.
+    pub(crate) fn note_persistent_online(&self) {
+        if self
+            .has_been_persistent
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            info!(
+                mode = %FinalisedStateMode::Persistent,
+                "finalised state online: reads are now served by the persistent database"
+            );
         }
     }
 
@@ -469,6 +548,11 @@ impl<T: BlockchainSource> Router<T> {
             }
         }
 
+        // Captured before `apply_ephemeral_mode` below so the reuse path can tell an actual mode
+        // change (ReadOnly -> Full) from a no-op refresh; the sync loop calls in here repeatedly, so
+        // logging unconditionally would bury the real transitions.
+        let mode_before = self.active_ephemeral_mode();
+
         let ephemeral = match self.ephemeral.load_full() {
             Some(ephemeral) => {
                 match ephemeral.as_ref() {
@@ -490,6 +574,14 @@ impl<T: BlockchainSource> Router<T> {
             None => {
                 let ephemeral = Arc::new(FinalisedSource::ephemeral(source, network, db_height));
                 self.ephemeral.store(Some(Arc::clone(&ephemeral)));
+                info!(
+                    requested_mode = ?mode,
+                    db_height = db_height.map(|height| height.0),
+                    mode = %FinalisedStateMode::EphemeralRouted,
+                    "finalised state switched to the ephemeral passthrough: reads are served from \
+                     the backing validator, NOT the persistent database, until sync/migration \
+                     completes"
+                );
                 ephemeral
             }
         };
@@ -501,6 +593,20 @@ impl<T: BlockchainSource> Router<T> {
         })?;
 
         self.apply_ephemeral_mode(ephemeral.as_ref(), active_mode);
+
+        // Escalation on an already-installed passthrough (ReadOnly -> Full, i.e. a migration
+        // freezing routed writes on top of a running sync). Only logged when the effective mode
+        // actually moved.
+        if let Some(previous_mode) = mode_before {
+            if previous_mode != active_mode {
+                info!(
+                    from = ?previous_mode,
+                    to = ?active_mode,
+                    requested_mode = ?mode,
+                    "finalised state ephemeral routing escalated"
+                );
+            }
+        }
 
         Ok(EphemeralReference::new(Arc::clone(self), ephemeral, mode))
     }
@@ -549,12 +655,29 @@ impl<T: BlockchainSource> Router<T> {
 
             match self.active_ephemeral_mode() {
                 Some(active_mode) => {
+                    // Still ephemeral, but a holder went away — e.g. a migration finished while a
+                    // sync still holds ReadOnly. Routing narrows; it does not return to disk.
+                    info!(
+                        released_mode = ?mode,
+                        active_mode = ?active_mode,
+                        mode = %FinalisedStateMode::EphemeralRouted,
+                        "finalised state ephemeral routing downgraded (still passthrough-backed)"
+                    );
                     self.apply_ephemeral_mode(active_ephemeral.as_ref(), active_mode);
                     return;
                 }
                 None => {
+                    // Last holder released: reads go back to the persistent database. This is the
+                    // edge CI should gate on rather than `StatusType::Ready`.
                     self.restore_primary_capability();
-                    self.ephemeral.swap(None)
+                    let removed = self.ephemeral.swap(None);
+                    info!(
+                        released_mode = ?mode,
+                        mode = %FinalisedStateMode::Persistent,
+                        "finalised state switched back to the persistent database"
+                    );
+                    self.note_persistent_online();
+                    removed
                 }
             }
         };
@@ -837,9 +960,16 @@ impl<T: BlockchainSource> DbCore for Router<T> {
     /// capability routing, shuts down the primary backend, and then shuts down the removed ephemeral
     /// backend.
     async fn shutdown(&self) -> Result<(), FinalisedStateError> {
+        let was_ephemeral = self.ephemeral_mask.load(Ordering::Acquire) != 0;
         self.ephemeral_mask.store(0, Ordering::Release);
 
         let ephemeral = self.ephemeral.swap(None);
+
+        // Terminal teardown clears routing directly rather than through the reference guards, so
+        // without this the last mode change of a process that shut down mid-sync goes unrecorded.
+        if was_ephemeral {
+            info!("finalised state ephemeral routing torn down during shutdown");
+        }
 
         self.primary_mask.store(
             self.primary.load_full().capability().bits(),

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/ephemeral.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/ephemeral.rs
@@ -18,6 +18,7 @@ use zaino_common::network::ActivationHeights;
 use zaino_common::{DatabaseConfig, StorageConfig};
 use zaino_proto::proto::utils::{prune_compact_block, PoolTypeFilter};
 
+use crate::chain_index::finalised_state::router::FinalisedStateMode;
 use crate::chain_index::finalised_state::FinalisedState;
 use crate::chain_index::tests::init_tracing;
 use crate::chain_index::tests::vectors::MockSource;
@@ -230,4 +231,83 @@ async fn reader_chain_block_and_header_identity_matches_source() {
 #[tokio::test]
 async fn shutdown_returns_promptly() {
     super::assert_shutdown_returns_promptly("Ephemeral", spawn_ephemeral_finalised_state).await;
+}
+
+/// `ephemeral_finalised_state = true` must be reported as a configuration choice, not as a
+/// transient sync state — the two are indistinguishable from `StatusType` alone, which is the
+/// ambiguity `FinalisedStateMode` exists to remove.
+#[tokio::test]
+async fn configured_ephemeral_reports_its_mode() {
+    init_tracing();
+
+    let source = build_mockchain_source(load_test_vectors().unwrap().blocks);
+    let (_db_dir, finalised_state) = spawn_ephemeral_finalised_state(source).await.unwrap();
+
+    finalised_state.wait_until_ready().await;
+
+    // `Ready` alone cannot distinguish this from a fully synced persistent database.
+    assert_eq!(finalised_state.status(), StatusType::Ready);
+    assert_eq!(
+        finalised_state.finalised_state_mode(),
+        FinalisedStateMode::EphemeralConfigured
+    );
+}
+
+/// Installing and releasing the ephemeral passthrough must move `finalised_state_mode` between
+/// `Persistent` and `EphemeralRouted`, and the released passthrough must hand reads back to the
+/// persistent database.
+///
+/// This is the transition the new routing logs describe, and the one `StatusType` cannot express:
+/// the passthrough reports `Ready` for the whole span, so a caller gating on `Ready` alone would
+/// see no change across either edge.
+///
+/// Drives the router directly rather than through `sync_to_height`: that path installs the
+/// passthrough in the foreground but releases it from a spawned task, so observing the
+/// intermediate state would race the background sync.
+///
+/// `multi_thread` required: the persistent v1 backend's validation path calls
+/// `block_in_place`, which panics on a current-thread runtime.
+#[tokio::test(flavor = "multi_thread")]
+async fn ephemeral_routing_transitions_are_visible_in_mode() {
+    init_tracing();
+
+    let source = build_mockchain_source(load_test_vectors().unwrap().blocks);
+    let (_db_dir, finalised_state) =
+        crate::chain_index::tests::finalised_state::v1::spawn_v1_zaino_db(source.clone())
+            .await
+            .unwrap();
+
+    // A persistent database serves its own reads before any ephemeral routing is installed.
+    assert_eq!(
+        finalised_state.finalised_state_mode(),
+        FinalisedStateMode::Persistent
+    );
+
+    let router = finalised_state.router_arc();
+    let network = ActivationHeights::default().to_regtest_network();
+
+    let ephemeral_reference = router
+        .init_or_take_ephemeral(
+            source.clone(),
+            network,
+            crate::chain_index::finalised_state::router::EphemeralMode::ReadOnly,
+            None,
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        finalised_state.finalised_state_mode(),
+        FinalisedStateMode::EphemeralRouted,
+        "an installed passthrough must be reported as ephemeral, not persistent"
+    );
+
+    // Dropping the last reference restores primary routing.
+    drop(ephemeral_reference);
+
+    assert_eq!(
+        finalised_state.finalised_state_mode(),
+        FinalisedStateMode::Persistent,
+        "releasing the last ephemeral reference must hand reads back to the persistent database"
+    );
 }

--- a/packages/zaino-state/src/indexer.rs
+++ b/packages/zaino-state/src/indexer.rs
@@ -92,6 +92,13 @@ pub trait ZcashService: Sized + Status {
     /// Returns a [`IndexerSubscriber`].
     fn get_subscriber(&self) -> IndexerSubscriber<Self::Subscriber>;
 
+    /// Returns which backend is currently answering finalised-state reads.
+    ///
+    /// Companion to [`Status::status`], which cannot express this: an ephemeral passthrough reports
+    /// [`zaino_status::StatusType::Ready`] identically to a synced persistent database, so a caller
+    /// gating on `Ready` alone cannot tell which one it is about to query.
+    fn finalised_state_mode(&self) -> crate::FinalisedStateMode;
+
     /// Shuts down the StateService.
     fn close(&mut self);
 }

--- a/packages/zaino-state/src/indexer/node_backed_indexer.rs
+++ b/packages/zaino-state/src/indexer/node_backed_indexer.rs
@@ -123,6 +123,10 @@ impl ZcashService for NodeBackedIndexerService<ZebraValidatorSource> {
     type Subscriber = NodeBackedIndexerServiceSubscriber<ZebraValidatorSource>;
     type Config = NodeBackedIndexerServiceConfig;
 
+    fn finalised_state_mode(&self) -> crate::FinalisedStateMode {
+        self.indexer.finalised_state_mode()
+    }
+
     /// Initializes a new [`NodeBackedIndexerService`] and starts its sync process.
     #[instrument(name = "NodeBackedIndexerService::spawn", skip(config), fields(network = %config.common.network))]
     async fn spawn(

--- a/packages/zaino-state/src/lib.rs
+++ b/packages/zaino-state/src/lib.rs
@@ -43,6 +43,9 @@ pub mod metric_names {
     pub const SYNC_LAST_BLOCK_WRITTEN_AT: &str = "zaino.sync.last_block_written_at";
 
     pub const DB_TIP_HEIGHT: &str = "zaino.db.tip_height";
+    pub const FINALISED_EPHEMERAL: &str = "zaino.db.finalised_ephemeral";
+    pub const ACCUMULATOR_BUILT_HEIGHT: &str = "zaino.db.accumulator_built_height";
+    pub const ACCUMULATOR_REBUILD_ACTIVE: &str = "zaino.db.accumulator_rebuild_active";
 
     pub const MEMPOOL_TRANSACTIONS: &str = "zaino.mempool.transactions";
     pub const MEMPOOL_TIP_CHANGES_TOTAL: &str = "zaino.mempool.tip_changes_total";
@@ -62,6 +65,8 @@ pub use indexer::node_backed_indexer::{
 };
 
 pub mod chain_index;
+
+pub use chain_index::finalised_state::router::FinalisedStateMode;
 
 // Core ChainIndex trait and implementations
 pub use chain_index::{

--- a/packages/zainod/CHANGELOG.md
+++ b/packages/zainod/CHANGELOG.md
@@ -9,6 +9,19 @@ and this crate adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+- An `fs_mode` field on the periodic `Zaino status check` log line, reporting
+  whether finalised-state reads are served by the persistent database
+  (`persistent`), by the ephemeral passthrough during sync or migration
+  (`ephemeral(syncing)`), or by a process configured with
+  `ephemeral_finalised_state = true` (`ephemeral(configured)`). `chain_state:
+  Ready` alone is ambiguous — the passthrough reports `Ready` identically to a
+  synced on-disk index — so containerised tests should gate startup on
+  `fs_mode: persistent`, or on the `finalised state online` log line, rather
+  than on `Ready`.
+- Metric descriptions for `zaino.db.finalised_ephemeral`,
+  `zaino.db.accumulator_built_height` and
+  `zaino.db.accumulator_rebuild_active`. Note the `prometheus` feature is off
+  by default, so these are inert unless explicitly enabled.
 ### Changed
 ### Deprecated
 ### Removed

--- a/packages/zainod/src/indexer.rs
+++ b/packages/zainod/src/indexer.rs
@@ -287,6 +287,16 @@ where
             None => StatusType::Offline,
         };
 
+        // `chain_state: Ready` on its own is ambiguous: while initial sync or a migration runs, an
+        // ephemeral passthrough serves finalised-state reads and reports `Ready` exactly like the
+        // real on-disk index. Reporting the mode next to the status is what lets an operator — or a
+        // containerised test polling this line — tell the two apart.
+        let finalised_state_mode = self
+            .service
+            .as_ref()
+            .map(|service| service.inner_ref().finalised_state_mode().to_string())
+            .unwrap_or_else(|| "unknown".to_string());
+
         let json_server_status = match &self.json_server {
             Some(json_server) => json_server.status(),
             None => StatusType::Offline,
@@ -299,6 +309,7 @@ where
 
         info!(
             chain_state = %service_status,
+            fs_mode = %finalised_state_mode,
             json_rpc = %json_server_status,
             grpc = %grpc_server_status,
             "Zaino status check"

--- a/packages/zainod/src/metrics.rs
+++ b/packages/zainod/src/metrics.rs
@@ -126,6 +126,23 @@ fn describe_metrics() {
         SYNC_LAST_BLOCK_WRITTEN_AT,
         "Unix timestamp of the last block written to the finalized database"
     );
+    metrics::describe_gauge!(
+        FINALISED_EPHEMERAL,
+        "1 while finalised-state reads are served by the ephemeral passthrough rather than the \
+         persistent database (initial sync, or a migration in progress); 0 once the on-disk index \
+         is serving. Note this reads 1 for the whole life of a process configured with \
+         ephemeral_finalised_state = true"
+    );
+    metrics::describe_gauge!(
+        ACCUMULATOR_BUILT_HEIGHT,
+        "Height the persisted txout-set accumulator currently reflects. Lagging far behind the DB \
+         tip means the next sync will trigger a full from-genesis rebuild"
+    );
+    metrics::describe_gauge!(
+        ACCUMULATOR_REBUILD_ACTIVE,
+        "1 while a from-genesis txout-set accumulator rebuild is running. This is a multi-pass \
+         full-chain scan; expect elevated read I/O for its duration"
+    );
 
     // Inbound gRPC
     metrics::describe_counter!(GRPC_REQUESTS_TOTAL, "Total inbound gRPC requests by method");

--- a/tools/scripts/init-podman-volumes.sh
+++ b/tools/scripts/init-podman-volumes.sh
@@ -9,7 +9,11 @@
 # on the actual Mountpoint directory, and force-recreate a stale record so the
 # DB and on-disk storage stay in sync.
 for vol in zaino-container-target zaino-cargo-git zaino-cargo-registry; do
-    mountpoint="$(podman volume inspect --format '{{.Mountpoint}}' "$vol" 2>/dev/null)"
+    # `|| true`: cargo-make runs task scripts under `set -e`, and an assignment
+    # takes the exit status of its command substitution. `volume inspect` exits
+    # 125 on a missing volume, so without this the script dies here — on the
+    # very case it exists to repair — and creates nothing.
+    mountpoint="$(podman volume inspect --format '{{.Mountpoint}}' "$vol" 2>/dev/null || true)"
     if [[ -z "$mountpoint" || ! -d "$mountpoint" ]]; then
         # -z: no DB record. `! -d`: DB record present but backing dir gone;
         # rm --force drops the dangling record before we recreate it.

--- a/tools/test-runner/src/bin/container-test.rs
+++ b/tools/test-runner/src/bin/container-test.rs
@@ -120,7 +120,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         "--init".into(),
         "--pids-limit=-1".into(),
         "--tmpfs".into(),
-        "/tmp:rw,exec,nosuid,nodev".into(),
+        // `size` must stay set: podman caps a `--tmpfs` mount at 64 MiB rather
+        // than inheriting the kernel's tmpfs default. That starves the tests
+        // that build LMDB databases in `tempfile` directories under /tmp.
+        // tmpfs occupies only the memory actually written, so this reserves
+        // nothing up front.
+        "/tmp:rw,exec,nosuid,nodev,size=8g".into(),
         "--name".into(),
         container_name,
         "-v".into(),

--- a/tools/test-runner/src/bin/container-test.rs
+++ b/tools/test-runner/src/bin/container-test.rs
@@ -87,11 +87,40 @@ fn main() -> Result<(), Box<dyn Error>> {
     // num-cpus profile each test spawns a full zebrad whose rayon pool also
     // sizes to num-cpus, so peak task count scales ~num_cpus^2 and breaches the
     // default cap on many-core hosts (EAGAIN / rayon ThreadPoolBuildError).
+    //
+    // `--tmpfs /tmp` keeps the live suite's scratch off the container's overlay
+    // layer.
+    //
+    // Why it is needed: the validator launcher polls the spawned validator's
+    // captured stdout for its readiness line, re-`open`ing that file every
+    // 50-100ms while a drainer thread appends the validator's debug output to
+    // it. On a host running IMA appraisal (which the kernel enables
+    // automatically under Secure Boot), IMA caches its verdict per inode, but
+    // overlayfs inodes do not carry stable identity, so every one of those
+    // opens misses the cache and re-hashes the whole file. Against a
+    // continuously growing log, several tests at once, the `openat` calls wedge
+    // in uninterruptible sleep (`ima_file_check` -> `process_measurement`) and
+    // the test hangs until the nextest timeout kills it. tmpfs inodes are
+    // stable and IMA policies do not appraise tmpfs, so the loop stays cheap.
+    //
+    // Why it is safe: everything the suite puts in /tmp is per-run scratch —
+    // generated validator configs, validator data directories, and the captured
+    // stdout/stderr logs — all of which are already discarded with the
+    // container, which runs `--rm`. Nothing that has to outlive the run is
+    // written there: the repository is bind-mounted at
+    // /home/container_user/zaino and build output goes to the named target
+    // volume. The mount keeps the default `exec` behaviour of the directory it
+    // replaces so build and link steps that use TMPDIR are unaffected, and it
+    // is left at the kernel's default size cap (half of RAM) rather than a
+    // guessed limit, so a large run fails no earlier than it does today.
+    // Hosts without IMA appraisal are unaffected apart from faster scratch I/O.
     let mut argv: Vec<String> = vec![
         "run".into(),
         "--rm".into(),
         "--init".into(),
         "--pids-limit=-1".into(),
+        "--tmpfs".into(),
+        "/tmp:rw,exec,nosuid,nodev".into(),
         "--name".into(),
         container_name,
         "-v".into(),


### PR DESCRIPTION
## Finalised-state observability

Additive observability only — no control flow, status semantics, or routing behaviour changes.

### Why

Two blind spots hit while syncing a mainnet node:

1. **The accumulator rebuild is silent.** `rebuild_tx_out_set_accumulator` logs two lines up front and nothing again until it commits. In between it runs a full `spent` count pass and one full-chain block scan *per shard* — ~40 minutes on a mainnet DB — with no output. "Working" and "hung" look identical.

2. **`chain_state: Ready` doesn't mean the persistent DB is serving.** During a long sync the router installs an ephemeral passthrough; it tracks the validator and reports `Ready` exactly like a synced on-disk index. Nothing logged the install or release, and nothing exposed routing state. Containerised tests waiting on `Ready` have been silently asserting against the passthrough.

### What

**Rebuild progress** — spent-entry count pass, per-shard start/spent-set-size/completion, and intra-shard height progress. Throttled to one line per 10s (reusing the existing `write_core` idiom, now a shared `PROGRESS_LOG_INTERVAL`) so output stays bounded regardless of shard count — a memory-constrained container can reach 256 shards. Also covers the startup `spent` integrity check and the incremental update path.

A shard bisect logs at **WARN**, naming `accumulator_rebuild_memory_size` — it means the budget under-provisioned and each split adds another full-chain pass.

**Routing mode** — new `FinalisedStateMode` (`EphemeralConfigured` / `EphemeralRouted` / `Persistent`), reported on every transition plus a one-shot "finalised state online" line:

INFO router: finalised state switched to the ephemeral passthrough: reads are served from the
     backing validator, NOT the persistent database ... mode=ephemeral(syncing)
INFO router: finalised state switched back to the persistent database mode=persistent
INFO router: finalised state online: reads are now served by the persistent database

The one-shot latch fires from both the ephemeral-release edge *and* the status poll — a restart against an already-current DB never installs a passthrough, so the release edge alone would never fire.

`ephemeral_finalised_state = true` now **warns** at startup; that branch previously returned completely silently.

**Status line** gains `fs_mode`, so CI can gate on `fs_mode: persistent` instead of `Ready`.

**Metrics** (`prometheus` feature, off by default): `zaino.db.finalised_ephemeral`, `zaino.db.accumulator_built_height`, `zaino.db.accumulator_rebuild_active`.

### Notes for review

- `fs_height` was dropped from the status line: `db_height()` is async, `log_status` is a sync `pub fn`, and making it async is a breaking change. The height is available via the gauges.
- One private-fn signature change (`shard_ordinal`/`shard_total` for logging), one `pub` accessor chain mirroring the existing `status()` chain, one `AtomicBool` latch on `Router`.
- Drive-by fix: `zaino.chain.tip_height` was emitted twice per sync iteration, once via a hard-coded string literal and once via `CHAIN_TIP_HEIGHT`. Removed the literal. Happy to split this out.
-  `makers lint` fails on this branch **before** this PR — `--all-features` enables `transparent_address_history_experimental`, which doesn't compile (`write_core.rs:404`, `:1541`). Verified against a clean tree. Not addressed here.

### Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets` and `--features prometheus` all clean (no new warnings); `makers lint-boundary-conversions` clean; **586 tests pass**. Two new tests cover the configured-ephemeral mode and the install→release transition.

14 files, +584/−19.

Out of scope and worth separate issues: checkpointing the rebuild so restarts resume, relaxing NO_READAHEAD for the rebuild's sequential scans, and whether Router::status() should report Syncing while ephemeral-backed.