### PR TITLE
Add sync plus concurrency tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,22 @@ and this library adheres to Rust's notion of
   cadence and exclude-list caps operator-configurable.
 
 ### Changed
+- **Bulk finalised-state sync now assembles blocks concurrently too.** Making
+  the fetch concurrent exposed the other half: a profile through the sandblast
+  heights put **54% of all CPU on a single thread**, holding the run to 8
+  blocks/s on 1.8 of 16 cores. That thread was the chainwork fold, which ran
+  `assemble_indexed_block` in block order. Assembly is as expensive as the
+  fetch and for the mirror-image reason — converting to the compact form
+  re-serialises the Jubjub points zebra just decompressed, and returning to
+  affine coordinates costs a field inversion per point. By Amdahl that capped
+  the whole run at 1.85x however many cores the fetches used.
+
+  A block's own proof-of-work depends only on its own header, so the cumulative
+  chainwork is a running sum that can be folded over already-fetched blocks in a
+  separate pass. Bulk sync is now three: fetch a window concurrently, fold the
+  chainwork in order (integer arithmetic, microseconds), then assemble the
+  window concurrently on `spawn_blocking`. The ordering guarantee is unchanged —
+  every block still gets exactly its parent's chainwork plus its own.
 - **Bulk finalised-state sync now fetches blocks concurrently.** A profile of a
   mainnet sync through the sandblast heights (~1.7M) put **91% of cycles in
   BLS12-381 scalar arithmetic** — `sqrt_tonelli_shanks`, `Scalar::square`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,30 @@ and this library adheres to Rust's notion of
   cadence and exclude-list caps operator-configurable.
 
 ### Changed
+- **Bulk finalised-state sync now fetches blocks concurrently.** A profile of a
+  mainnet sync through the sandblast heights (~1.7M) put **91% of cycles in
+  BLS12-381 scalar arithmetic** — `sqrt_tonelli_shanks`, `Scalar::square`,
+  `Scalar::invert` — against **1.3% in LMDB**. That is Jubjub point
+  decompression: zebra's block deserializer resolves `cv` and `ephemeral_key`
+  for every Sapling output via `from_bytes_not_small_order` (a modular square
+  root plus a cofactor multiplication), and Zaino discards all of it, keeping
+  only the compact representation. Sandblast-era blocks carry hundreds of
+  outputs each, which took block building from 1.4ms to 200ms per block — a
+  sync doing 5 blocks/s on one core with fifteen idle.
+
+  The fetch does not depend on `parent_chainwork`, so it no longer runs in block
+  order: `write_blocks_to_height` now issues one fetch per core (less one, capped
+  at 16) and folds the results back in height order. The read-state service runs
+  each read on `spawn_blocking`, so the decompression spreads across cores. The
+  order-dependent half — chaining `parent_chainwork` — is unchanged.
+
+  This divides the waste rather than removing it. The fix that removes it is
+  upstream in zebra: decompress `cv`/`ephemeral_key` lazily, since reading a
+  historical block never verifies it.
+
+  `zaino.sync.block_build_seconds` still records per-block cost, so with N
+  fetches in flight its sum approaches N x wall-clock; divide by the concurrency
+  before comparing it against elapsed time.
 - **Bulk finalised-state sync now pipelines its write batches.**
   `DbV1::write_blocks_to_height` commits batch N on a scoped thread while it
   builds batch N+1, instead of alternating between the two. Measured on a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,21 @@ and this library adheres to Rust's notion of
   cadence and exclude-list caps operator-configurable.
 
 ### Changed
+- **Bulk finalised-state sync now pipelines its write batches.**
+  `DbV1::write_blocks_to_height` commits batch N on a scoped thread while it
+  builds batch N+1, instead of alternating between the two. Measured on a
+  mainnet sync at height ~1.2M, the serial form spent 60% of wall-clock building
+  blocks and 40% inside `write_block_batch_blocking` + `env.sync`, with the
+  builder idle for every commit — a mean 79s pause every 120s. Overlapping them
+  hides the shorter half behind the longer.
+
+  Durability and resume semantics are unchanged: a batch is still written in one
+  transaction and fsynced before the validated tip advances, so the on-disk
+  `headers` tip never runs ahead of the indexes. The one operational change is
+  memory — peak heap for buffered blocks is now up to *twice*
+  `storage.database.sync_write_batch_size`, since the batch being committed is
+  still resident while its successor fills. That knob bounds one batch, not the
+  pipeline; size it for the host accordingly.
 - **The mempool no longer stalls across a tip transition.** `getrawmempool`,
   `getmempoolinfo` and `GetMempoolTx` are served from a tip-agnostic set that
   never clears; the old mempool wiped its whole map on every tip change and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ and this library adheres to Rust's notion of
 ## Unreleased
 
 ### Added
+- **`zaino-bench`** — a benchmark harness answering three operational questions
+  against a running zainod, from the outside, over the interfaces a real client
+  uses. A workspace member but not a `default-member`, so a bare
+  `cargo nextest run` never builds it; select it with `makers bench` or
+  `-p zaino-bench`.
+  - `sync` — initial-sync time, sampled from zainod's existing Prometheus
+    endpoint (`zaino.sync.*`). No new instrumentation: it reads what
+    `zaino-state` already emits behind the `prometheus` feature, with a unit
+    test pinning the metric names to `zaino_state::metric_names` so a rename
+    fails the build rather than the run. `--csv` writes the sync curve.
+  - `concurrent` — concurrent-connection load test with a `--sweep` mode that
+    locates the knee, tail percentiles (p50/p95/p99) alongside min/mean/max, and
+    an `RLIMIT_NOFILE` preflight so a client-side `ulimit` is not mistaken for a
+    server-side ceiling. Ported from the `zaino-admin concurrent-test` tool on
+    the `hahn/store` branch.
+  - `serve` — single-stream block serve rate, verifying every `prev_hash` link
+    in the same pass. Ported from that branch's `zaino-admin check`.
+  - `docs/perf.md` records the results and, next to them, the machine spec and
+    node configs that produced them:
+    `docs/example_configs/zainod-bench-mainnet{,-ephemeral}.toml`. Both select
+    `backend = 'direct'` deliberately — the fastest path Zaino has, and so the
+    honest ceiling to quote — and differ only in
+    `ephemeral_finalised_state`. `concurrent` and `serve` are reported under
+    both modes, since a finalised read is answered from Zaino's own index in one
+    and by passthrough to the validator in the other; `sync` is persistent-only.
 - **Eight new crates** implementing validator access as a hexagonal port /
   adapter stack (ADR-0008, ADR-0009). Each carries a `usage.md`:
   - `zaino-primitives` — Zaino's domain vocabulary. Depends on `thiserror` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,20 @@ and this library adheres to Rust's notion of
   cadence and exclude-list caps operator-configurable.
 
 ### Changed
+- **LMDB reader slots raised from 512 to 2048–8192.** The clamp was
+  `(cpu * 32).clamp(512, 4096)`, which gives exactly 512 — the floor — on any
+  host with 16 cores or fewer. With `NO_TLS` a slot belongs to a read
+  *transaction* rather than a thread, so 512 is a hard ceiling on concurrent
+  reads, and an ordinary concurrency benchmark exhausted it: reads failed with
+  `MDB_READERS_FULL`, the startup block scan treats that as fatal, and the node
+  restarted in a loop. A slot is one cache line (the measured `lock.mdb` is
+  32,896 bytes at 512 readers), so 8192 slots costs ~512 KiB of shared memory.
+
+  **This does not make exhaustion safe.** A client can still open more
+  concurrent reads than there are slots. `MDB_READERS_FULL` being classified as
+  a critical error — rather than the backpressure it is — remains an open bug,
+  and until it is fixed a client can restart a node by exceeding whatever limit
+  is configured.
 - **Bulk finalised-state sync now assembles blocks concurrently too.** Making
   the fetch concurrent exposed the other half: a profile through the sandblast
   heights put **54% of all CPU on a single thread**, holding the run to 8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5906,6 +5906,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "zaino-bench"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "futures",
+ "reqwest 0.13.1",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "zaino-common",
+ "zaino-proto",
+ "zaino-state",
+]
+
+[[package]]
 name = "zaino-chain-head"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ members = [
     "packages/zaino-serve",
     "packages/zaino-state",
     "packages/zaino-proto",
+    # Benchmark harness. Excluded from `default-members` for the same reason as
+    # the live-test crates: it is an operator tool run explicitly
+    # (`-p zaino-bench`), never part of the fast test loop.
+    "packages/zaino-bench",
     # Live-test suite (docs/adr/0002, docs/adr/0003, docs/adr/0004).
     # zaino-testutils first: the e2e/clientless partitions depend on it.
     "live-tests/zaino-testutils",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -206,6 +206,18 @@ esac
 
 # -------------------------------------------------------------------
 
+[tasks.bench]
+# clear = true fully replaces cargo-make's built-in `bench` task (which runs
+# `cargo bench`); without it our `script` would merge with the builtin `command`.
+clear = true
+description = "Run the zaino-bench harness against a running zainod (sync | concurrent | serve)"
+# Release, always: a debug load generator measures itself rather than the
+# server. Not a member of `default-members`, so `-p` is required to select it.
+script_runner = "bash"
+script = 'exec cargo run --release -p zaino-bench -- "$@"'
+
+# -------------------------------------------------------------------
+
 [tasks.zcashd_test]
 description = "Convenience: the whole suite with the zcashd-backed tests (`makers test all --with-zcashd`)"
 # Delegates to the `test all` front door with the explicit flag — there is no

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ packages/                          Cargo workspace member crates, in dependency 
   zaino-state/                       Chain state and indexer service library
   zaino-serve/                       gRPC + JSON-RPC servers, and the served JSON schema
   zainod/                            Daemon binary
+  zaino-bench/                       Benchmark harness (sync time, connection ceiling, serve rate)
 
 live-tests/                        Live-test suite — root-workspace members, run against zcashd/zebrad
   e2e/                               End-to-end partition (wallet client -> Zaino -> validator)
@@ -167,6 +168,7 @@ mistakes its design is trying to prevent.
 - [`zaino-mempool-service`](./packages/zaino-mempool-service/usage.md): spawning and consuming the mempool.
 - [`zaino-chain-head`](./packages/zaino-chain-head/usage.md): the chain head's ports, why reads live on the snapshot, and why there is no way to make it synchronise.
 - [`zaino-chain-head-service`](./packages/zaino-chain-head-service/usage.md): the chain head runtime, its two testing styles, and the properties to keep when editing the advance path.
+- [`zaino-bench`](./packages/zaino-bench/usage.md): measuring sync time, connection ceiling, and serve rate on a running node.
 
 
 ## Security Vulnerability Disclosure

--- a/docs/example_configs/zainod-bench-mainnet-ephemeral.toml
+++ b/docs/example_configs/zainod-bench-mainnet-ephemeral.toml
@@ -14,7 +14,7 @@
 #   zainod start --config docs/example_configs/zainod-bench-mainnet-ephemeral.toml
 
 backend = 'direct'
-zebra_db_path = '/home/idky137/.cache/zebra/'
+zebra_db_path = '<PATH_TO_ZEBRA>'
 network = 'Mainnet'
 
 # The ephemeral half of the pair — the one line that differs.
@@ -42,5 +42,5 @@ shard_power = 4
 # Still required by the config schema, and still the cache location, even though
 # no finalised-state database is written here in ephemeral mode.
 [storage.database]
-path = '/home/idky137/.cache/zaino/'
+path = '<ZAINO_CACHE>'
 size = 384

--- a/docs/example_configs/zainod-bench-mainnet-ephemeral.toml
+++ b/docs/example_configs/zainod-bench-mainnet-ephemeral.toml
@@ -14,7 +14,7 @@
 #   zainod start --config docs/example_configs/zainod-bench-mainnet-ephemeral.toml
 
 backend = 'direct'
-zebra_db_path = '/mnt/framework_ssd/.cache/zebra'
+zebra_db_path = '/home/idky137/.cache/zebra/'
 network = 'Mainnet'
 
 # The ephemeral half of the pair — the one line that differs.
@@ -42,5 +42,5 @@ shard_power = 4
 # Still required by the config schema, and still the cache location, even though
 # no finalised-state database is written here in ephemeral mode.
 [storage.database]
-path = '/mnt/framework_ssd/.cache/zaino'
+path = '/home/idky137/.cache/zaino/'
 size = 384

--- a/docs/example_configs/zainod-bench-mainnet-ephemeral.toml
+++ b/docs/example_configs/zainod-bench-mainnet-ephemeral.toml
@@ -1,0 +1,46 @@
+# Zaino mainnet benchmark configuration — ephemeral finalised state
+#
+# Identical to `zainod-bench-mainnet.toml` except for
+# `ephemeral_finalised_state`. In ephemeral mode Zaino keeps no finalised-state
+# database of its own and serves finalised reads by passthrough to the
+# validator, so `serve` and `concurrent` exercise a genuinely different path.
+# `docs/perf.md` reports both.
+#
+# There is nothing to sync in this mode, so `zaino-bench sync` does not apply:
+# the `zaino.sync.*` gauges it reads are never emitted, and it will sit waiting
+# for a metric that never arrives. Sync is a persistent-mode measurement.
+#
+#   cargo build --release -p zainod --features prometheus
+#   zainod start --config docs/example_configs/zainod-bench-mainnet-ephemeral.toml
+
+backend = 'direct'
+zebra_db_path = '/mnt/framework_ssd/.cache/zebra'
+network = 'Mainnet'
+
+# The ephemeral half of the pair — the one line that differs.
+ephemeral_finalised_state = true
+
+metrics_endpoint = '127.0.0.1:9998'
+
+[grpc_settings]
+listen_address = '127.0.0.1:8137'
+
+[validator_settings]
+validator_grpc_listen_address = '127.0.0.1:18230'
+validator_jsonrpc_listen_address = '127.0.0.1:18232'
+validator_user = 'xxxxxx'
+validator_password = 'xxxxxx'
+
+[service]
+timeout = 30
+channel_size = 32
+
+[storage.cache]
+capacity = 10000
+shard_power = 4
+
+# Still required by the config schema, and still the cache location, even though
+# no finalised-state database is written here in ephemeral mode.
+[storage.database]
+path = '/mnt/framework_ssd/.cache/zaino'
+size = 384

--- a/docs/example_configs/zainod-bench-mainnet.toml
+++ b/docs/example_configs/zainod-bench-mainnet.toml
@@ -1,0 +1,72 @@
+# Zaino mainnet benchmark configuration — persistent finalised state
+#
+# The node config behind the numbers in `docs/perf.md`. Paths and ports match
+# the measuring host; change them for yours, but keep the two choices that make
+# the numbers mean what they claim:
+#
+#   backend = 'direct'                  the fastest path Zaino has
+#   ephemeral_finalised_state = false   Zaino answers from its own index
+#
+# Pair it with `zainod-bench-mainnet-ephemeral.toml`, which flips the second.
+# `docs/perf.md` reports the serve and concurrency numbers under both.
+#
+# zainod must be built with the `prometheus` feature for `metrics_endpoint` to
+# bind — `zaino-bench sync` reads sync progress from there:
+#
+#   cargo build --release -p zainod --features prometheus
+#   zainod start --config docs/example_configs/zainod-bench-mainnet.toml
+#
+# See `packages/zaino-bench/usage.md` for the full run procedure.
+
+# "direct" reads Zebra's ReadStateService in-process; requires zainod and zebrad
+# on the same host. ("state" is the legacy spelling of the same value.) The
+# alternative, "rpc" ("fetch"), goes over JSON-RPC — a different question.
+backend = 'direct'
+
+# Zebra's `[state] cache_dir`, verbatim.
+zebra_db_path = '/mnt/framework_ssd/.cache/zebra'
+
+network = 'Mainnet'
+
+# The persistent half of the pair: Zaino keeps its own finalised-state database
+# and serves finalised reads from it.
+ephemeral_finalised_state = false
+
+# Where `zaino-bench sync` scrapes progress from. Requires --features prometheus;
+# the field parses either way, it just has no effect without it.
+metrics_endpoint = '127.0.0.1:9998'
+
+[grpc_settings]
+listen_address = '127.0.0.1:8137'
+
+[validator_settings]
+# Must match zebrad.toml's `[rpc]`, and the two must differ from each other
+# (zainod rejects a config where they collide):
+#
+#   [rpc]
+#   listen_addr         = '127.0.0.1:18232'   -> validator_jsonrpc_listen_address
+#   indexer_listen_addr = '127.0.0.1:18230'   -> validator_grpc_listen_address
+#
+# The gRPC address is required by the Direct backend; zainod refuses to start on
+# Direct without it.
+validator_grpc_listen_address = '127.0.0.1:18230'
+validator_jsonrpc_listen_address = '127.0.0.1:18232'
+validator_user = 'xxxxxx'
+validator_password = 'xxxxxx'
+
+# Left at defaults for the published numbers. `channel_size` in particular
+# bounds concurrency, so raising it changes the answer to "how many connections
+# can you support" — if you tune it, say so in docs/perf.md alongside the number.
+[service]
+timeout = 30
+channel_size = 32
+
+[storage.cache]
+capacity = 10000
+shard_power = 4
+
+[storage.database]
+path = '/mnt/framework_ssd/.cache/zaino'
+# GiB. A full mainnet index is ~275 GiB, so this needs headroom above that and
+# the volume needs the free space to match.
+size = 384

--- a/docs/example_configs/zainod-bench-mainnet.toml
+++ b/docs/example_configs/zainod-bench-mainnet.toml
@@ -24,7 +24,7 @@
 backend = 'direct'
 
 # Zebra's `[state] cache_dir`, verbatim.
-zebra_db_path = '/mnt/framework_ssd/.cache/zebra'
+zebra_db_path = '/home/idky137/.cache/zebra/'
 
 network = 'Mainnet'
 
@@ -66,7 +66,7 @@ capacity = 10000
 shard_power = 4
 
 [storage.database]
-path = '/mnt/framework_ssd/.cache/zaino'
+path = '/home/idky137/.cache/zaino/'
 # GiB. A full mainnet index is ~275 GiB, so this needs headroom above that and
 # the volume needs the free space to match.
 size = 384

--- a/docs/example_configs/zainod-bench-mainnet.toml
+++ b/docs/example_configs/zainod-bench-mainnet.toml
@@ -67,6 +67,7 @@ shard_power = 4
 
 [storage.database]
 path = '/home/idky137/.cache/zaino/'
-# GiB. A full mainnet index is ~275 GiB, so this needs headroom above that and
+# GiB. Measured: a full mainnet index is ~76 GiB at height 3.45M. This is the map
+# size (an upper bound, not a reservation), so leave headroom above that and
 # the volume needs the free space to match.
 size = 384

--- a/docs/example_configs/zainod-bench-mainnet.toml
+++ b/docs/example_configs/zainod-bench-mainnet.toml
@@ -24,7 +24,7 @@
 backend = 'direct'
 
 # Zebra's `[state] cache_dir`, verbatim.
-zebra_db_path = '/home/idky137/.cache/zebra/'
+zebra_db_path = '<PATH_TO_ZEBRA>'
 
 network = 'Mainnet'
 
@@ -66,7 +66,7 @@ capacity = 10000
 shard_power = 4
 
 [storage.database]
-path = '/home/idky137/.cache/zaino/'
+path = '<ZAINO_CACHE>'
 # GiB. Measured: a full mainnet index is ~76 GiB at height 3.45M. This is the map
 # size (an upper bound, not a reservation), so leave headroom above that and
 # the volume needs the free space to match.

--- a/docs/example_configs/zainod.toml
+++ b/docs/example_configs/zainod.toml
@@ -11,7 +11,7 @@
 #   https://github.com/zingolabs/zaino
 
 backend = 'fetch'
-zebra_db_path = '/home/cupress/.cache/zebra'
+zebra_db_path = '<PATH_TO_ZEBRA>'
 network = 'Testnet'
 
 # Run the finalised state in ephemeral/stateless mode. When true, Zaino opens no
@@ -36,7 +36,7 @@ capacity = 10000
 shard_power = 4
 
 [storage.database]
-path = '/home/cupress/.cache/zaino'
+path = '<ZAINO_CACHE>'
 size = 128
 # Heap budget (in GiB) for the bulk-sync write batch (buffered blocks only). Lower this on
 # memory-constrained hosts; a larger value does not speed up a small host, it just risks the

--- a/docs/example_configs/zebrad_config_3.1.0.toml
+++ b/docs/example_configs/zebrad_config_3.1.0.toml
@@ -76,7 +76,7 @@ network = "Testnet"
 peerset_initial_target_size = 25
 
 [rpc]
-cookie_dir = "/home/cupress/.cache/zebra"
+cookie_dir = "<PATH_TO_ZEBRA>"
 debug_force_finished_sync = false
 enable_cookie_auth = false
 max_response_body_size = 52428800
@@ -85,7 +85,7 @@ listen_addr = '127.0.0.1:18231'
 indexer_listen_addr = '127.0.0.1:18232'
 
 [state]
-cache_dir = "/home/cupress/.cache/zebra"
+cache_dir = "<PATH_TO_ZEBRA>"
 delete_old_database = true
 ephemeral = false
 should_backup_non_finalized_state = true

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -22,10 +22,15 @@ finalised-state modes, because they measure different machinery:
 Initial sync is a persistent-mode measurement only — in ephemeral mode there is
 no index to build.
 
-> **Status: not yet measured.** The harness and configs are in place; the
-> mainnet runs have not been done. Every `TBD` below is a value to fill in from
-> a real run — do not quote this document until they are filled, and complete
-> the [Test configuration](#test-configuration) section in the same pass.
+> **Status: initial sync measured; concurrency and serve rate not yet.**
+> Section 1 is filled in from a real mainnet run. Sections 2 and 3 are still
+> `TBD` — do not quote them.
+>
+> **These numbers are not `dev`.** They were produced on
+> `add_sync_plus_concurrency_tests` at commit `14720e74`, which carries three
+> bulk-sync performance changes not yet on `dev` (pipelined batch commits,
+> concurrent block fetch, concurrent block assembly). A `dev` measurement would
+> be materially slower and is not recorded here.
 
 ---
 
@@ -37,7 +42,7 @@ finalised-state database removed beforehand. Persistent mode
 
 | Configuration | Blocks synced | Wall-clock | Mean blocks/s |
 |---|---|---|---|
-| Direct backend (`backend = 'direct'`) | TBD | TBD | TBD |
+| Direct backend (`backend = 'direct'`) | 3,337,015 | **4h 43m** (16,981s) | **196** |
 | RPC backend (`backend = 'rpc'`) | TBD | TBD | TBD |
 
 The RPC row is worth having for contrast: it is what Zaino can do against a
@@ -45,7 +50,54 @@ validator it does not share a machine with, and the gap between the rows is the
 value of co-location. It is optional — record it only if a second full sync is
 worth the wall-clock.
 
-Sync curve: `sync-mainnet.csv` (from `--csv`), columns `elapsed_secs,
+### The mean hides the shape of the run
+
+Sync rate varies by more than two orders of magnitude across the chain, and one
+narrow band of heights dominates the wall-clock:
+
+| Region | Heights | Blocks | Wall-clock | Blocks/s | Share of blocks | Share of time |
+|---|---|---|---|---|---|---|
+| Pre-sandblast | 107,349–1,705,519 | 1,598,170 | 12m 23s | 2,151 | 48% | 4% |
+| **Sandblast** | 1,705,519–1,823,494 | 117,975 | **3h 12m** | **10.3** | **3.5%** | **68%** |
+| Post-sandblast | 1,823,494–3,444,364 | 1,620,870 | 1h 19m | 342 | 49% | 28% |
+
+**The sandblast heights are 3.5% of the chain and 68% of the sync.** A mean
+blocks/s figure quoted without this is close to meaningless: the same node does
+2,151 blocks/s before height 1.7M and 10 blocks/s just after it.
+
+The cause is measured, not inferred. A profile through that band puts ~91% of
+cycles in BLS12-381 scalar arithmetic — `sqrt_tonelli_shanks`, `Scalar::square`,
+`Scalar::invert` — against ~1% in LMDB. That is Jubjub point decompression:
+zebra's deserializer resolves `cv` and `ephemeral_key` into curve points for
+every Sapling output, and Zaino re-serialises them to store the compact form.
+Sandblast-era blocks carry hundreds of outputs each. Both directions are work
+Zaino does not need — the bytes are already on disk in compressed form — and
+removing rather than parallelising it is an upstream `zebra-chain` change (lazy
+`cv` / `ephemeral_key` decompression).
+
+### Caveats on these numbers
+
+Three things about how this run was measured, all of which affect how much
+weight the figures carry:
+
+- **The first 107,349 blocks are not in the window.** `zaino.sync.finalized_height`
+  is only emitted once the write loop's throttled progress branch first fires,
+  so the harness's t0 lands after the node has already synced its first batch.
+  Wall-clock from zainod start is roughly 50s longer than the 16,981s recorded.
+- **The run ended on the harness's stall timeout, not on completion.** The
+  durable tip (`zaino.db.tip_height`) reached the target 3,454,128 — the sync
+  finished — but the fetch-pointer gauge the harness watches stopped updating at
+  3,444,364, so `--stall-timeout-secs` fired 890s later. That final flat period
+  is excluded above; no sync work was outstanding during it. Two harness bugs to
+  fix before the next run: completion should be read from `zaino.db.tip_height`
+  rather than the fetch pointer, and the `--csv` curve should be written even
+  when the run ends in an error (it currently is not, so this run has no curve).
+- **The index is 76 GiB, not ~275 GiB.** That is the measured on-disk size at
+  the target height, and it contradicts the estimate in
+  `zainod-bench-mainnet.toml`. The config comment should be corrected.
+
+Sync curve: not captured for this run (see the second caveat above). When it is,
+`--csv` writes `elapsed_secs,
 finalized_height, target_height, lag_blocks, node_lag_gauge, db_tip_height,
 chain_tip_height, transactions_total, interval_blocks_per_sec`. `lag_blocks` is
 derived as `target - finalized`; `node_lag_gauge` is the node's own
@@ -119,13 +171,20 @@ Every field here changes the numbers above.
 
 | | |
 |---|---|
-| CPU | TBD |
-| RAM | TBD |
-| Disk | `/mnt/framework_ssd` — zebrad's and Zaino's databases share this volume |
+| CPU | AMD Ryzen 7 7840U, 16 threads |
+| RAM | 61 GiB |
+| Disk | **WD_BLACK SN850X NVMe** (LUKS + LVM, mounted at `/`) — zebrad's and Zaino's databases share this volume |
 | OS / kernel | Linux 6.1.0-40-amd64 (Debian) |
-| `ulimit -n` (client) | TBD — raise before the sweep |
-| `net.ipv4.tcp_slow_start_after_idle` | TBD — set to `0`; see below |
+| `ulimit -n` (client) | 1048576 |
+| `net.ipv4.tcp_slow_start_after_idle` | `0` |
 | zebrad co-located | yes — Direct backend requires it |
+
+**The disk matters more than anything else in this table.** An earlier attempt at
+this run used a USB-attached external drive (reported rotational, queue depth
+60), which served random reads at 2,577 IOPS / 0.31 ms against the SN850X's
+0.096 ms. On that volume the batch commit alone took 162s per 100k blocks and
+consumed 93% of wall-clock; on NVMe it is 38.5s per 100k and ~85%. No number in
+this document should be quoted against a non-NVMe volume.
 
 `tcp_slow_start_after_idle` defaults to `1`, which resets TCP's congestion
 window after an idle period. zebrad warns about it at startup for its own block
@@ -141,7 +200,7 @@ sudo sysctl -w net.ipv4.tcp_slow_start_after_idle=0
 
 | | |
 |---|---|
-| zaino | TBD (commit) |
+| zaino | `14720e74` (branch `add_sync_plus_concurrency_tests`, **not `dev`** — see the status note) |
 | zebrad | 6.3.0, git `f5c5277`, opt-level 3, **`debug checks: true`** |
 | Zebra state format | v28 (matches `zebra-state 13.0`; no migration on open) |
 | rustc | see `rust-toolchain.toml` |
@@ -206,10 +265,11 @@ makers bench serve --server http://127.0.0.1:8137 --start-height 3300000
 zainod start --config docs/example_configs/zainod-bench-mainnet-ephemeral.toml
 ```
 
-**Disk space.** A full mainnet Zaino index is ~275 GiB, alongside zebrad's
-~260 GiB on the same volume. Confirm the free space covers a fresh sync *before*
-starting one — an old index backup left in place is enough to run the volume out
-partway through, and the sync run is long enough that losing it hurts.
+**Disk space.** Measured on this run: the Zaino index is **76 GiB** at height
+3,454,128, alongside zebrad's 260 GiB on the same volume. (The ~275 GiB figure in
+`zainod-bench-mainnet.toml` is a large overestimate and should be corrected.)
+Confirm the free space covers a fresh sync *before* starting one — the sync run
+is long enough that losing it partway hurts.
 
 ---
 

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -22,10 +22,11 @@ finalised-state modes, because they measure different machinery:
 Initial sync is a persistent-mode measurement only — in ephemeral mode there is
 no index to build.
 
-> **Status: all three sections measured.** Section 2a carries a significant
-> methodological caveat — the persistent sweep did not achieve the concurrency
-> its connection counts imply — which is documented inline. Read it before
-> quoting a supported-connection figure.
+> **Status: all three sections measured.** The concurrency figures in section 2
+> are 5,000 connections at 100% success in both modes — but 5,000 is the largest
+> count tested, not a ceiling, and it is bounded by an LMDB reader limit this
+> branch changed. Read "The ceiling is the LMDB reader table" before quoting a
+> supported-connection number.
 >
 > **These numbers are not `dev`.** They were produced on
 > `add_sync_plus_concurrency_tests` at commit `14720e74`, which carries three
@@ -109,73 +110,89 @@ derived as `target - finalized`; `node_lag_gauge` is the node's own
 `zaino-bench concurrent --sweep`, against the synced instance. Each connection
 streams 1000 blocks from its own window of the pool.
 
-Both sweeps used `--blocks 200` over the pool `3000000..=3380000`.
+Both sweeps used `--blocks 200` over the pool `3000000..=3380000`, with every
+connection held open at a barrier until all of them had dialled, so the fetch
+phase begins with the full connection count established.
 
 ### 2a. Persistent finalised state
 
-| Connections | Success | Wall-clock | Mean fetch | p95 fetch | Aggregate blocks/s | Chain breaks | Mean in flight |
-|---|---|---|---|---|---|---|---|
-| 100 | 100% | 0.25s | 0.040s | 0.051s | 81,316 | 0 | 16 |
-| 500 | 100% | 1.08s | 0.039s | 0.050s | 92,821 | 0 | 18 |
-| 1000 | 100% | 2.11s | 0.040s | 0.050s | 94,630 | 0 | 19 |
-| 2000 | 100% | 4.19s | 0.040s | 0.050s | 95,470 | 0 | 19 |
-| 5000 | 100% | 5.40s | 0.039s | 0.050s | 185,266 | 0 | 36 |
-| 10000 | 100% | 10.59s | 0.040s | 0.050s | 188,878 | 0 | 38 |
+| Connections | Success | Wall-clock | Mean fetch | Aggregate blocks/s | Chain breaks | Mean in flight |
+|---|---|---|---|---|---|---|
+| 100 | 100% | 0.20s | 0.098s | 100,088 | 0 | 49 |
+| 500 | 100% | 0.48s | 0.315s | 209,945 | 0 | 328 |
+| 1000 | 100% | 0.97s | 0.666s | 205,890 | 0 | 687 |
+| 2000 | 100% | 2.03s | 1.877s | 196,684 | 0 | 1,849 |
+| 5000 | 100% | 4.95s | 4.027s | 201,936 | 0 | 4,068 |
 
-**Supported concurrent connections: not established by this run.** Every round
-reports 100% success with flat latency, but the run did not hold its connections
-open, so the connection counts in the first column are not concurrency. Read the
-next section before quoting any of these figures.
+**5,000 concurrent connections at 100% success, no chain breaks — and that is
+the largest count tested, not a measured ceiling.** The knee is somewhere above
+5,000; this run did not find it.
 
-#### Why the persistent sweep is not a concurrency measurement
-
-A finalised read from Zaino's own index takes ~40ms for 200 blocks. The harness
-brings connections up across a 2s ramp, so at 10,000 connections a new one starts
-every 200µs — and each finishes 40ms later. Connections retire about as fast as
-they are created, and the number actually open at any instant is
-`connections × mean fetch ÷ wall-clock`: the last column above, which never
-exceeds 38 regardless of the nominal count.
-
-Two independent checks agree. The client's `ulimit -n` was **8192** for this run
-(the harness warned), which cannot support 10,000 simultaneous sockets — yet all
-10,000 succeeded. And wall-clock scales linearly with the connection count
-(0.25s → 10.59s for 100 → 10,000), which is the signature of sequential work,
-not of concurrent work hitting a ceiling.
-
-What this row set *does* establish: the server absorbed 10,000 successive
-short requests at 100% success, with p99 fetch latency flat at 0.052s from 100
-through 10,000 and no chain breaks. That is a real result about throughput and
-stability. It is not the answer to "how many concurrent connections can it
-support", and the honest answer to that question from this run is that the
-harness cannot reach the ceiling on the persistent backend: per-connection work
-would have to outlast the ramp. Raising `--blocks` until mean fetch exceeds the
-ramp (or lowering `--spawn-window-ms`) is the fix, and `ulimit -n` must be raised
-past `2 × connections` first.
+Aggregate throughput plateaus at **~200,000 blocks/s** from 500 connections
+onward while mean fetch latency scales linearly with the connection count
+(0.098s → 4.027s). That is a saturated server queuing gracefully: added clients
+wait longer, they do not fail.
 
 ### 2b. Ephemeral finalised state
 
 | Connections | Success | Wall-clock | Mean fetch | Aggregate blocks/s | Chain breaks | Mean in flight |
 |---|---|---|---|---|---|---|
-| 100 | 100% | 2.41s | 1.758s | 8,284 | 0 | 73 |
-| 500 | 100% | 10.51s | 8.829s | 9,514 | 0 | 420 |
-| 1000 | 100% | 20.92s | 18.263s | 9,559 | 0 | 873 |
-| 2000 | 100% | 43.56s | 38.151s | 9,182 | 0 | 1,752 |
-| 5000 | 100% | 113.73s | 104.477s | 8,793 | 0 | 4,593 |
-| 10000 | **2.9%** | 134.61s | 109.848s | 437 | 0 | 8,160 |
+| 100 | 100% | 2.19s | 1.761s | 9,150 | 0 | 80 |
+| 500 | 100% | 9.53s | 9.198s | 10,494 | 0 | 483 |
+| 1000 | 100% | 20.58s | 20.208s | 9,720 | 0 | 982 |
+| 2000 | 100% | 42.72s | 42.284s | 9,364 | 0 | 1,980 |
+| 5000 | 100% | 110.28s | 109.522s | 9,068 | 0 | 4,966 |
 
-**Supported concurrent connections: 5,000.**
+**Also 5,000 at 100%, and also not a ceiling.** Aggregate throughput is flat at
+~9,400 blocks/s from 100 connections on — **~21× below persistent** — which
+places the limit in the validator passthrough rather than in Zaino's request
+handling. Mean fetch reaches 109s at 5,000 connections, well past the 30s
+`service.timeout`, so these are slow but not failing.
 
-This sweep *is* a concurrency measurement, and the contrast with 2a is the
-reason. In ephemeral mode a finalised read is a passthrough to the validator and
-takes seconds, not milliseconds — far longer than the 2s ramp — so connections
-accumulate instead of retiring, and the in-flight count tracks the nominal one
-(4,593 of 5,000). The knee is unambiguous: 100% success through 5,000, then
-collapse to 2.9% at 10,000, with mean fetch already at 104s by 5,000 against the
-30s `service.timeout`.
+### Reading these tables
 
-Aggregate throughput is flat at ~9,000 blocks/s from 100 connections onward,
-which says the ceiling is the validator passthrough rather than anything in
-Zaino's own request handling.
+Three things determine how much weight they carry:
+
+- **They are genuine concurrency measurements, unlike an earlier attempt.** The
+  "mean in flight" column is `connections × mean fetch ÷ wall-clock` — what was
+  actually open at once. It tracks the nominal count closely (4,068 of 5,000
+  persistent, 4,966 of 5,000 ephemeral). Before the harness held connections at a
+  barrier, the same sweep never had more than 38 open regardless of the count
+  asked for, because short reads retired faster than the ramp created them.
+- **The client was the tighter constraint at 5,000.** `ulimit -n` was 8192 during
+  these runs, and 5,000 connections need roughly 10,000 descriptors — the harness
+  warned. So the 5,000 row is bounded at least partly by the client, and a rerun
+  above `ulimit -n 32768` may well go further.
+- **The persistent figures are warm-cache.** The first run after a restart gave
+  ~110,000 blocks/s aggregate against ~200,000 on the two subsequent runs; the
+  table reports the steady state. Two consecutive warm runs agreed within 5%.
+
+### The ceiling is the LMDB reader table, and exceeding it restarts the node
+
+The concurrency limit is not a throughput property — it is the size of LMDB's
+reader table, and it is worth stating plainly because the failure mode is bad.
+
+The environment is opened with `NO_TLS`, so a reader slot belongs to a read
+*transaction* rather than a thread: every concurrent read holds one. Slots are
+sized by `(cpu × 32).clamp(MIN_LMDB_READERS, MAX_LMDB_READERS)`. **On this
+16-core host the applied value is 2,048** — the clamp floor, since `16 × 32 =
+512` falls below it. Confirmed by measurement: `lock.mdb` is 131,200 bytes,
+which is `2048 × 64B` plus a 128-byte header.
+
+An earlier attempt at this sweep ran against the previous floor of 512 and did
+not merely fail — it **restarted the node in a loop**. Reads failed with
+`MDB_READERS_FULL`, the startup block scan
+(`finalised_source/v1.rs`) treats any error from it as fatal and stored
+`CriticalError`, the indexer restarted into the same load, and the cycle
+repeated. The gRPC port disappeared and every client saw a transport error.
+
+**Raising the floor to 2,048 is what made these tables possible; it did not fix
+the underlying defect.** A client can still open more concurrent reads than
+there are slots, and `MDB_READERS_FULL` — which is backpressure, not corruption —
+is still classified as critical. Until that classification changes, any client
+can restart a Zaino node by exceeding whatever limit is configured. Treat the
+supported-connection figures here as properties of *this configuration*, not of
+Zaino.
 
 ### Knobs that bound these numbers
 
@@ -187,11 +204,14 @@ a number quoted without them is not reproducible:
 | `service.channel_size` | `ZainodConfig` | 32 (default) |
 | `service.timeout` | `ZainodConfig` | 30s (default) |
 | `storage.cache.capacity` | `ZainodConfig` | 10000 (default) |
-| Client `ulimit -n` | test host | **8192 — too low for the 10,000 round** (needs 20,000) |
+| `storage.database` LMDB `max_readers` | derived, `finalised_source/v1.rs` | **2048** (the clamp floor; `16 cores × 32 = 512` falls below it) |
+| Client `ulimit -n` | test host | **8192 — below the ~10,000 that 5,000 connections need** |
 
-The `ulimit -n` row is not a footnote: at 8192 the client cannot hold 10,000
-sockets open, which is part of why the persistent sweep never reached its nominal
-concurrency. Raise it before any rerun.
+Both bottom rows bound the results rather than describing the host. `max_readers`
+is the concurrency ceiling (see above), and at `ulimit -n 8192` the client cannot
+hold 5,000 connections' worth of descriptors — so the 5,000 row is bounded at
+least partly by the test client. Raise both before treating any figure here as
+Zaino's limit.
 
 If a tuned run is also recorded, it goes in its own table naming the knob that
 moved — a tuned number presented as the default is misleading.
@@ -318,7 +338,7 @@ ulimit -n 32768          # must exceed 2 x the largest sweep value
 makers bench concurrent \
   --server http://127.0.0.1:8137 \
   --start-height 3000000 --end-height 3380000 \
-  --blocks 200 --sweep 100,500,1000,2000,5000,10000
+  --blocks 200 --sweep 100,500,1000,2000,5000
 # --end-height pinned, not defaulted to the tip: the two modes report different
 # tips, and an unpinned range makes the persistent and ephemeral rows different
 # amounts of work.

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -295,7 +295,7 @@ numbers; a validator build is part of the configuration.
 and [`zainod-bench-mainnet-ephemeral.toml`](example_configs/zainod-bench-mainnet-ephemeral.toml),
 built with `--features prometheus` (required for the `sync` measurement).
 
-**zebrad** — `[state] cache_dir = '/home/idky137/.cache/zebra'`,
+**zebrad** — `[state] cache_dir = '<PATH_TO_ZEBRA>'`,
 `[rpc] listen_addr = '127.0.0.1:18232'`, `indexer_listen_addr = '127.0.0.1:18230'`.
 Record any other non-default `[state]` or `[sync]` settings.
 
@@ -329,7 +329,7 @@ cargo build --release -p zaino-bench
 # 1. Initial sync, persistent mode. Start the harness first, so t0 is the
 #    moment zainod starts. Removing the database is what makes it an *initial*
 #    sync rather than a catch-up — check free space first (see below).
-rm -rf ~/.cache/zaino/*
+rm -rf <ZAINO_CACHE>/*
 makers bench sync --csv sync-mainnet.csv
 zainod start --config docs/example_configs/zainod-bench-mainnet.toml
 

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -1,0 +1,223 @@
+# Zaino performance
+
+Three numbers, and the configuration that produced them. The numbers are
+meaningless without the configuration, so the two live in one document and are
+updated together.
+
+Everything here is produced by `zaino-bench` — see
+[`packages/zaino-bench/usage.md`](../packages/zaino-bench/usage.md) for the run
+procedure. Every result is measured on the **Direct backend**: Direct reads
+Zebra's `ReadStateService` in-process, which is the fastest path Zaino has and
+therefore the honest ceiling to quote. It requires zainod and zebrad on the same
+host.
+
+The serve and concurrency sections are reported **twice**, under the two
+finalised-state modes, because they measure different machinery:
+
+| Mode | `ephemeral_finalised_state` | What answers a finalised read |
+|---|---|---|
+| Persistent | `false` | Zaino's own finalised-state index |
+| Ephemeral | `true` | passthrough to the validator |
+
+Initial sync is a persistent-mode measurement only — in ephemeral mode there is
+no index to build.
+
+> **Status: not yet measured.** The harness and configs are in place; the
+> mainnet runs have not been done. Every `TBD` below is a value to fill in from
+> a real run — do not quote this document until they are filled, and complete
+> the [Test configuration](#test-configuration) section in the same pass.
+
+---
+
+## 1. Initial sync — mainnet, from genesis
+
+`zaino-bench sync`, against a fully synced mainnet zebrad, with Zaino's
+finalised-state database removed beforehand. Persistent mode
+([`zainod-bench-mainnet.toml`](example_configs/zainod-bench-mainnet.toml)).
+
+| Configuration | Blocks synced | Wall-clock | Mean blocks/s |
+|---|---|---|---|
+| Direct backend (`backend = 'direct'`) | TBD | TBD | TBD |
+| RPC backend (`backend = 'rpc'`) | TBD | TBD | TBD |
+
+The RPC row is worth having for contrast: it is what Zaino can do against a
+validator it does not share a machine with, and the gap between the rows is the
+value of co-location. It is optional — record it only if a second full sync is
+worth the wall-clock.
+
+Sync curve: `sync-mainnet.csv` (from `--csv`), columns `elapsed_secs,
+finalized_height, target_height, lag_blocks, db_tip_height, chain_tip_height,
+transactions_total, interval_blocks_per_sec`.
+
+## 2. Concurrent connections
+
+`zaino-bench concurrent --sweep`, against the synced instance. Each connection
+streams 1000 blocks from its own window of the pool.
+
+### 2a. Persistent finalised state
+
+| Connections | Success | Wall-clock | Mean fetch | p95 fetch | Aggregate blocks/s | Chain breaks |
+|---|---|---|---|---|---|---|
+| 100 | TBD | TBD | TBD | TBD | TBD | TBD |
+| 250 | TBD | TBD | TBD | TBD | TBD | TBD |
+| 500 | TBD | TBD | TBD | TBD | TBD | TBD |
+| 1000 | TBD | TBD | TBD | TBD | TBD | TBD |
+| 2000 | TBD | TBD | TBD | TBD | TBD | TBD |
+
+**Supported concurrent connections: TBD** — the largest row still at 100%
+success, with no chain breaks.
+
+### 2b. Ephemeral finalised state
+
+| Connections | Success | Wall-clock | Mean fetch | p95 fetch | Aggregate blocks/s | Chain breaks |
+|---|---|---|---|---|---|---|
+| 100 | TBD | TBD | TBD | TBD | TBD | TBD |
+| 250 | TBD | TBD | TBD | TBD | TBD | TBD |
+| 500 | TBD | TBD | TBD | TBD | TBD | TBD |
+| 1000 | TBD | TBD | TBD | TBD | TBD | TBD |
+| 2000 | TBD | TBD | TBD | TBD | TBD | TBD |
+
+**Supported concurrent connections: TBD.**
+
+### Knobs that bound these numbers
+
+Both sweeps were run at **default** settings. These cap concurrency directly, so
+a number quoted without them is not reproducible:
+
+| Knob | Where | Value used |
+|---|---|---|
+| `service.channel_size` | `ZainodConfig` | 32 (default) |
+| `service.timeout` | `ZainodConfig` | 30s (default) |
+| `storage.cache.capacity` | `ZainodConfig` | 10000 (default) |
+| Client `ulimit -n` | test host | TBD |
+
+If a tuned run is also recorded, it goes in its own table naming the knob that
+moved — a tuned number presented as the default is misleading.
+
+## 3. Block serve rate
+
+`zaino-bench serve`, one connection, one `GetBlockRange` stream, timed from the
+request. The same pass verifies every `prev_hash` link.
+
+| Mode | Range | Blocks | Wall-clock | Blocks/s | Payload MB/s | Errors |
+|---|---|---|---|---|---|---|
+| Persistent | TBD..=tip | TBD | TBD | TBD | TBD | TBD |
+| Ephemeral | TBD..=tip | TBD | TBD | TBD | TBD | TBD |
+
+Aggregate (multi-connection) throughput is the last column of the sweep tables in
+section 2; this section is the single-stream figure.
+
+---
+
+## Test configuration
+
+Every field here changes the numbers above.
+
+**Host**
+
+| | |
+|---|---|
+| CPU | TBD |
+| RAM | TBD |
+| Disk | `/mnt/framework_ssd` — zebrad's and Zaino's databases share this volume |
+| OS / kernel | Linux 6.1.0-40-amd64 (Debian) |
+| `ulimit -n` (client) | TBD — raise before the sweep |
+| `net.ipv4.tcp_slow_start_after_idle` | TBD — set to `0`; see below |
+| zebrad co-located | yes — Direct backend requires it |
+
+`tcp_slow_start_after_idle` defaults to `1`, which resets TCP's congestion
+window after an idle period. zebrad warns about it at startup for its own block
+fetching, and it applies just as much to the load generator, whose connections
+are idle between spawn and fetch. Set it to `0` before measuring and record
+which value was in force:
+
+```sh
+sudo sysctl -w net.ipv4.tcp_slow_start_after_idle=0
+```
+
+**Versions**
+
+| | |
+|---|---|
+| zaino | TBD (commit) |
+| zebrad | 6.3.0, git `f5c5277`, opt-level 3, **`debug checks: true`** |
+| Zebra state format | v28 (matches `zebra-state 13.0`; no migration on open) |
+| rustc | see `rust-toolchain.toml` |
+
+The zebrad build has `debug_assertions` compiled in, which slows the validator.
+It affects the Direct-backend rows least — Zaino reads Zebra's database rather
+than asking it questions — but it bounds the optional RPC-backend row and
+zebra's ability to hold the tip during a long run. Quote it alongside the
+numbers; a validator build is part of the configuration.
+
+**zainod** — [`zainod-bench-mainnet.toml`](example_configs/zainod-bench-mainnet.toml)
+and [`zainod-bench-mainnet-ephemeral.toml`](example_configs/zainod-bench-mainnet-ephemeral.toml),
+built with `--features prometheus` (required for the `sync` measurement).
+
+**zebrad** — `[state] cache_dir = '/mnt/framework_ssd/.cache/zebra'`,
+`[rpc] listen_addr = '127.0.0.1:18232'`, `indexer_listen_addr = '127.0.0.1:18230'`.
+Record any other non-default `[state]` or `[sync]` settings.
+
+**Validator must be holding the tip.** Confirm before each run, and record the
+connected peer count — a validator running on a handful of peers can fall behind
+mid-measurement, which moves the sync target and leaves the concurrency sweep
+reading a chain that is still advancing:
+
+```sh
+curl -s -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getblockchaininfo","params":[]}' \
+  http://127.0.0.1:18232 | python3 -m json.tool | grep -E 'blocks|headers|verificationprogress'
+curl -s -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"getpeerinfo","params":[]}' \
+  http://127.0.0.1:18232 | python3 -c 'import json,sys; print("peers:", len(json.load(sys.stdin)["result"]))'
+```
+
+A stale `network/mainnet.peers` cache is the usual cause of a low peer count:
+delete it and let the DNS seeds repopulate. Note that `[network] cache_dir = true`
+means "the default directory", so the peer cache does not follow
+`[state] cache_dir` onto the same volume.
+
+**Commands**
+
+```sh
+# 0. Host prep, then build. zainod needs the prometheus feature for step 1.
+sudo sysctl -w net.ipv4.tcp_slow_start_after_idle=0
+cargo build --release -p zainod --features prometheus
+cargo build --release -p zaino-bench
+
+# 1. Initial sync, persistent mode. Start the harness first, so t0 is the
+#    moment zainod starts. Removing the database is what makes it an *initial*
+#    sync rather than a catch-up — check free space first (see below).
+rm -rf /mnt/framework_ssd/.cache/zaino/*
+makers bench sync --csv sync-mainnet.csv
+zainod start --config docs/example_configs/zainod-bench-mainnet.toml
+
+# 2 + 3. Against the now-synced instance, persistent mode.
+ulimit -n 8192
+makers bench concurrent \
+  --server http://127.0.0.1:8137 \
+  --start-height 3000000 --end-height 3380000 \
+  --blocks 1000 --sweep 100,250,500,1000,2000
+makers bench serve --server http://127.0.0.1:8137 --start-height 3300000
+
+# 4. Restart zainod on the ephemeral config, then repeat 2 + 3 unchanged.
+zainod start --config docs/example_configs/zainod-bench-mainnet-ephemeral.toml
+```
+
+**Disk space.** A full mainnet Zaino index is ~275 GiB, alongside zebrad's
+~260 GiB on the same volume. Confirm the free space covers a fresh sync *before*
+starting one — an old index backup left in place is enough to run the volume out
+partway through, and the sync run is long enough that losing it hurts.
+
+---
+
+## Prior art
+
+The `concurrent` and `serve` tools were ported from the `zaino-admin` binary on
+the `hahn/store` branch (`hhanh00/zaino`, commit `14401f07`), which measured a
+different indexer — an LMDB block store that branch also introduced — against a
+Zaino of that vintage. Those numbers are not comparable to the ones above and are
+deliberately not reproduced here: this document measures the `dev` indexer on the
+Direct backend. The harness, the sweep, the tail percentiles, the ephemeral /
+persistent split, and the metrics-based sync measurement are additions on this
+side.

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -22,9 +22,10 @@ finalised-state modes, because they measure different machinery:
 Initial sync is a persistent-mode measurement only — in ephemeral mode there is
 no index to build.
 
-> **Status: initial sync measured; concurrency and serve rate not yet.**
-> Section 1 is filled in from a real mainnet run. Sections 2 and 3 are still
-> `TBD` — do not quote them.
+> **Status: all three sections measured.** Section 2a carries a significant
+> methodological caveat — the persistent sweep did not achieve the concurrency
+> its connection counts imply — which is documented inline. Read it before
+> quoting a supported-connection figure.
 >
 > **These numbers are not `dev`.** They were produced on
 > `add_sync_plus_concurrency_tests` at commit `14720e74`, which carries three
@@ -108,30 +109,73 @@ derived as `target - finalized`; `node_lag_gauge` is the node's own
 `zaino-bench concurrent --sweep`, against the synced instance. Each connection
 streams 1000 blocks from its own window of the pool.
 
+Both sweeps used `--blocks 200` over the pool `3000000..=3380000`.
+
 ### 2a. Persistent finalised state
 
-| Connections | Success | Wall-clock | Mean fetch | p95 fetch | Aggregate blocks/s | Chain breaks |
-|---|---|---|---|---|---|---|
-| 100 | TBD | TBD | TBD | TBD | TBD | TBD |
-| 250 | TBD | TBD | TBD | TBD | TBD | TBD |
-| 500 | TBD | TBD | TBD | TBD | TBD | TBD |
-| 1000 | TBD | TBD | TBD | TBD | TBD | TBD |
-| 2000 | TBD | TBD | TBD | TBD | TBD | TBD |
+| Connections | Success | Wall-clock | Mean fetch | p95 fetch | Aggregate blocks/s | Chain breaks | Mean in flight |
+|---|---|---|---|---|---|---|---|
+| 100 | 100% | 0.25s | 0.040s | 0.051s | 81,316 | 0 | 16 |
+| 500 | 100% | 1.08s | 0.039s | 0.050s | 92,821 | 0 | 18 |
+| 1000 | 100% | 2.11s | 0.040s | 0.050s | 94,630 | 0 | 19 |
+| 2000 | 100% | 4.19s | 0.040s | 0.050s | 95,470 | 0 | 19 |
+| 5000 | 100% | 5.40s | 0.039s | 0.050s | 185,266 | 0 | 36 |
+| 10000 | 100% | 10.59s | 0.040s | 0.050s | 188,878 | 0 | 38 |
 
-**Supported concurrent connections: TBD** — the largest row still at 100%
-success, with no chain breaks.
+**Supported concurrent connections: not established by this run.** Every round
+reports 100% success with flat latency, but the run did not hold its connections
+open, so the connection counts in the first column are not concurrency. Read the
+next section before quoting any of these figures.
+
+#### Why the persistent sweep is not a concurrency measurement
+
+A finalised read from Zaino's own index takes ~40ms for 200 blocks. The harness
+brings connections up across a 2s ramp, so at 10,000 connections a new one starts
+every 200µs — and each finishes 40ms later. Connections retire about as fast as
+they are created, and the number actually open at any instant is
+`connections × mean fetch ÷ wall-clock`: the last column above, which never
+exceeds 38 regardless of the nominal count.
+
+Two independent checks agree. The client's `ulimit -n` was **8192** for this run
+(the harness warned), which cannot support 10,000 simultaneous sockets — yet all
+10,000 succeeded. And wall-clock scales linearly with the connection count
+(0.25s → 10.59s for 100 → 10,000), which is the signature of sequential work,
+not of concurrent work hitting a ceiling.
+
+What this row set *does* establish: the server absorbed 10,000 successive
+short requests at 100% success, with p99 fetch latency flat at 0.052s from 100
+through 10,000 and no chain breaks. That is a real result about throughput and
+stability. It is not the answer to "how many concurrent connections can it
+support", and the honest answer to that question from this run is that the
+harness cannot reach the ceiling on the persistent backend: per-connection work
+would have to outlast the ramp. Raising `--blocks` until mean fetch exceeds the
+ramp (or lowering `--spawn-window-ms`) is the fix, and `ulimit -n` must be raised
+past `2 × connections` first.
 
 ### 2b. Ephemeral finalised state
 
-| Connections | Success | Wall-clock | Mean fetch | p95 fetch | Aggregate blocks/s | Chain breaks |
+| Connections | Success | Wall-clock | Mean fetch | Aggregate blocks/s | Chain breaks | Mean in flight |
 |---|---|---|---|---|---|---|
-| 100 | TBD | TBD | TBD | TBD | TBD | TBD |
-| 250 | TBD | TBD | TBD | TBD | TBD | TBD |
-| 500 | TBD | TBD | TBD | TBD | TBD | TBD |
-| 1000 | TBD | TBD | TBD | TBD | TBD | TBD |
-| 2000 | TBD | TBD | TBD | TBD | TBD | TBD |
+| 100 | 100% | 2.41s | 1.758s | 8,284 | 0 | 73 |
+| 500 | 100% | 10.51s | 8.829s | 9,514 | 0 | 420 |
+| 1000 | 100% | 20.92s | 18.263s | 9,559 | 0 | 873 |
+| 2000 | 100% | 43.56s | 38.151s | 9,182 | 0 | 1,752 |
+| 5000 | 100% | 113.73s | 104.477s | 8,793 | 0 | 4,593 |
+| 10000 | **2.9%** | 134.61s | 109.848s | 437 | 0 | 8,160 |
 
-**Supported concurrent connections: TBD.**
+**Supported concurrent connections: 5,000.**
+
+This sweep *is* a concurrency measurement, and the contrast with 2a is the
+reason. In ephemeral mode a finalised read is a passthrough to the validator and
+takes seconds, not milliseconds — far longer than the 2s ramp — so connections
+accumulate instead of retiring, and the in-flight count tracks the nominal one
+(4,593 of 5,000). The knee is unambiguous: 100% success through 5,000, then
+collapse to 2.9% at 10,000, with mean fetch already at 104s by 5,000 against the
+30s `service.timeout`.
+
+Aggregate throughput is flat at ~9,000 blocks/s from 100 connections onward,
+which says the ceiling is the validator passthrough rather than anything in
+Zaino's own request handling.
 
 ### Knobs that bound these numbers
 
@@ -143,7 +187,11 @@ a number quoted without them is not reproducible:
 | `service.channel_size` | `ZainodConfig` | 32 (default) |
 | `service.timeout` | `ZainodConfig` | 30s (default) |
 | `storage.cache.capacity` | `ZainodConfig` | 10000 (default) |
-| Client `ulimit -n` | test host | TBD |
+| Client `ulimit -n` | test host | **8192 — too low for the 10,000 round** (needs 20,000) |
+
+The `ulimit -n` row is not a footnote: at 8192 the client cannot hold 10,000
+sockets open, which is part of why the persistent sweep never reached its nominal
+concurrency. Raise it before any rerun.
 
 If a tuned run is also recorded, it goes in its own table naming the knob that
 moved — a tuned number presented as the default is misleading.
@@ -155,11 +203,23 @@ request. The same pass verifies every `prev_hash` link.
 
 | Mode | Range | Blocks | Wall-clock | Blocks/s | Payload MB/s | Errors |
 |---|---|---|---|---|---|---|
-| Persistent | TBD..=tip | TBD | TBD | TBD | TBD | TBD |
-| Ephemeral | TBD..=tip | TBD | TBD | TBD | TBD | TBD |
+| Persistent | 3300000..=3454000 | 154,001 | 1.00s | **154,203** | 99.9 | 0 |
+| Ephemeral | 3300000..=3454000 | 47,821 (of 154,001) | 120.00s | **399** | 0.2 | timed out |
 
-Aggregate (multi-connection) throughput is the last column of the sweep tables in
-section 2; this section is the single-stream figure.
+Both modes verified every `prev_hash` link over the blocks they delivered — the
+chain is valid in each case, including the truncated ephemeral stream.
+
+**Persistent serves finalised blocks ~390× faster than ephemeral.** That is the
+whole point of the index: in persistent mode the read is answered from Zaino's
+own finalised state, in ephemeral mode it is a passthrough to the validator. The
+ephemeral run did not finish — it hit the gRPC deadline after 47,821 blocks and
+120s, which is itself the finding: a full-range `GetBlockRange` over 154,001
+blocks is not serviceable by passthrough within the client's timeout.
+
+Aggregate (multi-connection) throughput is in the sweep tables in section 2; this
+section is the single-stream figure. Note the two are not directly comparable —
+the sweeps draw from a 380,001-block pool with heavy range overlap at high
+connection counts, so cache hit rates differ.
 
 ---
 
@@ -215,7 +275,7 @@ numbers; a validator build is part of the configuration.
 and [`zainod-bench-mainnet-ephemeral.toml`](example_configs/zainod-bench-mainnet-ephemeral.toml),
 built with `--features prometheus` (required for the `sync` measurement).
 
-**zebrad** — `[state] cache_dir = '/mnt/framework_ssd/.cache/zebra'`,
+**zebrad** — `[state] cache_dir = '/home/idky137/.cache/zebra'`,
 `[rpc] listen_addr = '127.0.0.1:18232'`, `indexer_listen_addr = '127.0.0.1:18230'`.
 Record any other non-default `[state]` or `[sync]` settings.
 
@@ -249,17 +309,21 @@ cargo build --release -p zaino-bench
 # 1. Initial sync, persistent mode. Start the harness first, so t0 is the
 #    moment zainod starts. Removing the database is what makes it an *initial*
 #    sync rather than a catch-up — check free space first (see below).
-rm -rf /mnt/framework_ssd/.cache/zaino/*
+rm -rf ~/.cache/zaino/*
 makers bench sync --csv sync-mainnet.csv
 zainod start --config docs/example_configs/zainod-bench-mainnet.toml
 
 # 2 + 3. Against the now-synced instance, persistent mode.
-ulimit -n 8192
+ulimit -n 32768          # must exceed 2 x the largest sweep value
 makers bench concurrent \
   --server http://127.0.0.1:8137 \
   --start-height 3000000 --end-height 3380000 \
-  --blocks 1000 --sweep 100,250,500,1000,2000
-makers bench serve --server http://127.0.0.1:8137 --start-height 3300000
+  --blocks 200 --sweep 100,500,1000,2000,5000,10000
+# --end-height pinned, not defaulted to the tip: the two modes report different
+# tips, and an unpinned range makes the persistent and ephemeral rows different
+# amounts of work.
+makers bench serve --server http://127.0.0.1:8137 \
+  --start-height 3300000 --end-height 3454000
 
 # 4. Restart zainod on the ephemeral config, then repeat 2 + 3 unchanged.
 zainod start --config docs/example_configs/zainod-bench-mainnet-ephemeral.toml

--- a/docs/perf.md
+++ b/docs/perf.md
@@ -46,8 +46,10 @@ value of co-location. It is optional — record it only if a second full sync is
 worth the wall-clock.
 
 Sync curve: `sync-mainnet.csv` (from `--csv`), columns `elapsed_secs,
-finalized_height, target_height, lag_blocks, db_tip_height, chain_tip_height,
-transactions_total, interval_blocks_per_sec`.
+finalized_height, target_height, lag_blocks, node_lag_gauge, db_tip_height,
+chain_tip_height, transactions_total, interval_blocks_per_sec`. `lag_blocks` is
+derived as `target - finalized`; `node_lag_gauge` is the node's own
+`zaino.sync.lag_blocks`, which reports the seam depth rather than the sync lag.
 
 ## 2. Concurrent connections
 

--- a/packages/zaino-bench/Cargo.toml
+++ b/packages/zaino-bench/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "zaino-bench"
+description = "Benchmark harness for Zaino: initial-sync time, concurrent-connection load, and block serve rate."
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
+version = "0.1.0"
+publish = false
+
+[[bin]]
+name = "zaino-bench"
+path = "src/main.rs"
+
+[dependencies]
+zaino-proto = { workspace = true }
+# For `ensure_default_crypto_provider`: the workspace enables reqwest's
+# `rustls-no-provider`, so a provider must be installed explicitly before any
+# rustls config is built, or `reqwest::Client::new` panics with "No provider
+# set" (ADR-0006).
+zaino-common = { workspace = true }
+
+# Runtime
+tokio = { workspace = true, features = ["full"] }
+
+# Network / RPC
+# TLS features match `zaino-serve`'s, so pointing the harness at an https
+# endpoint adds no second rustls CryptoProvider path to the graph (ADR-0006).
+tonic = { workspace = true, features = ["tls-native-roots", "tls-aws-lc"] }
+reqwest = { workspace = true }
+
+# CLI
+clap = { workspace = true, features = ["derive"] }
+
+# Utility
+futures = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+# Test-only, so the `prometheus` feature is not unified into non-test builds of
+# the workspace. `metric_names_match_zaino_state` asserts the metric names this
+# crate scrapes are still the ones `zaino-state` emits.
+zaino-state = { workspace = true, features = ["prometheus"] }

--- a/packages/zaino-bench/src/chain.rs
+++ b/packages/zaino-bench/src/chain.rs
@@ -1,0 +1,195 @@
+//! Incremental `prev_hash` link verification over a stream of compact blocks.
+//!
+//! Both the load generator and the serve-rate run need to know whether the
+//! blocks they were served actually form a chain — a server that answers fast
+//! with garbage is not answering. They differ only in how much detail they
+//! report, so the checking itself lives here and each caller reads what it needs.
+
+use zaino_proto::proto::compact_formats::CompactBlock;
+
+use crate::grpc_client::copy_hash;
+
+/// A place where the served blocks stopped forming a chain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChainBreak {
+    /// The height at which the break was observed.
+    pub(crate) height: u64,
+    /// What was wrong, in operator-readable terms.
+    pub(crate) detail: String,
+}
+
+/// Feed blocks in ascending height order; read the tally when the stream ends.
+#[derive(Debug, Default)]
+pub(crate) struct ChainVerifier {
+    prev_hash: Option<[u8; 32]>,
+    last_height: Option<u64>,
+    breaks: Vec<ChainBreak>,
+    hash_length_errors: usize,
+}
+
+impl ChainVerifier {
+    /// A verifier with no blocks seen yet.
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Checks `block` against the one before it and records any break.
+    pub(crate) fn push(&mut self, block: &CompactBlock) {
+        let height = block.height;
+
+        if let Some(last) = self.last_height {
+            if height <= last {
+                self.record(
+                    height,
+                    format!("height {height} is not strictly after previous height {last} — blocks out of order"),
+                );
+            }
+        }
+        self.last_height = Some(height);
+
+        // A malformed hash is a protocol violation, not a chain break: count it
+        // separately and drop the link, so the next block is not also blamed.
+        let (Some(hash), Some(prev_hash)) = (copy_hash(&block.hash), copy_hash(&block.prev_hash))
+        else {
+            self.hash_length_errors += 1;
+            self.prev_hash = None;
+            return;
+        };
+
+        if height == 0 && prev_hash != [0u8; 32] {
+            self.record(
+                0,
+                "genesis block (height 0) must have prevHash = all-zeros".to_string(),
+            );
+        }
+
+        if let Some(expected) = self.prev_hash {
+            if prev_hash != expected {
+                self.record(
+                    height,
+                    format!(
+                        "prevHash {} does not match previous block's hash {}",
+                        hex(&prev_hash),
+                        hex(&expected)
+                    ),
+                );
+            }
+        }
+
+        self.prev_hash = Some(hash);
+    }
+
+    /// Every break found so far, in the order they were observed.
+    pub(crate) fn breaks(&self) -> &[ChainBreak] {
+        &self.breaks
+    }
+
+    /// How many blocks carried a hash field of the wrong length.
+    pub(crate) fn hash_length_errors(&self) -> usize {
+        self.hash_length_errors
+    }
+
+    /// Breaks plus malformed hashes — the number the summary reports.
+    pub(crate) fn total_errors(&self) -> usize {
+        self.breaks.len() + self.hash_length_errors
+    }
+
+    fn record(&mut self, height: u64, detail: String) {
+        self.breaks.push(ChainBreak { height, detail });
+    }
+}
+
+fn hex(bytes: &[u8; 32]) -> String {
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Builds a linked run of `count` blocks starting at `start`, where block
+    /// `n`'s hash is `[n; 32]` — enough structure to exercise the link check
+    /// without constructing real blocks.
+    fn linked(start: u64, count: u64) -> Vec<CompactBlock> {
+        (start..start + count)
+            .map(|height| CompactBlock {
+                height,
+                hash: vec![height as u8; 32],
+                prev_hash: vec![height.wrapping_sub(1) as u8; 32],
+                ..CompactBlock::default()
+            })
+            .collect()
+    }
+
+    fn verify(blocks: &[CompactBlock]) -> ChainVerifier {
+        let mut verifier = ChainVerifier::new();
+        for block in blocks {
+            verifier.push(block);
+        }
+        verifier
+    }
+
+    #[test]
+    fn a_linked_run_has_no_errors() {
+        let verifier = verify(&linked(100, 10));
+        assert_eq!(verifier.total_errors(), 0);
+    }
+
+    #[test]
+    fn a_broken_link_is_one_break() {
+        let mut blocks = linked(100, 10);
+        blocks[5].prev_hash = vec![0xaa; 32];
+
+        let verifier = verify(&blocks);
+        assert_eq!(verifier.breaks().len(), 1);
+        assert_eq!(verifier.breaks()[0].height, 105);
+        assert_eq!(verifier.hash_length_errors(), 0);
+    }
+
+    #[test]
+    fn a_short_hash_is_a_length_error_not_a_break() {
+        let mut blocks = linked(100, 10);
+        blocks[5].hash = vec![0xaa; 31];
+
+        let verifier = verify(&blocks);
+        assert_eq!(verifier.hash_length_errors(), 1);
+        // The block after the malformed one has no link to check against, so it
+        // is not blamed for the gap.
+        assert_eq!(verifier.breaks(), &[]);
+    }
+
+    #[test]
+    fn genesis_must_have_a_zero_prev_hash() {
+        let block = CompactBlock {
+            height: 0,
+            hash: vec![1u8; 32],
+            prev_hash: vec![9u8; 32],
+            ..CompactBlock::default()
+        };
+
+        let verifier = verify(&[block]);
+        assert_eq!(verifier.breaks().len(), 1);
+        assert_eq!(verifier.breaks()[0].height, 0);
+    }
+
+    #[test]
+    fn genesis_with_a_zero_prev_hash_is_clean() {
+        let block = CompactBlock {
+            height: 0,
+            hash: vec![1u8; 32],
+            prev_hash: vec![0u8; 32],
+            ..CompactBlock::default()
+        };
+
+        assert_eq!(verify(&[block]).total_errors(), 0);
+    }
+
+    #[test]
+    fn out_of_order_heights_are_a_break() {
+        let mut blocks = linked(100, 3);
+        blocks.swap(1, 2);
+
+        let verifier = verify(&blocks);
+        assert!(!verifier.breaks().is_empty());
+    }
+}

--- a/packages/zaino-bench/src/concurrent.rs
+++ b/packages/zaino-bench/src/concurrent.rs
@@ -50,8 +50,21 @@ pub(super) struct ConcurrentArgs {
 
     /// Milliseconds between spawning each connection, to avoid a SYN burst that
     /// would measure the kernel's accept backlog rather than the server.
+    ///
+    /// An upper bound only: the actual gap is whichever is smaller, this or an
+    /// even spread across `--spawn-window-ms`. See [`spawn_gap`].
     #[arg(long, default_value = "1")]
     spawn_delay_ms: u64,
+
+    /// Longest the whole round may take to bring every connection up.
+    ///
+    /// At high connection counts a fixed per-connection delay stops measuring
+    /// concurrency: 10,000 connections at 1ms apart take 10s to establish, by
+    /// which time the first ones have finished and the peak overlap is nowhere
+    /// near 10,000. Capping the total ramp keeps the round a concurrency
+    /// measurement instead of a throughput one.
+    #[arg(long, default_value = "2000")]
+    spawn_window_ms: u64,
 
     /// Seconds to settle between sweep rounds, so one round's teardown does not
     /// land on the next round's connects.
@@ -180,6 +193,14 @@ async fn round(args: &ConcurrentArgs, pool_size: u64, connections: usize) -> Rou
     );
     eprintln!();
 
+    let gap = spawn_gap(args.spawn_delay_ms, args.spawn_window_ms, connections);
+    eprintln!(
+        "  ramp: {:.0}µs between connects, {:.1}s to bring all {connections} up",
+        gap.as_secs_f64() * 1e6,
+        gap.as_secs_f64() * connections as f64
+    );
+    eprintln!();
+
     let wall_start = Instant::now();
 
     let mut handles = Vec::with_capacity(connections);
@@ -188,8 +209,8 @@ async fn round(args: &ConcurrentArgs, pool_size: u64, connections: usize) -> Rou
         handles.push(tokio::spawn(async move {
             fetch_one(index, &server, range_start, range_end).await
         }));
-        if args.spawn_delay_ms > 0 {
-            tokio::time::sleep(Duration::from_millis(args.spawn_delay_ms)).await;
+        if !gap.is_zero() {
+            tokio::time::sleep(gap).await;
         }
     }
 
@@ -429,6 +450,19 @@ fn verbose_line(result: &ConnectionResult) -> String {
 ///
 /// Without this, a client-side `ulimit -n` of 1024 reads as "the server tops out
 /// near 1000 connections", which is the wrong answer to the question being asked.
+/// Gap between two connects: the per-connection delay, or an even spread across
+/// the ramp window, whichever is smaller.
+///
+/// Sub-millisecond by design at high counts — 10,000 connections across a 2s
+/// window is 200µs apart, which still avoids a SYN burst but keeps every
+/// connection up inside the window rather than 10s later.
+fn spawn_gap(delay_ms: u64, window_ms: u64, connections: usize) -> Duration {
+    let requested = Duration::from_millis(delay_ms);
+    let connections = connections.max(1) as u32;
+    let spread = Duration::from_millis(window_ms) / connections;
+    requested.min(spread)
+}
+
 fn fd_limit_warning(limit: u64, max_connections: usize) -> Option<String> {
     let needed = (max_connections as u64).saturating_mul(2);
 
@@ -505,6 +539,41 @@ mod tests {
         assert!(pool_size(2_000, 1_000).is_err());
         assert_eq!(pool_size(1_000, 1_000).ok(), Some(1));
         assert_eq!(pool_size(1_000, 1_999).ok(), Some(1_000));
+    }
+
+    /// At low counts the per-connection delay governs and the ramp is short. At
+    /// high counts the window governs, so the round stays a concurrency
+    /// measurement: 10,000 connections come up inside the window rather than
+    /// 10s apart, which is what a fixed 1ms delay would have done.
+    #[test]
+    fn the_spawn_ramp_is_bounded_by_the_window() {
+        let ramp =
+            |connections: usize| spawn_gap(1, 2000, connections).as_secs_f64() * connections as f64;
+
+        assert_eq!(
+            spawn_gap(1, 2000, 100),
+            Duration::from_millis(1),
+            "at 100 connections the per-connection delay is the smaller bound"
+        );
+        assert!(
+            ramp(100) < 0.2,
+            "and the whole ramp is a fraction of a second"
+        );
+
+        assert_eq!(
+            spawn_gap(1, 2000, 10_000),
+            Duration::from_micros(200),
+            "at 10,000 the window is the smaller bound: 2s / 10,000"
+        );
+        assert!(
+            (ramp(10_000) - 2.0).abs() < 0.01,
+            "so the ramp is the window, not the 10s a fixed 1ms delay would give"
+        );
+    }
+
+    #[test]
+    fn a_single_connection_ramp_does_not_divide_by_zero() {
+        assert_eq!(spawn_gap(1, 2000, 0), Duration::from_millis(1));
     }
 
     #[test]

--- a/packages/zaino-bench/src/concurrent.rs
+++ b/packages/zaino-bench/src/concurrent.rs
@@ -7,6 +7,7 @@
 //! hides the tail that clients actually feel, and a client-side `ulimit` is
 //! easily mistaken for a server-side ceiling.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -212,13 +213,15 @@ async fn round(args: &ConcurrentArgs, pool_size: u64, connections: usize) -> Rou
     // when the first one was created. The ramp is then a setup cost outside the
     // measurement, not part of it.
     let barrier = Arc::new(Barrier::new(connections + 1));
+    let established = Arc::new(AtomicUsize::new(0));
 
     let mut handles = Vec::with_capacity(connections);
     for (index, (range_start, range_end)) in ranges.into_iter().enumerate() {
         let server = args.server.clone();
         let barrier = Arc::clone(&barrier);
+        let established = Arc::clone(&established);
         handles.push(tokio::spawn(async move {
-            fetch_one(index, &server, range_start, range_end, barrier).await
+            fetch_one(index, &server, range_start, range_end, barrier, established).await
         }));
         if !gap.is_zero() {
             tokio::time::sleep(gap).await;
@@ -226,7 +229,18 @@ async fn round(args: &ConcurrentArgs, pool_size: u64, connections: usize) -> Rou
     }
 
     barrier.wait().await;
-    eprintln!("  all {connections} connected; starting fetch");
+    // Report what actually connected, not what was asked for: a failed dial
+    // still reaches the barrier (so one failure cannot strand the round), so
+    // "all N" would be a lie exactly when the server is refusing connections.
+    let established = established.load(Ordering::Relaxed);
+    if established == connections {
+        eprintln!("  all {connections} connected; starting fetch");
+    } else {
+        eprintln!(
+            "  {established}/{connections} connected ({} failed to dial); starting fetch",
+            connections - established
+        );
+    }
     eprintln!();
     let wall_start = Instant::now();
 
@@ -267,6 +281,7 @@ async fn fetch_one(
     range_start: u64,
     range_end: u64,
     barrier: Arc<Barrier>,
+    established: Arc<AtomicUsize>,
 ) -> ConnectionResult {
     let connect_start = Instant::now();
     // Bound the connect so a single hung dial cannot hold the barrier — and
@@ -280,6 +295,9 @@ async fn fetch_one(
             )),
         };
     let connect_elapsed = connect_start.elapsed();
+    if client.is_ok() {
+        established.fetch_add(1, Ordering::Relaxed);
+    }
 
     barrier.wait().await;
 

--- a/packages/zaino-bench/src/concurrent.rs
+++ b/packages/zaino-bench/src/concurrent.rs
@@ -7,7 +7,10 @@
 //! hides the tail that clients actually feel, and a client-side `ulimit` is
 //! easily mistaken for a server-side ceiling.
 
+use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+use tokio::sync::Barrier;
 
 use clap::Args;
 use tonic::transport::Channel;
@@ -121,6 +124,10 @@ impl RoundSummary {
     }
 }
 
+/// Longest a single connection may take to establish before the round gives up
+/// on it. Bounds the barrier: without it one hung dial stalls the whole round.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(60);
+
 pub(super) async fn run(args: ConcurrentArgs) -> Result<(), BenchError> {
     let pool_size = pool_size(args.start_height, args.end_height)?;
 
@@ -199,20 +206,29 @@ async fn round(args: &ConcurrentArgs, pool_size: u64, connections: usize) -> Rou
         gap.as_secs_f64() * 1e6,
         gap.as_secs_f64() * connections as f64
     );
-    eprintln!();
 
-    let wall_start = Instant::now();
+    // `connections + 1`: every connection, plus this task, so the round's
+    // wall-clock starts the instant the last socket is established rather than
+    // when the first one was created. The ramp is then a setup cost outside the
+    // measurement, not part of it.
+    let barrier = Arc::new(Barrier::new(connections + 1));
 
     let mut handles = Vec::with_capacity(connections);
     for (index, (range_start, range_end)) in ranges.into_iter().enumerate() {
         let server = args.server.clone();
+        let barrier = Arc::clone(&barrier);
         handles.push(tokio::spawn(async move {
-            fetch_one(index, &server, range_start, range_end).await
+            fetch_one(index, &server, range_start, range_end, barrier).await
         }));
         if !gap.is_zero() {
             tokio::time::sleep(gap).await;
         }
     }
+
+    barrier.wait().await;
+    eprintln!("  all {connections} connected; starting fetch");
+    eprintln!();
+    let wall_start = Instant::now();
 
     // A task that panicked has no timing to contribute; dropping it here keeps
     // it out of the statistics, and it still shows in the success/total counts.
@@ -234,26 +250,48 @@ async fn round(args: &ConcurrentArgs, pool_size: u64, connections: usize) -> Rou
     summarise(connections, args.blocks, wall_elapsed, &results)
 }
 
-/// Connect, fetch, verify — the whole of one connection's work.
+/// Connect, wait for every other connection, then fetch and verify.
+///
+/// The barrier is what makes the round a concurrency measurement. Without it a
+/// connection whose work is shorter than the spawn ramp finishes before its
+/// successors are even created, so the number open at once never approaches the
+/// nominal count — the round silently becomes a throughput test. Holding every
+/// connection open until all of them have connected means the fetch phase starts
+/// with exactly `connections` sockets established, whatever the work costs.
+///
+/// A connection that fails to connect still waits, so one failure cannot strand
+/// the rest; it just skips the fetch.
 async fn fetch_one(
     index: usize,
     server: &str,
     range_start: u64,
     range_end: u64,
+    barrier: Arc<Barrier>,
 ) -> ConnectionResult {
-    let started = Instant::now();
+    let connect_start = Instant::now();
+    // Bound the connect so a single hung dial cannot hold the barrier — and
+    // with it the whole round — open indefinitely.
+    let client =
+        match tokio::time::timeout(CONNECT_TIMEOUT, grpc_client::connect_eager(server)).await {
+            Ok(result) => result.map_err(|error| error.to_string()),
+            Err(_) => Err(format!(
+                "connect timed out after {}s",
+                CONNECT_TIMEOUT.as_secs()
+            )),
+        };
+    let connect_elapsed = connect_start.elapsed();
 
-    let client = grpc_client::connect_eager(server).await;
-    let connect_elapsed = started.elapsed();
+    barrier.wait().await;
 
-    let failed = |error: grpc_client::Error| ConnectionResult {
+    let fetch_start = Instant::now();
+    let failed = |error: String| ConnectionResult {
         index,
         range_start,
         range_end,
         blocks: 0,
         connect_elapsed,
-        fetch_elapsed: started.elapsed().saturating_sub(connect_elapsed),
-        error: Some(error.to_string()),
+        fetch_elapsed: fetch_start.elapsed(),
+        error: Some(error),
         chain_breaks: 0,
     };
 
@@ -274,12 +312,12 @@ async fn fetch_one(
                 range_end,
                 blocks: blocks.len(),
                 connect_elapsed,
-                fetch_elapsed: started.elapsed().saturating_sub(connect_elapsed),
+                fetch_elapsed: fetch_start.elapsed(),
                 error: None,
                 chain_breaks: verifier.total_errors(),
             }
         }
-        Err(error) => failed(error),
+        Err(error) => failed(error.to_string()),
     }
 }
 

--- a/packages/zaino-bench/src/concurrent.rs
+++ b/packages/zaino-bench/src/concurrent.rs
@@ -1,0 +1,529 @@
+//! Concurrent load test — "how many connections can you support, and how fast
+//! can you serve blocks?"
+//!
+//! Ported from the `zaino-admin concurrent-test` tool on the `hahn/store`
+//! branch, with a connection sweep, tail percentiles, and a file-descriptor
+//! preflight added: a single point sample cannot say where the knee is, a mean
+//! hides the tail that clients actually feel, and a client-side `ulimit` is
+//! easily mistaken for a server-side ceiling.
+
+use std::time::{Duration, Instant};
+
+use clap::Args;
+use tonic::transport::Channel;
+use zaino_proto::proto::service::compact_tx_streamer_client::CompactTxStreamerClient;
+
+use crate::chain::ChainVerifier;
+use crate::error::BenchError;
+use crate::grpc_client;
+use crate::stats::Summary;
+
+/// Hammer a server with N concurrent `GetBlockRange` clients and report how
+/// many succeeded, how long they took, and the aggregate block throughput.
+#[derive(Args)]
+pub(super) struct ConcurrentArgs {
+    /// Server under test (e.g. "http://127.0.0.1:8137").
+    #[arg(short, long)]
+    server: String,
+
+    /// Lower bound of the height pool connections draw their ranges from.
+    #[arg(long)]
+    start_height: u64,
+
+    /// Upper bound (inclusive) of the height pool.
+    #[arg(long)]
+    end_height: u64,
+
+    /// Blocks each connection fetches.
+    #[arg(short, long, default_value = "1000")]
+    blocks: u64,
+
+    /// Concurrent connections. Ignored when `--sweep` is given.
+    #[arg(short, long, default_value = "1000")]
+    connections: usize,
+
+    /// Run one round per value and print a comparison table, e.g.
+    /// `--sweep 100,250,500,1000,2000`. This is what locates the knee — the
+    /// point where the success rate starts falling off.
+    #[arg(long, value_delimiter = ',')]
+    sweep: Vec<usize>,
+
+    /// Milliseconds between spawning each connection, to avoid a SYN burst that
+    /// would measure the kernel's accept backlog rather than the server.
+    #[arg(long, default_value = "1")]
+    spawn_delay_ms: u64,
+
+    /// Seconds to settle between sweep rounds, so one round's teardown does not
+    /// land on the next round's connects.
+    #[arg(long, default_value = "5")]
+    settle_secs: u64,
+
+    /// Print per-connection timing.
+    #[arg(short, long)]
+    verbose: bool,
+}
+
+/// What one connection did.
+struct ConnectionResult {
+    index: usize,
+    range_start: u64,
+    range_end: u64,
+    blocks: usize,
+    connect_elapsed: Duration,
+    fetch_elapsed: Duration,
+    error: Option<String>,
+    chain_breaks: usize,
+}
+
+impl ConnectionResult {
+    fn total_elapsed(&self) -> Duration {
+        self.connect_elapsed + self.fetch_elapsed
+    }
+}
+
+/// The headline numbers for one round, kept so the sweep can tabulate them.
+struct RoundSummary {
+    connections: usize,
+    succeeded: usize,
+    wall_elapsed: Duration,
+    blocks_fetched: usize,
+    chain_breaks: usize,
+    fetch: Option<Summary>,
+}
+
+impl RoundSummary {
+    fn success_rate(&self) -> f64 {
+        if self.connections == 0 {
+            return 0.0;
+        }
+        self.succeeded as f64 / self.connections as f64 * 100.0
+    }
+
+    fn aggregate_throughput(&self) -> f64 {
+        let seconds = self.wall_elapsed.as_secs_f64();
+        if seconds <= 0.0 {
+            return 0.0;
+        }
+        self.blocks_fetched as f64 / seconds
+    }
+}
+
+pub(super) async fn run(args: ConcurrentArgs) -> Result<(), BenchError> {
+    let pool_size = pool_size(args.start_height, args.end_height)?;
+
+    if args.blocks == 0 {
+        return Err(BenchError::Args("--blocks must be at least 1".into()));
+    }
+    if args.blocks > pool_size {
+        return Err(BenchError::Args(format!(
+            "--blocks {} is larger than the available pool {}..={} ({pool_size} blocks)",
+            args.blocks, args.start_height, args.end_height,
+        )));
+    }
+
+    let rounds = if args.sweep.is_empty() {
+        vec![args.connections]
+    } else {
+        args.sweep.clone()
+    };
+    if rounds.contains(&0) {
+        return Err(BenchError::Args(
+            "connection counts must be at least 1".into(),
+        ));
+    }
+
+    eprintln!("Server: {}", args.server);
+    eprintln!(
+        "Pool:   {}..={} ({pool_size} blocks)",
+        args.start_height, args.end_height
+    );
+    let max_connections = rounds.iter().copied().max().unwrap_or(0);
+    if let Some(warning) =
+        open_file_limit().and_then(|limit| fd_limit_warning(limit, max_connections))
+    {
+        eprintln!();
+        eprintln!("  ⚠ {warning}");
+    }
+    eprintln!();
+
+    let mut summaries = Vec::with_capacity(rounds.len());
+    for (position, connections) in rounds.iter().copied().enumerate() {
+        if position > 0 && args.settle_secs > 0 {
+            tokio::time::sleep(Duration::from_secs(args.settle_secs)).await;
+        }
+        summaries.push(round(&args, pool_size, connections).await);
+    }
+
+    if summaries.len() > 1 {
+        print_sweep_table(&summaries, args.blocks);
+    }
+
+    // A sweep is *meant* to push past the knee, so partial failure is a result,
+    // not an error. Zero successes anywhere means the harness never reached the
+    // server at all — that is a failed run, and it should exit non-zero.
+    if summaries.iter().all(|summary| summary.succeeded == 0) {
+        return Err(BenchError::AllConnectionsFailed(args.server.clone()));
+    }
+
+    Ok(())
+}
+
+async fn round(args: &ConcurrentArgs, pool_size: u64, connections: usize) -> RoundSummary {
+    let ranges = distribute_ranges(args.start_height, pool_size, args.blocks, connections);
+    let overlap = args.blocks.saturating_mul(connections as u64) > pool_size;
+
+    eprintln!("──────────────────────────────────────────");
+    eprintln!(
+        "{connections} connections × {} blocks each{}",
+        args.blocks,
+        if overlap { " (ranges overlap)" } else { "" }
+    );
+    eprintln!();
+
+    let wall_start = Instant::now();
+
+    let mut handles = Vec::with_capacity(connections);
+    for (index, (range_start, range_end)) in ranges.into_iter().enumerate() {
+        let server = args.server.clone();
+        handles.push(tokio::spawn(async move {
+            fetch_one(index, &server, range_start, range_end).await
+        }));
+        if args.spawn_delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(args.spawn_delay_ms)).await;
+        }
+    }
+
+    // A task that panicked has no timing to contribute; dropping it here keeps
+    // it out of the statistics, and it still shows in the success/total counts.
+    let results: Vec<ConnectionResult> = futures::future::join_all(handles)
+        .await
+        .into_iter()
+        .filter_map(Result::ok)
+        .collect();
+
+    let wall_elapsed = wall_start.elapsed();
+
+    if args.verbose {
+        for result in &results {
+            eprintln!("{}", verbose_line(result));
+        }
+        eprintln!();
+    }
+
+    summarise(connections, args.blocks, wall_elapsed, &results)
+}
+
+/// Connect, fetch, verify — the whole of one connection's work.
+async fn fetch_one(
+    index: usize,
+    server: &str,
+    range_start: u64,
+    range_end: u64,
+) -> ConnectionResult {
+    let started = Instant::now();
+
+    let client = grpc_client::connect_eager(server).await;
+    let connect_elapsed = started.elapsed();
+
+    let failed = |error: grpc_client::Error| ConnectionResult {
+        index,
+        range_start,
+        range_end,
+        blocks: 0,
+        connect_elapsed,
+        fetch_elapsed: started.elapsed().saturating_sub(connect_elapsed),
+        error: Some(error.to_string()),
+        chain_breaks: 0,
+    };
+
+    let mut client: CompactTxStreamerClient<Channel> = match client {
+        Ok(client) => client,
+        Err(error) => return failed(error),
+    };
+
+    match grpc_client::fetch_block_range(&mut client, range_start, range_end).await {
+        Ok(blocks) => {
+            let mut verifier = ChainVerifier::new();
+            for block in &blocks {
+                verifier.push(block);
+            }
+            ConnectionResult {
+                index,
+                range_start,
+                range_end,
+                blocks: blocks.len(),
+                connect_elapsed,
+                fetch_elapsed: started.elapsed().saturating_sub(connect_elapsed),
+                error: None,
+                chain_breaks: verifier.total_errors(),
+            }
+        }
+        Err(error) => failed(error),
+    }
+}
+
+/// Spreads `connections` windows of `blocks` evenly across the pool.
+///
+/// The first window starts at `start_height` and the last ends at the pool's
+/// end. When `blocks × connections` exceeds the pool the windows overlap, which
+/// is fine: this is a load test, not a coverage sweep.
+fn distribute_ranges(
+    start_height: u64,
+    pool_size: u64,
+    blocks: u64,
+    connections: usize,
+) -> Vec<(u64, u64)> {
+    let end_height = start_height + pool_size - 1;
+    let step = if connections > 1 {
+        (pool_size - blocks) as f64 / (connections - 1) as f64
+    } else {
+        0.0
+    };
+
+    (0..connections)
+        .map(|index| {
+            let range_start = start_height + (step * index as f64).round() as u64;
+            (range_start, (range_start + blocks - 1).min(end_height))
+        })
+        .collect()
+}
+
+fn pool_size(start_height: u64, end_height: u64) -> Result<u64, BenchError> {
+    end_height
+        .checked_sub(start_height)
+        .map(|span| span + 1)
+        .ok_or_else(|| {
+            BenchError::Args(format!(
+                "--end-height {end_height} is below --start-height {start_height}"
+            ))
+        })
+}
+
+fn summarise(
+    connections: usize,
+    blocks_each: u64,
+    wall_elapsed: Duration,
+    results: &[ConnectionResult],
+) -> RoundSummary {
+    let ok: Vec<&ConnectionResult> = results.iter().filter(|r| r.error.is_none()).collect();
+    let failed = connections - ok.len();
+
+    let seconds = |extract: fn(&ConnectionResult) -> Duration| -> Vec<f64> {
+        ok.iter().map(|r| extract(r).as_secs_f64()).collect()
+    };
+    let connect = Summary::new(&seconds(|r| r.connect_elapsed));
+    let fetch = Summary::new(&seconds(|r| r.fetch_elapsed));
+    let total = Summary::new(&seconds(ConnectionResult::total_elapsed));
+
+    let summary = RoundSummary {
+        connections,
+        succeeded: ok.len(),
+        wall_elapsed,
+        blocks_fetched: ok.iter().map(|r| r.blocks).sum(),
+        chain_breaks: ok.iter().map(|r| r.chain_breaks).sum(),
+        fetch,
+    };
+
+    eprintln!("Results:");
+    eprintln!(
+        "  Connections: {}/{failed}/{connections}  (success / failed / total) — {:.1}% success",
+        summary.succeeded,
+        summary.success_rate(),
+    );
+    eprintln!(
+        "  Per connection: {blocks_each} blocks ({} total fetched)",
+        summary.blocks_fetched,
+    );
+    eprintln!(
+        "  Chain breaks: {}{}",
+        summary.chain_breaks,
+        if summary.chain_breaks > 0 { " ⚠" } else { "" }
+    );
+    eprintln!(
+        "  Wall-clock time: {:.2}s",
+        summary.wall_elapsed.as_secs_f64()
+    );
+
+    if let (Some(connect), Some(fetch), Some(total)) = (connect, fetch, total) {
+        eprintln!();
+        eprintln!("{}", connect.line("Connect time (s):"));
+        eprintln!("{}", fetch.line("Fetch time (s):"));
+        eprintln!("{}", total.line("Per-connection total (s):"));
+        eprintln!();
+        eprintln!(
+            "  Aggregate throughput: {:.0} blocks/s across {connections} connections",
+            summary.aggregate_throughput(),
+        );
+        if total.mean > 0.0 {
+            eprintln!(
+                "  Per-connection throughput: {:.0} blocks/s (mean)",
+                blocks_each as f64 / total.mean,
+            );
+        }
+    } else {
+        eprintln!();
+        eprintln!("  All {connections} connections failed — no timings to report.");
+        if let Some(first) = results.iter().find_map(|r| r.error.as_deref()) {
+            eprintln!("  First error: {first}");
+        }
+    }
+    eprintln!();
+
+    summary
+}
+
+fn print_sweep_table(summaries: &[RoundSummary], blocks_each: u64) {
+    eprintln!("══════════════════════════════════════════");
+    eprintln!("  Connection Sweep — {blocks_each} blocks per connection");
+    eprintln!("══════════════════════════════════════════");
+    eprintln!(
+        "  {:>6}  {:>9}  {:>8}  {:>10}  {:>12}  {:>8}",
+        "conns", "success", "wall (s)", "mean fetch", "blocks/s", "breaks"
+    );
+
+    for summary in summaries {
+        eprintln!(
+            "  {:>6}  {:>8.1}%  {:>8.2}  {:>10}  {:>12.0}  {:>8}",
+            summary.connections,
+            summary.success_rate(),
+            summary.wall_elapsed.as_secs_f64(),
+            summary
+                .fetch
+                .map(|fetch| format!("{:.3}s", fetch.mean))
+                .unwrap_or_else(|| "—".to_string()),
+            summary.aggregate_throughput(),
+            summary.chain_breaks,
+        );
+    }
+    eprintln!();
+    eprintln!("  The supported connection count is the last row still at 100% success.");
+}
+
+fn verbose_line(result: &ConnectionResult) -> String {
+    match &result.error {
+        Some(error) => format!(
+            "  Connection {:>4}: {}..={} → ERROR (connect {:.2}s) — {error}",
+            result.index,
+            result.range_start,
+            result.range_end,
+            result.connect_elapsed.as_secs_f64(),
+        ),
+        None => format!(
+            "  Connection {:>4}: {}..={} → {} blocks, connect {:.2}s, fetch {:.2}s{}",
+            result.index,
+            result.range_start,
+            result.range_end,
+            result.blocks,
+            result.connect_elapsed.as_secs_f64(),
+            result.fetch_elapsed.as_secs_f64(),
+            if result.chain_breaks > 0 {
+                format!(", {} chain break(s) ⚠", result.chain_breaks)
+            } else {
+                String::new()
+            },
+        ),
+    }
+}
+
+/// Warns when this process cannot open enough sockets for the largest round.
+///
+/// Without this, a client-side `ulimit -n` of 1024 reads as "the server tops out
+/// near 1000 connections", which is the wrong answer to the question being asked.
+fn fd_limit_warning(limit: u64, max_connections: usize) -> Option<String> {
+    let needed = (max_connections as u64).saturating_mul(2);
+
+    (limit < needed).then(|| {
+        format!(
+            "open-file limit is {limit}, but {max_connections} connections need roughly \
+             {needed}. Raise it (`ulimit -n {needed}`) or the ceiling you measure will \
+             be this client's, not the server's."
+        )
+    })
+}
+
+/// This process's soft `RLIMIT_NOFILE`, read from procfs.
+///
+/// Procfs rather than a `libc` dependency: the harness only needs to *warn*, and
+/// on a platform without procfs it simply declines to.
+fn open_file_limit() -> Option<u64> {
+    let limits = std::fs::read_to_string("/proc/self/limits").ok()?;
+    parse_open_file_limit(&limits)
+}
+
+fn parse_open_file_limit(limits: &str) -> Option<u64> {
+    let line = limits
+        .lines()
+        .find(|line| line.starts_with("Max open files"))?;
+    line.split_whitespace()
+        .find_map(|field| field.parse::<u64>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ranges_span_the_pool_end_to_end() {
+        let ranges = distribute_ranges(1_000, 1_000, 100, 4);
+        assert_eq!(ranges.len(), 4);
+        assert_eq!(ranges[0], (1_000, 1_099));
+        assert_eq!(ranges[3], (1_900, 1_999));
+        assert!(ranges.windows(2).all(|pair| pair[0].0 <= pair[1].0));
+    }
+
+    #[test]
+    fn a_single_connection_starts_at_the_pool_start() {
+        assert_eq!(distribute_ranges(1_000, 1_000, 100, 1), [(1_000, 1_099)]);
+    }
+
+    #[test]
+    fn ranges_overlap_rather_than_overrun_when_demand_exceeds_the_pool() {
+        let pool_start = 1_000;
+        let pool_size = 500;
+        let ranges = distribute_ranges(pool_start, pool_size, 400, 10);
+
+        assert_eq!(ranges.len(), 10);
+        assert!(
+            ranges.iter().all(|&(_, end)| end < pool_start + pool_size),
+            "no range may run past the pool: {ranges:?}"
+        );
+        assert!(
+            ranges.windows(2).any(|pair| pair[1].0 <= pair[0].1),
+            "windows should overlap once demand exceeds the pool: {ranges:?}"
+        );
+    }
+
+    #[test]
+    fn every_range_holds_the_requested_block_count() {
+        for &(start, end) in &distribute_ranges(1_000, 10_000, 250, 16) {
+            assert_eq!(end - start + 1, 250);
+        }
+    }
+
+    #[test]
+    fn an_inverted_pool_is_rejected() {
+        assert!(pool_size(2_000, 1_000).is_err());
+        assert_eq!(pool_size(1_000, 1_000).ok(), Some(1));
+        assert_eq!(pool_size(1_000, 1_999).ok(), Some(1_000));
+    }
+
+    #[test]
+    fn the_fd_warning_fires_only_below_the_requirement() {
+        let limits = "Max open files            1024                 4096                 files\n";
+        assert_eq!(parse_open_file_limit(limits), Some(1024));
+
+        // 1024 fds cannot cover 1000 connections, but comfortably covers 100.
+        let warning = fd_limit_warning(1024, 1000).expect("1024 fds is short of 2000");
+        assert!(
+            warning.contains("2000"),
+            "warning should name the requirement: {warning}"
+        );
+        assert!(fd_limit_warning(1024, 100).is_none());
+    }
+
+    #[test]
+    fn an_unparseable_limits_file_yields_no_limit() {
+        assert_eq!(parse_open_file_limit("Max open files unlimited"), None);
+        assert_eq!(parse_open_file_limit(""), None);
+    }
+}

--- a/packages/zaino-bench/src/concurrent.rs
+++ b/packages/zaino-bench/src/concurrent.rs
@@ -609,9 +609,18 @@ mod tests {
         );
     }
 
+    /// `Barrier::new(connections + 1)` would panic on a zero-party barrier, and
+    /// the gap arithmetic divides by the connection count.
     #[test]
-    fn a_single_connection_ramp_does_not_divide_by_zero() {
+    fn a_degenerate_connection_count_is_handled() {
         assert_eq!(spawn_gap(1, 2000, 0), Duration::from_millis(1));
+        assert_eq!(spawn_gap(1, 2000, 1), Duration::from_millis(1));
+    }
+
+    /// A zero window means "no ramp": spawn as fast as the loop allows.
+    #[test]
+    fn a_zero_window_removes_the_ramp() {
+        assert!(spawn_gap(1, 0, 100).is_zero());
     }
 
     #[test]

--- a/packages/zaino-bench/src/error.rs
+++ b/packages/zaino-bench/src/error.rs
@@ -1,0 +1,59 @@
+//! Error type for the benchmark harness.
+
+use std::time::Duration;
+
+/// Every way a benchmark run can fail.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum BenchError {
+    /// An argument combination the harness cannot act on.
+    #[error("invalid arguments: {0}")]
+    Args(String),
+
+    /// The gRPC endpoint could not be reached or refused a call.
+    #[error(transparent)]
+    Grpc(#[from] crate::grpc_client::Error),
+
+    /// The Prometheus scrape endpoint could not be reached.
+    #[error("failed to scrape {url}: {source}")]
+    Scrape {
+        /// The endpoint that was scraped.
+        url: String,
+        /// The underlying transport failure.
+        source: reqwest::Error,
+    },
+
+    /// zainod is serving `/metrics`, but without a metric the harness needs.
+    /// Most often this means zainod was built without `--features prometheus`,
+    /// or has not yet emitted its first sync sample.
+    #[error(
+        "metric `{0}` is absent from the scrape — is zainod built with \
+         `--features prometheus`, and has its sync loop started?"
+    )]
+    MissingMetric(&'static str),
+
+    /// `finalized_height` did not advance within the stall timeout.
+    #[error("sync stalled: finalized height held at {height} for {}s", .timeout.as_secs())]
+    SyncStalled {
+        /// The height sync was stuck at.
+        height: u64,
+        /// How long it was stuck for.
+        timeout: Duration,
+    },
+
+    /// Not one connection reached the server, in any round.
+    #[error("no connection to {0} succeeded in any round")]
+    AllConnectionsFailed(String),
+
+    /// The chain served over gRPC does not link up.
+    #[error("chain is invalid: {0} error(s) found")]
+    InvalidChain(usize),
+
+    /// Writing the CSV sample log failed.
+    #[error("failed to write CSV to {path}: {source}")]
+    Csv {
+        /// The path that was being written.
+        path: String,
+        /// The underlying IO failure.
+        source: std::io::Error,
+    },
+}

--- a/packages/zaino-bench/src/grpc_client.rs
+++ b/packages/zaino-bench/src/grpc_client.rs
@@ -1,0 +1,146 @@
+//! Thin tonic client helpers over `CompactTxStreamer`.
+//!
+//! The workspace has no reusable public client helper — `zaino-testutils`'
+//! `build_client` is `#[cfg(test)]` and `tonic` is only a dev-dependency there —
+//! so the load generator carries its own.
+
+use futures::TryStreamExt;
+use tonic::transport::{Channel, Endpoint};
+use tonic::Status;
+use zaino_proto::proto::{
+    compact_formats::CompactBlock,
+    service::{
+        compact_tx_streamer_client::CompactTxStreamerClient, BlockId, BlockRange, ChainSpec,
+    },
+};
+
+/// A failure reaching, or talking to, the server under test.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Error {
+    /// The endpoint URL was malformed, or the TCP/TLS connection failed.
+    #[error("failed to connect to {url}: {source}")]
+    Connect {
+        /// The endpoint that was dialled.
+        url: String,
+        /// The underlying transport failure.
+        source: Box<dyn std::error::Error + Send + Sync>,
+    },
+
+    /// The server accepted the connection but rejected the call.
+    #[error("gRPC call failed: {0}")]
+    Grpc(#[from] Status),
+}
+
+/// Dials `url` and completes the connection before returning.
+///
+/// The load generator needs the connect step to be a *measurable* phase, which
+/// rules out tonic's lazy channel: a lazy connect would fold the handshake into
+/// the first request and inflate the fetch timing instead.
+pub(crate) async fn connect_eager(url: &str) -> Result<CompactTxStreamerClient<Channel>, Error> {
+    let endpoint = endpoint(url)?.keep_alive_while_idle(true);
+
+    let channel = match endpoint.uri().scheme_str() {
+        Some("https") => tls(&endpoint, url)?.connect().await,
+        _ => endpoint.connect().await,
+    }
+    .map_err(|source| connect_error(url, source))?;
+
+    Ok(CompactTxStreamerClient::new(channel))
+}
+
+/// Returns the chain tip height the server is currently advertising.
+pub(crate) async fn get_latest_height(
+    client: &mut CompactTxStreamerClient<Channel>,
+) -> Result<u64, Error> {
+    let response = client.get_latest_block(ChainSpec::default()).await?;
+    Ok(response.into_inner().height)
+}
+
+/// Opens a `GetBlockRange` stream over `start..=end`.
+///
+/// Returns the raw stream rather than a collected `Vec` so a caller measuring
+/// serve rate can time each block as it arrives; [`fetch_block_range`] collects
+/// for callers that only need the total.
+pub(crate) async fn block_range_stream(
+    client: &mut CompactTxStreamerClient<Channel>,
+    start: u64,
+    end: u64,
+) -> Result<tonic::Streaming<CompactBlock>, Error> {
+    let response = client.get_block_range(block_range(start, end)).await?;
+    Ok(response.into_inner())
+}
+
+/// Streams `start..=end` to completion, returning the blocks sorted by height.
+pub(crate) async fn fetch_block_range(
+    client: &mut CompactTxStreamerClient<Channel>,
+    start: u64,
+    end: u64,
+) -> Result<Vec<CompactBlock>, Error> {
+    let stream = block_range_stream(client, start, end).await?;
+    let mut blocks: Vec<CompactBlock> = stream.try_collect().await?;
+    blocks.sort_by_key(|block| block.height);
+    Ok(blocks)
+}
+
+/// Copies a wire hash into a fixed array, rejecting any other length.
+///
+/// A wrong length is a protocol violation rather than a chain break, so callers
+/// count it separately; returning `Option` keeps that decision at the call site.
+pub(crate) fn copy_hash(bytes: &[u8]) -> Option<[u8; 32]> {
+    <[u8; 32]>::try_from(bytes).ok()
+}
+
+fn block_range(start: u64, end: u64) -> BlockRange {
+    BlockRange {
+        start: Some(BlockId {
+            height: start,
+            hash: Vec::new(),
+        }),
+        end: Some(BlockId {
+            height: end,
+            hash: Vec::new(),
+        }),
+        pool_types: Vec::new(),
+    }
+}
+
+fn endpoint(url: &str) -> Result<Endpoint, Error> {
+    Endpoint::from_shared(url.to_string()).map_err(|source| connect_error(url, source))
+}
+
+fn tls(endpoint: &Endpoint, url: &str) -> Result<Endpoint, Error> {
+    endpoint
+        .clone()
+        .tls_config(tonic::transport::ClientTlsConfig::new().with_native_roots())
+        .map_err(|source| connect_error(url, source))
+}
+
+fn connect_error(url: &str, source: impl std::error::Error + Send + Sync + 'static) -> Error {
+    Error::Connect {
+        url: url.to_string(),
+        source: Box::new(source),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn copy_hash_accepts_only_32_bytes() {
+        assert_eq!(copy_hash(&[7u8; 32]), Some([7u8; 32]));
+        assert_eq!(copy_hash(&[7u8; 31]), None);
+        assert_eq!(copy_hash(&[7u8; 33]), None);
+        assert_eq!(copy_hash(&[]), None);
+    }
+
+    #[test]
+    fn block_range_spans_the_requested_heights_unfiltered() {
+        let range = block_range(100, 200);
+        assert_eq!(range.start.map(|id| id.height), Some(100));
+        assert_eq!(range.end.map(|id| id.height), Some(200));
+        // An unfiltered request is what real clients send; filtering here would
+        // measure a cheaper path than the one under test.
+        assert!(range.pool_types.is_empty());
+    }
+}

--- a/packages/zaino-bench/src/main.rs
+++ b/packages/zaino-bench/src/main.rs
@@ -1,0 +1,78 @@
+//! Benchmark harness for Zaino.
+//!
+//! Answers three operational questions against a running zainod, from the
+//! outside, over the interfaces a real client uses:
+//!
+//! - `sync`       — how long does an initial sync take?
+//! - `concurrent` — how many concurrent connections can it support?
+//! - `serve`      — how fast can it serve blocks on one stream?
+//!
+//! The measured configuration belongs with the numbers: see `docs/perf.md` for
+//! results and `docs/example_configs/zainod-bench-mainnet.toml` for the node
+//! config they were produced with.
+
+#![forbid(unsafe_code)]
+
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand};
+
+mod chain;
+mod concurrent;
+mod error;
+mod grpc_client;
+mod metrics;
+mod serve;
+mod stats;
+mod sync;
+
+#[derive(Parser)]
+#[command(name = "zaino-bench", about, version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Measure how long zainod takes to sync to the chain tip.
+    Sync(sync::SyncArgs),
+    /// Load-test a running server with concurrent block-range clients.
+    Concurrent(concurrent::ConcurrentArgs),
+    /// Measure single-stream block serve rate, verifying the chain as it goes.
+    Serve(serve::ServeArgs),
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    // Must run before any rustls config is built — the workspace enables
+    // reqwest's `rustls-no-provider`, which never auto-selects one, so the
+    // metrics scrape panics with "No provider set" without this (ADR-0006).
+    zaino_common::crypto::ensure_default_crypto_provider();
+
+    let result = match Cli::parse().command {
+        Command::Sync(args) => sync::run(args).await,
+        Command::Concurrent(args) => concurrent::run(args).await,
+        Command::Serve(args) => serve::run(args).await,
+    };
+
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(error) => {
+            eprintln!();
+            eprintln!("Error: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::CommandFactory;
+
+    #[test]
+    fn the_cli_is_well_formed() {
+        Cli::command().debug_assert();
+    }
+}

--- a/packages/zaino-bench/src/metrics.rs
+++ b/packages/zaino-bench/src/metrics.rs
@@ -1,0 +1,207 @@
+//! Scraping and parsing zainod's Prometheus endpoint.
+//!
+//! Measuring initial sync needs no new instrumentation: zainod already emits
+//! everything required behind its `prometheus` feature. The harness reads that
+//! endpoint from the outside, so a sync measurement never perturbs the run it is
+//! measuring.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use crate::error::BenchError;
+
+/// The metrics this harness reads, in the form `zaino-state` registers them.
+///
+/// Mirrors `zaino_state::metric_names`, which is `#[cfg(feature = "prometheus")]`
+/// and would pull that feature into every workspace build if depended on
+/// directly. The `metric_names_match_zaino_state` test below pins the two
+/// together via a dev-dependency, so drift fails the build rather than the run.
+pub(crate) mod names {
+    pub(crate) const SYNC_FINALIZED_HEIGHT: &str = "zaino.sync.finalized_height";
+    pub(crate) const SYNC_TARGET_HEIGHT: &str = "zaino.sync.target_height";
+    pub(crate) const SYNC_LAG_BLOCKS: &str = "zaino.sync.lag_blocks";
+    pub(crate) const SYNC_HAS_REACHED_TIP: &str = "zaino.sync.has_reached_tip";
+    pub(crate) const SYNC_TRANSACTIONS_TOTAL: &str = "zaino.sync.transactions_total";
+    pub(crate) const DB_TIP_HEIGHT: &str = "zaino.db.tip_height";
+    pub(crate) const CHAIN_TIP_HEIGHT: &str = "zaino.chain.tip_height";
+}
+
+/// One scrape of the endpoint, parsed into unlabelled sample values.
+#[derive(Debug, Default)]
+pub(crate) struct Scrape {
+    samples: HashMap<String, f64>,
+}
+
+impl Scrape {
+    /// Reads a metric, or reports which one was missing.
+    pub(crate) fn require(&self, name: &'static str) -> Result<f64, BenchError> {
+        self.get(name).ok_or(BenchError::MissingMetric(name))
+    }
+
+    /// Reads a metric that may legitimately be absent — a gauge zainod has not
+    /// set yet, such as `has_reached_tip` before the first sync iteration.
+    pub(crate) fn get(&self, name: &str) -> Option<f64> {
+        self.samples.get(&exposed_name(name)).copied()
+    }
+
+    /// Reads a height metric, rounded to the integer it represents.
+    ///
+    /// Heights cross the exposition format as `f64`; every value in play is far
+    /// below 2^53, so the round-trip is exact.
+    pub(crate) fn height(&self, name: &'static str) -> Result<u64, BenchError> {
+        Ok(self.require(name)?.max(0.0) as u64)
+    }
+
+    /// Parses the Prometheus text exposition format.
+    ///
+    /// Only unlabelled samples are kept: every metric the harness reads is a
+    /// process-wide gauge, and skipping labelled series avoids collapsing a
+    /// per-method histogram into a single meaningless number.
+    fn parse(body: &str) -> Self {
+        let samples = body
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty() && !line.starts_with('#'))
+            .filter_map(parse_sample)
+            .collect();
+
+        Self { samples }
+    }
+}
+
+/// Polls `url` until it answers, then returns the first successful scrape.
+///
+/// Waiting rather than failing is deliberate: the operator starts the harness
+/// *before* zainod so that t0 is the moment zainod begins, not the moment
+/// someone got to a second terminal.
+pub(crate) async fn await_endpoint(
+    client: &reqwest::Client,
+    url: &str,
+    poll_interval: Duration,
+) -> Scrape {
+    loop {
+        match scrape(client, url).await {
+            Ok(scrape) => return scrape,
+            Err(error) => {
+                eprintln!("  waiting for {url}: {error}");
+                tokio::time::sleep(poll_interval).await;
+            }
+        }
+    }
+}
+
+/// Fetches and parses one scrape.
+pub(crate) async fn scrape(client: &reqwest::Client, url: &str) -> Result<Scrape, BenchError> {
+    let scrape_error = |source| BenchError::Scrape {
+        url: url.to_string(),
+        source,
+    };
+
+    let body = client
+        .get(url)
+        .send()
+        .await
+        .and_then(reqwest::Response::error_for_status)
+        .map_err(scrape_error)?
+        .text()
+        .await
+        .map_err(scrape_error)?;
+
+    Ok(Scrape::parse(&body))
+}
+
+/// Translates a registered metric name into the name it is exposed under.
+///
+/// `metrics-exporter-prometheus` sanitises names to the Prometheus character
+/// set, so the dotted name `zaino-state` registers reaches the wire as
+/// `zaino_sync_finalized_height`.
+fn exposed_name(registered: &str) -> String {
+    registered.replace(['.', '-'], "_")
+}
+
+/// Splits `name value` / `name{labels} value`, keeping only unlabelled samples.
+fn parse_sample(line: &str) -> Option<(String, f64)> {
+    let (name, value) = line.rsplit_once(char::is_whitespace)?;
+    let name = name.trim();
+    if name.contains('{') {
+        return None;
+    }
+    Some((name.to_string(), value.trim().parse().ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = "\
+# HELP zaino_sync_finalized_height Highest finalised block written to Zaino's db.
+# TYPE zaino_sync_finalized_height gauge
+zaino_sync_finalized_height 3200000
+# TYPE zaino_sync_target_height gauge
+zaino_sync_target_height 3390744
+zaino_sync_has_reached_tip 0
+zaino_db_tip_height 3200000
+zaino_chain_tip_height 3390744
+# TYPE zaino_grpc_request_duration_seconds histogram
+zaino_grpc_request_duration_seconds{method=\"get_block_range\",quantile=\"0.5\"} 0.012
+
+";
+
+    #[test]
+    fn parses_unlabelled_gauges() {
+        let scrape = Scrape::parse(SAMPLE);
+        assert_eq!(
+            scrape.height(names::SYNC_FINALIZED_HEIGHT).ok(),
+            Some(3200000)
+        );
+        assert_eq!(scrape.height(names::SYNC_TARGET_HEIGHT).ok(), Some(3390744));
+        assert_eq!(scrape.get(names::SYNC_HAS_REACHED_TIP), Some(0.0));
+    }
+
+    #[test]
+    fn skips_labelled_series() {
+        let scrape = Scrape::parse(SAMPLE);
+        assert_eq!(scrape.get("zaino.grpc.request_duration_seconds"), None);
+    }
+
+    #[test]
+    fn a_missing_metric_names_itself() {
+        let error = Scrape::default()
+            .require(names::SYNC_FINALIZED_HEIGHT)
+            .expect_err("empty scrape has no metrics");
+        assert!(
+            error.to_string().contains(names::SYNC_FINALIZED_HEIGHT),
+            "error should name the missing metric: {error}"
+        );
+    }
+
+    #[test]
+    fn dotted_names_reach_the_wire_underscored() {
+        assert_eq!(
+            exposed_name(names::SYNC_FINALIZED_HEIGHT),
+            "zaino_sync_finalized_height"
+        );
+    }
+
+    /// Pins this crate's copy of the metric names to the ones `zaino-state`
+    /// actually emits, so a rename there fails the build rather than silently
+    /// producing a harness that waits forever for a metric nobody publishes.
+    #[test]
+    fn metric_names_match_zaino_state() {
+        use zaino_state::metric_names as upstream;
+
+        assert_eq!(
+            names::SYNC_FINALIZED_HEIGHT,
+            upstream::SYNC_FINALIZED_HEIGHT
+        );
+        assert_eq!(names::SYNC_TARGET_HEIGHT, upstream::SYNC_TARGET_HEIGHT);
+        assert_eq!(names::SYNC_LAG_BLOCKS, upstream::SYNC_LAG_BLOCKS);
+        assert_eq!(names::SYNC_HAS_REACHED_TIP, upstream::SYNC_HAS_REACHED_TIP);
+        assert_eq!(
+            names::SYNC_TRANSACTIONS_TOTAL,
+            upstream::SYNC_TRANSACTIONS_TOTAL
+        );
+        assert_eq!(names::DB_TIP_HEIGHT, upstream::DB_TIP_HEIGHT);
+        assert_eq!(names::CHAIN_TIP_HEIGHT, upstream::CHAIN_TIP_HEIGHT);
+    }
+}

--- a/packages/zaino-bench/src/metrics.rs
+++ b/packages/zaino-bench/src/metrics.rs
@@ -69,19 +69,33 @@ impl Scrape {
     }
 }
 
-/// Polls `url` until it answers, then returns the first successful scrape.
+/// Polls `url` until it serves `required`, then returns that scrape.
 ///
 /// Waiting rather than failing is deliberate: the operator starts the harness
 /// *before* zainod so that t0 is the moment zainod begins, not the moment
 /// someone got to a second terminal.
-pub(crate) async fn await_endpoint(
+///
+/// Readiness is the *metric*, not the endpoint. zainod binds its exporter
+/// during startup, but the sync gauges are first set from inside the write
+/// loop — after network adoption and the db open, and then only on a ten-second
+/// throttle. So there is a window, unbounded on a cold start, where the endpoint
+/// answers 200 with a body that does not mention `zaino.sync.*` yet. Returning
+/// the first successful scrape lands in that window and fails the run before it
+/// begins; waiting for the gauge is what "zainod has started syncing" actually
+/// means.
+pub(crate) async fn await_metric(
     client: &reqwest::Client,
     url: &str,
+    required: &'static str,
     poll_interval: Duration,
 ) -> Scrape {
     loop {
         match scrape(client, url).await {
-            Ok(scrape) => return scrape,
+            Ok(scrape) if scrape.get(required).is_some() => return scrape,
+            Ok(_) => {
+                eprintln!("  {url} is up; waiting for `{required}` (zainod is still starting)");
+                tokio::time::sleep(poll_interval).await;
+            }
             Err(error) => {
                 eprintln!("  waiting for {url}: {error}");
                 tokio::time::sleep(poll_interval).await;
@@ -172,6 +186,29 @@ zaino_grpc_request_duration_seconds{method=\"get_block_range\",quantile=\"0.5\"}
         assert!(
             error.to_string().contains(names::SYNC_FINALIZED_HEIGHT),
             "error should name the missing metric: {error}"
+        );
+    }
+
+    /// The scrape zainod serves between binding its exporter and the write
+    /// loop's first gauge set: a healthy 200 that does not carry `zaino.sync.*`
+    /// yet. `await_metric` must keep waiting on this, not accept it — accepting
+    /// it is what failed a run before it started.
+    #[test]
+    fn a_started_exporter_without_the_sync_gauges_is_not_ready() {
+        const STARTING_UP: &str = "\
+# TYPE zaino_grpc_request_duration_seconds histogram
+zaino_grpc_request_duration_seconds{method=\"get_block_range\",quantile=\"0.5\"} 0.012
+";
+        let scrape = Scrape::parse(STARTING_UP);
+        assert!(
+            scrape.get(names::SYNC_FINALIZED_HEIGHT).is_none(),
+            "the readiness predicate must treat this scrape as not-yet-ready"
+        );
+        assert!(
+            Scrape::parse(SAMPLE)
+                .get(names::SYNC_FINALIZED_HEIGHT)
+                .is_some(),
+            "and must treat a scrape carrying the gauge as ready"
         );
     }
 

--- a/packages/zaino-bench/src/serve.rs
+++ b/packages/zaino-bench/src/serve.rs
@@ -1,0 +1,264 @@
+//! Single-stream serve rate — "how fast can you serve blocks?"
+//!
+//! Ported from the `zaino-admin check` tool on the `hahn/store` branch. Streams
+//! one large `GetBlockRange` and verifies the chain links as blocks arrive, so
+//! the run reports serve rate and correctness from the same pass: a fast answer
+//! that does not link up is not an answer.
+
+use std::time::Instant;
+
+use clap::Args;
+use futures::StreamExt;
+use zaino_proto::proto::compact_formats::CompactBlock;
+
+use crate::chain::ChainVerifier;
+use crate::error::BenchError;
+use crate::grpc_client;
+
+/// Stream a height range from one connection and report blocks/s and bytes/s.
+#[derive(Args)]
+pub(super) struct ServeArgs {
+    /// Server under test (e.g. "http://127.0.0.1:8137").
+    #[arg(short, long)]
+    server: String,
+
+    /// Height to start streaming from.
+    #[arg(long, default_value = "0")]
+    start_height: u64,
+
+    /// Height to stop at. Defaults to the server's chain tip.
+    #[arg(long)]
+    end_height: Option<u64>,
+
+    /// Print progress every N blocks.
+    #[arg(long, default_value = "100000")]
+    progress_interval: u64,
+
+    /// Stop after this many chain errors.
+    #[arg(long, default_value = "10")]
+    max_errors: usize,
+}
+
+/// What the stream delivered.
+struct Delivered {
+    blocks: u64,
+    bytes: u64,
+    verifier: ChainVerifier,
+    stream_error: Option<String>,
+}
+
+pub(super) async fn run(args: ServeArgs) -> Result<(), BenchError> {
+    let mut client = grpc_client::connect_eager(&args.server).await?;
+    let tip = grpc_client::get_latest_height(&mut client).await?;
+    let end_height = args.end_height.unwrap_or(tip);
+
+    if args.start_height > end_height {
+        return Err(BenchError::Args(format!(
+            "--start-height {} is above --end-height {end_height}",
+            args.start_height
+        )));
+    }
+
+    eprintln!("Server:    {}", args.server);
+    eprintln!("Chain tip: {tip}");
+    eprintln!(
+        "Streaming: {}..={end_height} ({} blocks)",
+        args.start_height,
+        end_height - args.start_height + 1,
+    );
+    eprintln!();
+
+    // The clock starts at the request, not at the connect: connect cost is the
+    // load test's concern, and folding it in here would understate serve rate on
+    // short ranges.
+    let started = Instant::now();
+    let stream =
+        grpc_client::block_range_stream(&mut client, args.start_height, end_height).await?;
+    let delivered = drain(stream, args.progress_interval.max(1), args.max_errors).await;
+    let elapsed = started.elapsed();
+
+    report(&delivered, elapsed);
+
+    let total_errors = delivered.verifier.total_errors();
+    if total_errors > 0 {
+        return Err(BenchError::InvalidChain(total_errors));
+    }
+    Ok(())
+}
+
+async fn drain(
+    mut stream: tonic::Streaming<CompactBlock>,
+    progress_interval: u64,
+    max_errors: usize,
+) -> Delivered {
+    let mut delivered = Delivered {
+        blocks: 0,
+        bytes: 0,
+        verifier: ChainVerifier::new(),
+        stream_error: None,
+    };
+
+    while let Some(item) = stream.next().await {
+        let block = match item {
+            Ok(block) => block,
+            Err(status) => {
+                // A mid-stream failure is itself a result worth reporting — the
+                // `hahn/store` numbers show exactly this under load — so record
+                // it and summarise what did arrive rather than bailing out.
+                delivered.stream_error = Some(status.to_string());
+                break;
+            }
+        };
+
+        delivered.blocks += 1;
+        delivered.bytes += wire_size(&block);
+        delivered.verifier.push(&block);
+
+        if delivered.verifier.breaks().len() >= max_errors {
+            break;
+        }
+        if delivered.blocks.is_multiple_of(progress_interval) {
+            eprintln!("  ... {} blocks streamed ...", delivered.blocks);
+        }
+    }
+
+    delivered
+}
+
+/// Approximate served bytes for a compact block.
+///
+/// `prost::Message::encoded_len` would need a `prost` dependency purely to
+/// re-measure what the server already sent; summing the variable-length fields
+/// tracks the payload closely enough for a throughput figure, and the report
+/// labels it as approximate.
+fn wire_size(block: &CompactBlock) -> u64 {
+    let header = (block.hash.len() + block.prev_hash.len() + block.header.len()) as u64;
+    let transactions: u64 = block
+        .vtx
+        .iter()
+        .map(|tx| {
+            let spends: usize = tx.spends.iter().map(|spend| spend.nf.len()).sum();
+            let outputs: usize = tx
+                .outputs
+                .iter()
+                .map(|output| {
+                    output.cmu.len() + output.ephemeral_key.len() + output.ciphertext.len()
+                })
+                .sum();
+            let actions: usize = tx
+                .actions
+                .iter()
+                .map(|action| {
+                    action.nullifier.len()
+                        + action.cmx.len()
+                        + action.ephemeral_key.len()
+                        + action.ciphertext.len()
+                })
+                .sum();
+            (tx.txid.len() + spends + outputs + actions) as u64
+        })
+        .sum();
+
+    header + transactions
+}
+
+fn report(delivered: &Delivered, elapsed: std::time::Duration) {
+    let seconds = elapsed.as_secs_f64();
+
+    eprintln!();
+    if let Some(error) = &delivered.stream_error {
+        eprintln!("  Stream error after {} blocks: {error}", delivered.blocks);
+        eprintln!();
+    }
+
+    eprintln!("══════════════════════════════════════════");
+    eprintln!("  Single-Stream Serve Rate — Summary");
+    eprintln!("══════════════════════════════════════════");
+    eprintln!("  Blocks streamed:    {}", delivered.blocks);
+    eprintln!("  Wall-clock time:    {seconds:.2}s");
+    if seconds > 0.0 {
+        eprintln!(
+            "  Serve rate:         {:.0} blocks/s",
+            delivered.blocks as f64 / seconds
+        );
+        eprintln!(
+            "  Payload rate:       {:.1} MB/s (approx)",
+            delivered.bytes as f64 / seconds / 1_000_000.0
+        );
+    }
+    eprintln!(
+        "  Payload:            {:.1} MB (approx)",
+        delivered.bytes as f64 / 1_000_000.0
+    );
+    eprintln!(
+        "  Chain breaks:       {}",
+        delivered.verifier.breaks().len()
+    );
+    eprintln!(
+        "  Hash length errors: {}",
+        delivered.verifier.hash_length_errors()
+    );
+    eprintln!(
+        "  Total errors:       {}",
+        delivered.verifier.total_errors()
+    );
+    eprintln!();
+
+    for chain_break in delivered.verifier.breaks() {
+        eprintln!(
+            "  CHAIN BREAK at height {}: {}",
+            chain_break.height, chain_break.detail
+        );
+    }
+
+    if delivered.verifier.total_errors() == 0 {
+        eprintln!(
+            "  ✅ Chain is VALID — all {} blocks link correctly.",
+            delivered.blocks
+        );
+    } else {
+        eprintln!(
+            "  ❌ Chain is INVALID — {} error(s) found.",
+            delivered.verifier.total_errors()
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zaino_proto::proto::compact_formats::{CompactSaplingOutput, CompactTx};
+
+    #[test]
+    fn wire_size_counts_header_and_transaction_payload() {
+        let block = CompactBlock {
+            height: 1,
+            hash: vec![0u8; 32],
+            prev_hash: vec![0u8; 32],
+            header: vec![0u8; 100],
+            vtx: vec![CompactTx {
+                txid: vec![0u8; 32],
+                outputs: vec![CompactSaplingOutput {
+                    cmu: vec![0u8; 32],
+                    ephemeral_key: vec![0u8; 32],
+                    ciphertext: vec![0u8; 52],
+                }],
+                ..CompactTx::default()
+            }],
+            ..CompactBlock::default()
+        };
+
+        // 32 + 32 + 100 header, then 32 + (32 + 32 + 52) for the one transaction.
+        assert_eq!(wire_size(&block), 164 + 148);
+    }
+
+    #[test]
+    fn an_empty_block_has_only_its_header() {
+        let block = CompactBlock {
+            hash: vec![0u8; 32],
+            prev_hash: vec![0u8; 32],
+            ..CompactBlock::default()
+        };
+        assert_eq!(wire_size(&block), 64);
+    }
+}

--- a/packages/zaino-bench/src/stats.rs
+++ b/packages/zaino-bench/src/stats.rs
@@ -1,0 +1,94 @@
+//! Summary statistics over a sample of durations.
+
+/// Min / mean / max plus the tail percentiles.
+///
+/// Under load the mean understates what a client actually experiences, so every
+/// latency line the harness prints carries p50/p95/p99 alongside it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct Summary {
+    pub(crate) min: f64,
+    pub(crate) mean: f64,
+    pub(crate) max: f64,
+    pub(crate) p50: f64,
+    pub(crate) p95: f64,
+    pub(crate) p99: f64,
+}
+
+impl Summary {
+    /// Summarises `samples`, or returns `None` when there is nothing to
+    /// summarise (every connection failed, so there are no timings to report).
+    pub(crate) fn new(samples: &[f64]) -> Option<Self> {
+        if samples.is_empty() {
+            return None;
+        }
+
+        let mut sorted = samples.to_vec();
+        sorted.sort_by(f64::total_cmp);
+
+        Some(Self {
+            min: sorted[0],
+            mean: sorted.iter().sum::<f64>() / sorted.len() as f64,
+            max: sorted[sorted.len() - 1],
+            p50: percentile(&sorted, 0.50),
+            p95: percentile(&sorted, 0.95),
+            p99: percentile(&sorted, 0.99),
+        })
+    }
+
+    /// One aligned line: `<label> min .. mean .. max .. p50 .. p95 .. p99`.
+    pub(crate) fn line(&self, label: &str) -> String {
+        format!(
+            "  {label:<26} min {:>8.3}  mean {:>8.3}  max {:>8.3}  \
+             p50 {:>8.3}  p95 {:>8.3}  p99 {:>8.3}",
+            self.min, self.mean, self.max, self.p50, self.p95, self.p99
+        )
+    }
+}
+
+/// Nearest-rank percentile over an already-sorted slice.
+///
+/// Nearest-rank (rather than an interpolating definition) so every reported
+/// percentile is a timing some connection actually observed.
+fn percentile(sorted: &[f64], fraction: f64) -> f64 {
+    debug_assert!(!sorted.is_empty(), "percentile of an empty sample");
+    let rank = (fraction * sorted.len() as f64).ceil() as usize;
+    sorted[rank.saturating_sub(1).min(sorted.len() - 1)]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ONE_TO_TEN: [f64; 10] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0];
+
+    #[test]
+    fn summarises_a_known_sample() {
+        let summary = Summary::new(&ONE_TO_TEN).expect("non-empty sample");
+        assert_eq!(summary.min, 1.0);
+        assert_eq!(summary.max, 10.0);
+        assert_eq!(summary.mean, 5.5);
+        assert_eq!(summary.p50, 5.0);
+        assert_eq!(summary.p95, 10.0);
+        assert_eq!(summary.p99, 10.0);
+    }
+
+    #[test]
+    fn sorts_before_summarising() {
+        let mut shuffled = ONE_TO_TEN;
+        shuffled.reverse();
+        assert_eq!(Summary::new(&shuffled), Summary::new(&ONE_TO_TEN));
+    }
+
+    #[test]
+    fn a_single_sample_is_every_percentile() {
+        let summary = Summary::new(&[4.0]).expect("non-empty sample");
+        assert_eq!(summary.min, 4.0);
+        assert_eq!(summary.max, 4.0);
+        assert_eq!(summary.p99, 4.0);
+    }
+
+    #[test]
+    fn an_empty_sample_has_no_summary() {
+        assert!(Summary::new(&[]).is_none());
+    }
+}

--- a/packages/zaino-bench/src/sync.rs
+++ b/packages/zaino-bench/src/sync.rs
@@ -1,0 +1,340 @@
+//! Initial-sync timing — "how long does it take to sync mainnet?"
+//!
+//! Samples zainod's Prometheus endpoint until its sync loop reports it has
+//! reached the chain tip, then reports wall-clock time and the block rate.
+//! Nothing here touches the node under test beyond an HTTP GET, so the number
+//! it produces is the node's, not the harness's.
+
+use std::fmt::Write as _;
+use std::io::Write as _;
+use std::time::{Duration, Instant};
+
+use clap::Args;
+
+use crate::error::BenchError;
+use crate::metrics::{self, names, Scrape};
+
+/// Measure how long zainod takes to sync from its current height to the tip.
+///
+/// Start this *before* zainod: it waits for `/metrics` to come up, so t0 is the
+/// moment the node starts rather than the moment you reached a second terminal.
+#[derive(Args)]
+pub(super) struct SyncArgs {
+    /// zainod's Prometheus scrape endpoint.
+    ///
+    /// Requires zainod built with `--features prometheus` and `metrics_endpoint`
+    /// set in its config.
+    #[arg(long, default_value = "http://127.0.0.1:9998/metrics")]
+    metrics_url: String,
+
+    /// Seconds between samples.
+    #[arg(long, default_value = "10")]
+    poll_interval_secs: u64,
+
+    /// Stop once the finalised height reaches this, instead of waiting for the
+    /// tip. Useful for a bounded run over a fixed span of blocks.
+    #[arg(long)]
+    until_height: Option<u64>,
+
+    /// Fail if the finalised height does not advance for this many seconds.
+    #[arg(long, default_value = "900")]
+    stall_timeout_secs: u64,
+
+    /// Also write every sample to this CSV, for graphing the sync curve.
+    #[arg(long)]
+    csv: Option<String>,
+}
+
+/// One sample of the node's sync progress.
+struct Sample {
+    elapsed: Duration,
+    finalized_height: u64,
+    target_height: u64,
+    /// The node's own lag gauge, preferred over `target - finalized`: it is
+    /// what zainod believes, and a disagreement between the two is itself a
+    /// finding rather than something to smooth over.
+    lag_blocks: Option<u64>,
+    db_tip_height: Option<u64>,
+    chain_tip_height: Option<u64>,
+    transactions: Option<u64>,
+    reached_tip: bool,
+}
+
+impl Sample {
+    /// Blocks still to go, from the node's gauge where it has one.
+    fn lag(&self) -> u64 {
+        self.lag_blocks
+            .unwrap_or_else(|| self.target_height.saturating_sub(self.finalized_height))
+    }
+}
+
+pub(super) async fn run(args: SyncArgs) -> Result<(), BenchError> {
+    let poll_interval = Duration::from_secs(args.poll_interval_secs.max(1));
+    let stall_timeout = Duration::from_secs(args.stall_timeout_secs);
+    let client = reqwest::Client::new();
+
+    eprintln!("Metrics:  {}", args.metrics_url);
+    eprintln!("Sampling every {}s", poll_interval.as_secs());
+    eprintln!();
+
+    let first = metrics::await_endpoint(&client, &args.metrics_url, poll_interval).await;
+    let started = Instant::now();
+    let start_height = first.height(names::SYNC_FINALIZED_HEIGHT)?;
+
+    eprintln!("Start height: {start_height}");
+    if let Some(target) = first.get(names::SYNC_TARGET_HEIGHT) {
+        eprintln!("Target height (at t0): {}", target as u64);
+    }
+    eprintln!();
+
+    let mut samples = vec![sample(&first, Duration::ZERO)?];
+    let mut last_progress = (started, start_height);
+
+    loop {
+        if finished(samples.last(), args.until_height) {
+            break;
+        }
+
+        tokio::time::sleep(poll_interval).await;
+
+        let scrape = metrics::scrape(&client, &args.metrics_url).await?;
+        let current = sample(&scrape, started.elapsed())?;
+
+        if current.finalized_height > last_progress.1 {
+            last_progress = (Instant::now(), current.finalized_height);
+        } else if last_progress.0.elapsed() >= stall_timeout {
+            report(&samples, start_height);
+            return Err(BenchError::SyncStalled {
+                height: current.finalized_height,
+                timeout: stall_timeout,
+            });
+        }
+
+        eprintln!("{}", progress_line(&current, samples.last()));
+        samples.push(current);
+    }
+
+    report(&samples, start_height);
+
+    if let Some(path) = &args.csv {
+        write_csv(path, &samples)?;
+        eprintln!();
+        eprintln!("  Sample curve written to {path}");
+    }
+
+    Ok(())
+}
+
+/// Whether the run is done: the node says it reached the tip, or the caller's
+/// `--until-height` has been passed.
+fn finished(latest: Option<&Sample>, until_height: Option<u64>) -> bool {
+    let Some(latest) = latest else {
+        return false;
+    };
+
+    match until_height {
+        Some(target) => latest.finalized_height >= target,
+        None => latest.reached_tip,
+    }
+}
+
+fn sample(scrape: &Scrape, elapsed: Duration) -> Result<Sample, BenchError> {
+    Ok(Sample {
+        elapsed,
+        finalized_height: scrape.height(names::SYNC_FINALIZED_HEIGHT)?,
+        target_height: scrape.height(names::SYNC_TARGET_HEIGHT)?,
+        lag_blocks: scrape
+            .get(names::SYNC_LAG_BLOCKS)
+            .map(|v| v.max(0.0) as u64),
+        db_tip_height: scrape.get(names::DB_TIP_HEIGHT).map(|v| v as u64),
+        chain_tip_height: scrape.get(names::CHAIN_TIP_HEIGHT).map(|v| v as u64),
+        transactions: scrape.get(names::SYNC_TRANSACTIONS_TOTAL).map(|v| v as u64),
+        // Absent until the sync loop completes its first iteration, which is
+        // "not yet at tip" rather than an error.
+        reached_tip: scrape.get(names::SYNC_HAS_REACHED_TIP).unwrap_or(0.0) >= 1.0,
+    })
+}
+
+fn progress_line(current: &Sample, previous: Option<&Sample>) -> String {
+    let mut line = format!(
+        "  [{:>8.0}s] height {:>9} / {:<9}  lag {:>8}",
+        current.elapsed.as_secs_f64(),
+        current.finalized_height,
+        current.target_height,
+        current.lag(),
+    );
+
+    if let Some(rate) = interval_rate(current, previous) {
+        let _ = write!(line, "  {rate:>9.0} blocks/s");
+    }
+    if current.reached_tip {
+        line.push_str("  ✅ at tip");
+    }
+
+    line
+}
+
+/// Blocks per second over the interval between two samples.
+///
+/// `None` when there is no earlier sample, or when two samples share a
+/// timestamp — a rate over a zero interval is not a number worth printing.
+fn interval_rate(current: &Sample, previous: Option<&Sample>) -> Option<f64> {
+    let previous = previous?;
+    let seconds = (current.elapsed.saturating_sub(previous.elapsed)).as_secs_f64();
+    if seconds <= 0.0 {
+        return None;
+    }
+    let blocks = current
+        .finalized_height
+        .saturating_sub(previous.finalized_height);
+    Some(blocks as f64 / seconds)
+}
+
+fn report(samples: &[Sample], start_height: u64) {
+    let Some(last) = samples.last() else {
+        return;
+    };
+
+    let elapsed = last.elapsed.as_secs_f64();
+    let blocks = last.finalized_height.saturating_sub(start_height);
+
+    eprintln!();
+    eprintln!("══════════════════════════════════════════");
+    eprintln!("  Initial Sync — Summary");
+    eprintln!("══════════════════════════════════════════");
+    eprintln!("  Start height:       {start_height}");
+    eprintln!("  End height:         {}", last.finalized_height);
+    eprintln!("  Blocks synced:      {blocks}");
+    eprintln!("  Target height:      {}", last.target_height);
+    if let Some(db_tip) = last.db_tip_height {
+        eprintln!("  Db tip height:      {db_tip}");
+    }
+    if let Some(chain_tip) = last.chain_tip_height {
+        eprintln!("  Chain tip height:   {chain_tip}");
+    }
+    if let Some(transactions) = last.transactions {
+        eprintln!("  Transactions indexed: {transactions}");
+    }
+    eprintln!("  Wall-clock time:    {}", human_duration(last.elapsed));
+    if elapsed > 0.0 {
+        eprintln!(
+            "  Mean rate:          {:.0} blocks/s",
+            blocks as f64 / elapsed
+        );
+    }
+    eprintln!(
+        "  Reached tip:        {}",
+        if last.reached_tip { "yes" } else { "no" }
+    );
+}
+
+fn human_duration(duration: Duration) -> String {
+    let total = duration.as_secs();
+    format!(
+        "{}h {:02}m {:02}s ({:.1}s)",
+        total / 3600,
+        (total % 3600) / 60,
+        total % 60,
+        duration.as_secs_f64()
+    )
+}
+
+fn write_csv(path: &str, samples: &[Sample]) -> Result<(), BenchError> {
+    let csv_error = |source| BenchError::Csv {
+        path: path.to_string(),
+        source,
+    };
+
+    let mut file = std::fs::File::create(path).map_err(csv_error)?;
+    writeln!(
+        file,
+        "elapsed_secs,finalized_height,target_height,lag_blocks,db_tip_height,chain_tip_height,transactions_total,interval_blocks_per_sec"
+    )
+    .map_err(csv_error)?;
+
+    let mut previous: Option<&Sample> = None;
+    for current in samples {
+        writeln!(
+            file,
+            "{:.3},{},{},{},{},{},{},{}",
+            current.elapsed.as_secs_f64(),
+            current.finalized_height,
+            current.target_height,
+            current.lag(),
+            optional(current.db_tip_height),
+            optional(current.chain_tip_height),
+            optional(current.transactions),
+            interval_rate(current, previous)
+                .map(|rate| format!("{rate:.3}"))
+                .unwrap_or_default(),
+        )
+        .map_err(csv_error)?;
+        previous = Some(current);
+    }
+
+    Ok(())
+}
+
+fn optional(value: Option<u64>) -> String {
+    value.map(|v| v.to_string()).unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at(elapsed_secs: u64, finalized_height: u64, reached_tip: bool) -> Sample {
+        Sample {
+            elapsed: Duration::from_secs(elapsed_secs),
+            finalized_height,
+            target_height: 3_390_744,
+            lag_blocks: None,
+            db_tip_height: Some(finalized_height),
+            chain_tip_height: Some(3_390_744),
+            transactions: None,
+            reached_tip,
+        }
+    }
+
+    #[test]
+    fn lag_prefers_the_nodes_own_gauge() {
+        let mut sample = at(10, 3_000_000, false);
+        assert_eq!(sample.lag(), 390_744, "falls back to target - finalized");
+
+        sample.lag_blocks = Some(7);
+        assert_eq!(sample.lag(), 7, "the node's gauge wins when present");
+    }
+
+    #[test]
+    fn a_run_without_until_height_finishes_at_the_tip() {
+        assert!(!finished(Some(&at(10, 100, false)), None));
+        assert!(finished(Some(&at(10, 100, true)), None));
+    }
+
+    #[test]
+    fn until_height_finishes_the_run_before_the_tip() {
+        assert!(!finished(Some(&at(10, 99, false)), Some(100)));
+        assert!(finished(Some(&at(10, 100, false)), Some(100)));
+        assert!(finished(Some(&at(10, 101, false)), Some(100)));
+    }
+
+    #[test]
+    fn a_run_with_no_samples_yet_is_not_finished() {
+        assert!(!finished(None, None));
+        assert!(!finished(None, Some(100)));
+    }
+
+    #[test]
+    fn interval_rate_is_blocks_over_the_gap() {
+        let previous = at(10, 1_000, false);
+        let current = at(20, 6_000, false);
+        assert_eq!(interval_rate(&current, Some(&previous)), Some(500.0));
+    }
+
+    #[test]
+    fn interval_rate_needs_two_samples_and_a_positive_gap() {
+        let current = at(10, 1_000, false);
+        assert_eq!(interval_rate(&current, None), None);
+        assert_eq!(interval_rate(&current, Some(&at(10, 900, false))), None);
+    }
+}

--- a/packages/zaino-bench/src/sync.rs
+++ b/packages/zaino-bench/src/sync.rs
@@ -77,7 +77,13 @@ pub(super) async fn run(args: SyncArgs) -> Result<(), BenchError> {
     eprintln!("Sampling every {}s", poll_interval.as_secs());
     eprintln!();
 
-    let first = metrics::await_endpoint(&client, &args.metrics_url, poll_interval).await;
+    let first = metrics::await_metric(
+        &client,
+        &args.metrics_url,
+        names::SYNC_FINALIZED_HEIGHT,
+        poll_interval,
+    )
+    .await;
     let started = Instant::now();
     let start_height = first.height(names::SYNC_FINALIZED_HEIGHT)?;
 

--- a/packages/zaino-bench/src/sync.rs
+++ b/packages/zaino-bench/src/sync.rs
@@ -50,9 +50,9 @@ struct Sample {
     elapsed: Duration,
     finalized_height: u64,
     target_height: u64,
-    /// The node's own lag gauge, preferred over `target - finalized`: it is
-    /// what zainod believes, and a disagreement between the two is itself a
-    /// finding rather than something to smooth over.
+    /// The node's own `zaino.sync.lag_blocks` gauge, recorded raw. Not used
+    /// for progress or completion — see [`Sample::lag`] for why — but kept in
+    /// the CSV so the run has the node's own reading next to the derived one.
     lag_blocks: Option<u64>,
     db_tip_height: Option<u64>,
     chain_tip_height: Option<u64>,
@@ -61,10 +61,35 @@ struct Sample {
 }
 
 impl Sample {
-    /// Blocks still to go, from the node's gauge where it has one.
+    /// Blocks still to go.
+    ///
+    /// Derived from the two height gauges rather than read from
+    /// `zaino.sync.lag_blocks`. That gauge is set to
+    /// `chain_tip - finalized_height_floor(chain_tip)`, which is the
+    /// non-finalised seam depth — a constant, not the distance left to sync. It
+    /// reads as ~100 whether the node is at the tip or three million blocks
+    /// short of it, so it cannot drive progress or completion here. It is still
+    /// recorded in the CSV as the node reported it.
     fn lag(&self) -> u64 {
-        self.lag_blocks
-            .unwrap_or_else(|| self.target_height.saturating_sub(self.finalized_height))
+        self.target_height.saturating_sub(self.finalized_height)
+    }
+
+    /// Whether the finalised writer has caught up with the height it is syncing
+    /// to.
+    ///
+    /// This, not the `zaino.sync.has_reached_tip` gauge, is what ends a run.
+    /// That gauge is set when the sync loop's iteration returns `Ok`, and
+    /// `FinalisedState::sync_to_height` returns `Ok` as soon as it has *spawned*
+    /// the background sync (it is single-flight: a poll landing on an in-flight
+    /// sync is a no-op that also returns `Ok`). So the gauge goes to 1 seconds
+    /// after start-up and stays there for the whole multi-hour sync — it means
+    /// "the sync loop is healthy", not "the index is at the tip".
+    ///
+    /// `target_height` is the finalised floor the writer was spawned against,
+    /// so `finalized >= target` is the writer's own definition of done, read
+    /// from the outside.
+    fn caught_up(&self) -> bool {
+        self.target_height > 0 && self.finalized_height >= self.target_height
     }
 }
 
@@ -131,8 +156,8 @@ pub(super) async fn run(args: SyncArgs) -> Result<(), BenchError> {
     Ok(())
 }
 
-/// Whether the run is done: the node says it reached the tip, or the caller's
-/// `--until-height` has been passed.
+/// Whether the run is done: the finalised height has caught up with the height
+/// being synced to, or the caller's `--until-height` has been passed.
 fn finished(latest: Option<&Sample>, until_height: Option<u64>) -> bool {
     let Some(latest) = latest else {
         return false;
@@ -140,7 +165,7 @@ fn finished(latest: Option<&Sample>, until_height: Option<u64>) -> bool {
 
     match until_height {
         Some(target) => latest.finalized_height >= target,
-        None => latest.reached_tip,
+        None => latest.caught_up(),
     }
 }
 
@@ -173,8 +198,8 @@ fn progress_line(current: &Sample, previous: Option<&Sample>) -> String {
     if let Some(rate) = interval_rate(current, previous) {
         let _ = write!(line, "  {rate:>9.0} blocks/s");
     }
-    if current.reached_tip {
-        line.push_str("  ✅ at tip");
+    if current.caught_up() {
+        line.push_str("  ✅ caught up");
     }
 
     line
@@ -229,8 +254,13 @@ fn report(samples: &[Sample], start_height: u64) {
         );
     }
     eprintln!(
-        "  Reached tip:        {}",
-        if last.reached_tip { "yes" } else { "no" }
+        "  Caught up:          {}",
+        if last.caught_up() { "yes" } else { "no" }
+    );
+    eprintln!(
+        "  Node's has_reached_tip gauge: {} (set once the sync loop is healthy, \
+         not on arrival at the tip)",
+        if last.reached_tip { "1" } else { "0" }
     );
 }
 
@@ -254,7 +284,7 @@ fn write_csv(path: &str, samples: &[Sample]) -> Result<(), BenchError> {
     let mut file = std::fs::File::create(path).map_err(csv_error)?;
     writeln!(
         file,
-        "elapsed_secs,finalized_height,target_height,lag_blocks,db_tip_height,chain_tip_height,transactions_total,interval_blocks_per_sec"
+        "elapsed_secs,finalized_height,target_height,lag_blocks,node_lag_gauge,db_tip_height,chain_tip_height,transactions_total,interval_blocks_per_sec"
     )
     .map_err(csv_error)?;
 
@@ -262,11 +292,12 @@ fn write_csv(path: &str, samples: &[Sample]) -> Result<(), BenchError> {
     for current in samples {
         writeln!(
             file,
-            "{:.3},{},{},{},{},{},{},{}",
+            "{:.3},{},{},{},{},{},{},{},{}",
             current.elapsed.as_secs_f64(),
             current.finalized_height,
             current.target_height,
             current.lag(),
+            optional(current.lag_blocks),
             optional(current.db_tip_height),
             optional(current.chain_tip_height),
             optional(current.transactions),
@@ -302,19 +333,44 @@ mod tests {
         }
     }
 
+    /// The node's `lag_blocks` gauge reports the non-finalised seam depth, a
+    /// constant, so a run three million blocks short of the tip and one sitting
+    /// on it both publish roughly the same value. `lag` must therefore derive
+    /// from the heights and ignore the gauge entirely.
     #[test]
-    fn lag_prefers_the_nodes_own_gauge() {
+    fn lag_is_derived_from_the_heights_not_the_nodes_gauge() {
         let mut sample = at(10, 3_000_000, false);
-        assert_eq!(sample.lag(), 390_744, "falls back to target - finalized");
+        assert_eq!(sample.lag(), 390_744, "target - finalized");
 
-        sample.lag_blocks = Some(7);
-        assert_eq!(sample.lag(), 7, "the node's gauge wins when present");
+        sample.lag_blocks = Some(100);
+        assert_eq!(
+            sample.lag(),
+            390_744,
+            "the seam-depth gauge must not override the derived lag"
+        );
+    }
+
+    /// The regression behind an early exit: the node sets `has_reached_tip` as
+    /// soon as its sync loop is healthy, which is seconds into a multi-hour
+    /// sync. Completion must follow the heights instead.
+    #[test]
+    fn the_nodes_reached_tip_gauge_does_not_end_a_run() {
+        let early = at(30, 8_897, true);
+        assert!(
+            !early.caught_up(),
+            "8897 of 3390744 is not caught up, whatever the gauge says"
+        );
+        assert!(!finished(Some(&early), None), "the run must keep going");
+
+        let done = at(9_000, 3_390_744, false);
+        assert!(done.caught_up(), "finalized == target is caught up");
+        assert!(finished(Some(&done), None), "and ends the run");
     }
 
     #[test]
-    fn a_run_without_until_height_finishes_at_the_tip() {
+    fn a_run_without_until_height_finishes_when_it_catches_up() {
         assert!(!finished(Some(&at(10, 100, false)), None));
-        assert!(finished(Some(&at(10, 100, true)), None));
+        assert!(finished(Some(&at(10, 3_390_744, false)), None));
     }
 
     #[test]

--- a/packages/zaino-bench/usage.md
+++ b/packages/zaino-bench/usage.md
@@ -60,9 +60,25 @@ Three things about them matter:
 
 ## `sync` — initial sync time
 
-Samples `zaino.sync.finalized_height` / `target_height` / `has_reached_tip` until
-zainod reports it has reached the tip, then prints wall-clock time, blocks
-synced, and mean blocks/s.
+Samples `zaino.sync.finalized_height` / `target_height` until the finalised
+height catches up with the height being synced to, then prints wall-clock time,
+blocks synced, and mean blocks/s.
+
+Completion is derived from those two heights, deliberately, rather than read
+from the node's own `zaino.sync.has_reached_tip` and `zaino.sync.lag_blocks`
+gauges. Neither means what its name suggests:
+
+- `has_reached_tip` is set when the sync loop's iteration returns `Ok`, and
+  `sync_to_height` returns `Ok` as soon as it has *spawned* the background sync
+  (it is single-flight, so a poll landing on an in-flight sync is also an `Ok`
+  no-op). It goes to 1 seconds after start-up and stays there — it means "the
+  sync loop is healthy", not "the index is at the tip".
+- `lag_blocks` is `chain_tip - finalized_height_floor(chain_tip)`: the
+  non-finalised seam depth, a constant, not the distance left to sync.
+
+Both are still recorded — `has_reached_tip` in the summary, `lag_blocks` in the
+CSV's `node_lag_gauge` column — so a run carries the node's own readings next to
+the derived ones.
 
 **Start it before zainod.** It waits for the `zaino.sync.finalized_height`
 gauge to appear — not merely for `/metrics` to answer, since zainod binds the

--- a/packages/zaino-bench/usage.md
+++ b/packages/zaino-bench/usage.md
@@ -64,7 +64,9 @@ Samples `zaino.sync.finalized_height` / `target_height` / `has_reached_tip` unti
 zainod reports it has reached the tip, then prints wall-clock time, blocks
 synced, and mean blocks/s.
 
-**Start it before zainod.** It waits for `/metrics` to answer, so t0 is the
+**Start it before zainod.** It waits for the `zaino.sync.finalized_height`
+gauge to appear — not merely for `/metrics` to answer, since zainod binds the
+exporter well before the write loop first sets that gauge — so t0 is the
 moment the node starts rather than the moment you reached a second terminal:
 
 ```sh

--- a/packages/zaino-bench/usage.md
+++ b/packages/zaino-bench/usage.md
@@ -1,0 +1,144 @@
+# `zaino-bench` — measuring a running Zaino
+
+Three questions, three subcommands, all asked from *outside* the node over the
+interfaces a real client uses:
+
+| Question | Command |
+|---|---|
+| How long does it take to sync mainnet? | `zaino-bench sync` |
+| How many concurrent connections can it support? | `zaino-bench concurrent --sweep …` |
+| How fast can it serve blocks? | `zaino-bench serve`, and the sweep's throughput column |
+
+The harness is a workspace member but **not** a `default-member`, for the same
+reason as the live-test crates (docs/adr/0002): it is an operator tool, not part
+of the fast test loop. A bare `cargo nextest run` never builds it. Select it
+explicitly:
+
+```sh
+makers bench <SUBCOMMAND> [ARGS]         # cargo run --release -p zaino-bench --
+cargo nextest run -p zaino-bench         # the harness's own unit tests
+```
+
+Always run it **release**. A debug load generator spends its time in its own
+code and measures itself rather than the server; `makers bench` enforces this.
+
+## The node under test
+
+Results are only meaningful next to the config that produced them. Two configs
+in `docs/example_configs/` are the ones behind `docs/perf.md`, differing in one
+line:
+
+| File | `ephemeral_finalised_state` |
+|---|---|
+| `zainod-bench-mainnet.toml` | `false` — persistent |
+| `zainod-bench-mainnet-ephemeral.toml` | `true` — ephemeral |
+
+Three things about them matter:
+
+- **`backend = 'direct'`** — the Direct backend reads Zebra's `ReadStateService`
+  in-process, which is the fastest path Zaino has. It requires zainod and zebrad
+  on the same host. Measuring `'rpc'` instead answers a different question (what
+  Zaino can do against a *remote* validator), so say which one you measured.
+  `'state'` is the legacy spelling of `'direct'`; either parses.
+- **`ephemeral_finalised_state`** — in persistent mode a finalised read is
+  answered from Zaino's own index; in ephemeral mode Zaino keeps no index and
+  passes the read through to the validator. Those are different machinery, so
+  `concurrent` and `serve` are run and reported under both. `sync` is
+  persistent-only: there is no index to build in ephemeral mode, the
+  `zaino.sync.*` gauges are never emitted, and the harness would wait forever
+  for a metric that never arrives.
+- **`metrics_endpoint`** — `sync` reads its progress from there, which means
+  zainod must be built with the `prometheus` feature:
+
+  ```sh
+  cargo build --release -p zainod --features prometheus
+  zainod start --config docs/example_configs/zainod-bench-mainnet.toml
+  ```
+
+  Without that feature the endpoint never binds and `sync` waits forever; the
+  other two subcommands do not need it.
+
+## `sync` — initial sync time
+
+Samples `zaino.sync.finalized_height` / `target_height` / `has_reached_tip` until
+zainod reports it has reached the tip, then prints wall-clock time, blocks
+synced, and mean blocks/s.
+
+**Start it before zainod.** It waits for `/metrics` to answer, so t0 is the
+moment the node starts rather than the moment you reached a second terminal:
+
+```sh
+# terminal 1
+makers bench sync --csv sync-mainnet.csv
+# terminal 2, once the harness says it is waiting
+zainod start --config docs/example_configs/zainod-bench-mainnet.toml
+```
+
+To measure a *fresh* sync, empty `storage.database.path` first — an existing
+finalised-state db means you are measuring a catch-up, not an initial sync.
+Check free space before you do: a full mainnet index is ~275 GiB and shares a
+volume with zebrad's ~260 GiB, so an old index backup left in place is enough to
+run the volume out partway through a run that takes hours.
+
+`--csv` writes every sample (elapsed, heights, lag, transactions, interval rate)
+for graphing the curve. `--until-height N` bounds the run to a fixed span instead
+of waiting for the tip. `--stall-timeout-secs` fails the run, non-zero, if the
+finalised height stops advancing — so an overnight run does not silently hang.
+
+## `concurrent` — connection ceiling and aggregate throughput
+
+Spawns N clients, each streaming `--blocks` blocks from its own window of
+`--start-height..=--end-height`, and reports success/failure counts, connect and
+fetch latency (min/mean/max **and** p50/p95/p99), chain breaks, and aggregate
+plus per-connection blocks/s.
+
+```sh
+makers bench concurrent \
+  --server http://127.0.0.1:8137 \
+  --start-height 3000000 --end-height 3380000 \
+  --blocks 1000 --sweep 100,250,500,1000,2000
+```
+
+Use `--sweep`, not a single `--connections` value. The answer to "how many
+connections can you support" is the knee — the largest round still at 100%
+success — and one point sample cannot locate it. The sweep prints a comparison
+table with exactly that reading in mind.
+
+Two things that will otherwise give you the wrong number:
+
+- **File descriptors.** Each connection needs a socket. The harness reads
+  `/proc/self/limits` and warns when the soft limit is under roughly
+  `connections × 2`; heed it (`ulimit -n 8192`) or the ceiling you measure is
+  this client's, not the server's.
+- **Server-side bounds.** `service.channel_size` (default 32) and
+  `service.timeout` (default 30s) in `ZainodConfig` cap concurrency directly.
+  Run at defaults first. If you tune them, report both numbers and name the knob
+  you moved — an untuned number and a tuned one are both interesting, and a
+  tuned number presented as the default is misleading.
+
+Partial failure in a sweep is a *result*, not an error, so the run still exits
+zero; a round set where no connection anywhere succeeded exits non-zero.
+
+## `serve` — single-stream serve rate
+
+One connection, one large `GetBlockRange`, timed from the request (not the
+connect — connect cost is the load test's concern). Reports blocks/s, approximate
+payload MB/s, and verifies every `prev_hash` link as blocks arrive, because a
+fast answer that does not link up is not an answer.
+
+```sh
+makers bench serve --server http://127.0.0.1:8137 --start-height 3300000
+```
+
+Run it — and the sweep above — once per finalised-state mode: restart zainod on
+the other config and repeat the same commands unchanged.
+
+`--end-height` defaults to the server's tip. The run exits non-zero if the chain
+does not link. A mid-stream gRPC failure is reported and summarised rather than
+swallowed — under load that failure *is* the finding.
+
+## Where the results go
+
+`docs/perf.md` holds the published numbers, and alongside them the machine spec,
+zebrad and zainod versions and configs, `ulimit -n`, and the exact commands.
+Numbers without that section are not reproducible; update them together.

--- a/packages/zaino-bench/usage.md
+++ b/packages/zaino-bench/usage.md
@@ -94,12 +94,13 @@ zainod start --config docs/example_configs/zainod-bench-mainnet.toml
 
 To measure a *fresh* sync, empty `storage.database.path` first — an existing
 finalised-state db means you are measuring a catch-up, not an initial sync.
-Check free space before you do: a full mainnet index is ~275 GiB and shares a
-volume with zebrad's ~260 GiB, so an old index backup left in place is enough to
-run the volume out partway through a run that takes hours.
+Check free space before you do: a full mainnet index measures ~76 GiB and shares
+a volume with zebrad's ~260 GiB. Use an NVMe volume — a USB-attached disk makes
+the batch commit the bottleneck and roughly halves the sync rate.
 
 `--csv` writes every sample (elapsed, heights, lag, transactions, interval rate)
-for graphing the curve. `--until-height N` bounds the run to a fixed span instead
+for graphing the curve. **Known bug:** the file is only written when the run ends
+normally, so a run that ends on `--stall-timeout-secs` discards its curve. `--until-height N` bounds the run to a fixed span instead
 of waiting for the tip. `--stall-timeout-secs` fails the run, non-zero, if the
 finalised height stops advancing — so an overnight run does not silently hang.
 
@@ -111,10 +112,11 @@ fetch latency (min/mean/max **and** p50/p95/p99), chain breaks, and aggregate
 plus per-connection blocks/s.
 
 ```sh
+ulimit -n 32768          # must exceed 2 x the largest sweep value
 makers bench concurrent \
   --server http://127.0.0.1:8137 \
   --start-height 3000000 --end-height 3380000 \
-  --blocks 1000 --sweep 100,250,500,1000,2000
+  --blocks 200 --sweep 100,500,1000,2000,5000,10000
 ```
 
 Use `--sweep`, not a single `--connections` value. The answer to "how many
@@ -126,8 +128,17 @@ Two things that will otherwise give you the wrong number:
 
 - **File descriptors.** Each connection needs a socket. The harness reads
   `/proc/self/limits` and warns when the soft limit is under roughly
-  `connections × 2`; heed it (`ulimit -n 8192`) or the ceiling you measure is
-  this client's, not the server's.
+  `connections × 2`; heed it (`ulimit -n 32768` for a 10,000 round) or the
+  ceiling you measure is this client's, not the server's.
+- **Per-connection work must outlast the ramp, or the round measures nothing.**
+  Connections are brought up over `--spawn-window-ms` (default 2000). If each
+  finishes faster than the ramp creates the next, they retire as fast as they
+  arrive and the number actually open never approaches the nominal count — the
+  round becomes a throughput test wearing a concurrency test's label. A
+  persistent-mode finalised read of 200 blocks takes ~40ms, so a 10,000-connection
+  round held only ~38 open at once (see `docs/perf.md` §2a). Sanity-check every
+  round with `connections × mean fetch ÷ wall-clock`; if that is far below the
+  nominal count, raise `--blocks` until mean fetch exceeds the ramp.
 - **Server-side bounds.** `service.channel_size` (default 32) and
   `service.timeout` (default 30s) in `ZainodConfig` cap concurrency directly.
   Run at defaults first. If you tune them, report both numbers and name the knob
@@ -145,8 +156,13 @@ payload MB/s, and verifies every `prev_hash` link as blocks arrive, because a
 fast answer that does not link up is not an answer.
 
 ```sh
-makers bench serve --server http://127.0.0.1:8137 --start-height 3300000
+makers bench serve --server http://127.0.0.1:8137 \
+  --start-height 3300000 --end-height 3454000
 ```
+
+Pin `--end-height` rather than letting it default to the tip when comparing the
+two finalised-state modes: they report different tips, so an unpinned range makes
+the two runs different amounts of work.
 
 Run it — and the sweep above — once per finalised-state mode: restart zainod on
 the other config and repeat the same commands unchanged.

--- a/packages/zaino-chain-head-service/src/service.rs
+++ b/packages/zaino-chain-head-service/src/service.rs
@@ -176,8 +176,7 @@ impl<S: ChainHeadBlockSource> ChainHeadService<S> {
         config: ChainHeadConfig,
         cancel: CancellationToken,
     ) -> Result<Arc<Self>, ChainHeadInitError> {
-        let status = NamedAtomicStatus::new(COMPONENT, StatusType::Spawning);
-        status.store(StatusType::Syncing);
+        let status = NamedAtomicStatus::new(COMPONENT, StatusType::Syncing);
 
         let snapshot = anchor_with_retry(&source, &config, &cancel).await?;
         info!(

--- a/packages/zaino-chain-head-service/src/service.rs
+++ b/packages/zaino-chain-head-service/src/service.rs
@@ -293,11 +293,11 @@ impl<S: ChainHeadBlockSource> ChainHeadService<S> {
                             attempts = consecutive_failures,
                             "ChainHead giving up on the validator; last published snapshot is now stale",
                         );
-                        self.status.store(StatusType::CriticalError);
+                        self.status.apply(|s| next_status(s, TickOutcome::GaveUp));
                         break;
                     }
                     warn!(%error, attempts = consecutive_failures, "ChainHead failed to advance; retrying");
-                    self.status.store(StatusType::RecoverableError);
+                    self.status.apply(|s| next_status(s, TickOutcome::Retrying));
                     if sleep_or_cancel(backoff, &self.cancel).await.is_break() {
                         break;
                     }
@@ -365,16 +365,10 @@ impl<S: ChainHeadBlockSource> ChainHeadService<S> {
         Ok(())
     }
 
-    /// Publishes `Ready` on a successful advance, once the built graph matches
-    /// the validator tip read this iteration — stored before the snapshot swap
-    /// so no reader can observe a fresh snapshot under a stale `Syncing`.
-    ///
-    /// `Closing` is not overwritten: a shutdown that races the final tick must
-    /// stay observable on every handle.
+    /// Publishes the [`TickOutcome::Advanced`] transition before the snapshot
+    /// swap, so no reader can observe a fresh snapshot under a stale `Syncing`.
     fn mark_fresh(&self) {
-        if self.status.load() != StatusType::Closing {
-            self.status.store(StatusType::Ready);
-        }
+        self.status.apply(|s| next_status(s, TickOutcome::Advanced));
     }
 
     /// Builds the graph as it should be at `chain_height`.
@@ -730,6 +724,30 @@ impl<S: ChainHeadBlockSource> Drop for ChainHeadService<S> {
     }
 }
 
+/// What one writer iteration concluded about the published snapshot.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TickOutcome {
+    /// The snapshot now matches the validator tip read this iteration.
+    Advanced,
+    /// The advance failed and the backoff ladder will retry it.
+    Retrying,
+    /// The advance failed `max_consecutive_failures` times and the writer is exiting.
+    GaveUp,
+}
+
+/// The chain head's status transition rule, pure and total so its invariants
+/// are stated once here instead of re-derived at every store site.
+fn next_status(current: StatusType, outcome: TickOutcome) -> StatusType {
+    match (current, outcome) {
+        // Closing absorbs every outcome: a shutdown that races the final
+        // iteration must stay observable on every handle.
+        (StatusType::Closing, _) => StatusType::Closing,
+        (_, TickOutcome::Advanced) => StatusType::Ready,
+        (_, TickOutcome::Retrying) => StatusType::RecoverableError,
+        (_, TickOutcome::GaveUp) => StatusType::CriticalError,
+    }
+}
+
 /// Builds a [`ChainHeadBlock`], accumulating work onto its parent's.
 ///
 /// The old `create_indexed_block_with_optional_roots`, less the parts only a
@@ -925,5 +943,56 @@ impl Block for zaino_primitives::types::Block {
         service: &ChainHeadService<S>,
     ) -> Result<ChainHeadBlock, ChainHeadAdvanceError> {
         service.block_to_chainblock(prev_block, self).await
+    }
+}
+
+#[cfg(test)]
+mod next_status_rule {
+    use super::{next_status, StatusType, TickOutcome};
+
+    const OUTCOMES: [TickOutcome; 3] = [
+        TickOutcome::Advanced,
+        TickOutcome::Retrying,
+        TickOutcome::GaveUp,
+    ];
+
+    /// No outcome may overwrite `Closing`, so a shutdown stays observable.
+    #[test]
+    fn closing_absorbs_every_outcome() {
+        for outcome in OUTCOMES {
+            assert_eq!(
+                next_status(StatusType::Closing, outcome),
+                StatusType::Closing,
+                "{outcome:?} must not overwrite Closing"
+            );
+        }
+    }
+
+    /// Every non-`Closing` state takes the status its outcome names.
+    #[test]
+    fn every_live_state_takes_the_outcome_status() {
+        let live_states = [
+            StatusType::Spawning,
+            StatusType::Syncing,
+            StatusType::Ready,
+            StatusType::Busy,
+            StatusType::RecoverableError,
+            StatusType::CriticalError,
+            StatusType::Offline,
+        ];
+        for current in live_states {
+            assert_eq!(
+                next_status(current, TickOutcome::Advanced),
+                StatusType::Ready
+            );
+            assert_eq!(
+                next_status(current, TickOutcome::Retrying),
+                StatusType::RecoverableError
+            );
+            assert_eq!(
+                next_status(current, TickOutcome::GaveUp),
+                StatusType::CriticalError
+            );
+        }
     }
 }

--- a/packages/zaino-chain-head-service/src/service.rs
+++ b/packages/zaino-chain-head-service/src/service.rs
@@ -202,7 +202,10 @@ impl<S: ChainHeadBlockSource> ChainHeadService<S> {
             task: Mutex::new(None),
             config,
         });
-        service.status.store(StatusType::Ready);
+        // Still `Syncing`: the anchor is the window's floor, not its tip, so a
+        // reader served now would see a head up to `max_depth` below the
+        // chain. `Ready` is published by the first successful advance, which
+        // is the first moment the snapshot matches the validator's tip.
 
         Ok(service)
     }
@@ -276,9 +279,8 @@ impl<S: ChainHeadBlockSource> ChainHeadService<S> {
                 Ok(()) => {
                     consecutive_failures = 0;
                     backoff = self.config.initial_backoff();
-                    if self.status.load() != StatusType::Closing {
-                        self.status.store(StatusType::Ready);
-                    }
+                    // `Ready` is already published from inside `tick`, before
+                    // the advanced snapshot becomes observable to readers.
                     if self.wait_for_work(&mut wake).await.is_break() {
                         break;
                     }
@@ -353,12 +355,26 @@ impl<S: ChainHeadBlockSource> ChainHeadService<S> {
         // for a same-height reorg, which costs a round trip per poll for an
         // answer that cannot have changed.
         if tip == previous.best_tip() {
+            self.mark_fresh();
             return Ok(());
         }
 
         let next = self.next_graph(&previous, tip.height).await?;
+        self.mark_fresh();
         self.publish_snapshot(&previous, next);
         Ok(())
+    }
+
+    /// Publishes `Ready` on a successful advance, once the built graph matches
+    /// the validator tip read this iteration — stored before the snapshot swap
+    /// so no reader can observe a fresh snapshot under a stale `Syncing`.
+    ///
+    /// `Closing` is not overwritten: a shutdown that races the final tick must
+    /// stay observable on every handle.
+    fn mark_fresh(&self) {
+        if self.status.load() != StatusType::Closing {
+            self.status.store(StatusType::Ready);
+        }
     }
 
     /// Builds the graph as it should be at `chain_height`.

--- a/packages/zaino-common/src/config/storage.rs
+++ b/packages/zaino-common/src/config/storage.rs
@@ -67,6 +67,9 @@ impl Default for SyncWriteBatchSize {
         // host (or a cgroup-limited container). A larger value does not make a small host faster — it
         // just risks the OOM-killer, and a kill under `NO_SYNC` is what then corrupts the on-disk DB.
         // (Previously 32 GiB, which OOM-killed small hosts.)
+        //
+        // Bulk sync is pipelined, so this bounds *one* batch and peak usage is up to twice it: the
+        // batch being committed stays resident while its successor fills.
         SyncWriteBatchSize(8)
     }
 }

--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -287,6 +287,36 @@ pub(crate) async fn build_indexed_block_from_source<S: BlockchainSource>(
     height_int: u32,
     parent_chainwork: Option<ChainWork>,
 ) -> Result<IndexedBlock, FinalisedStateError> {
+    let fetched = fetch_block_for_indexing(source, height_int).await?;
+    assemble_indexed_block(
+        fetched,
+        network,
+        sapling_activation_height,
+        nu5_activation_height,
+        nu6_3_activation_height,
+        height_int,
+        parent_chainwork,
+    )
+}
+
+/// The two source reads behind one indexed block, kept together.
+///
+/// Split out of [`build_indexed_block_from_source`] because this half does not depend on
+/// `parent_chainwork` and so does not have to run in block order — which is what lets a bulk sync
+/// issue many of them at once. It is also where a sync spends nearly all of its CPU: deserialising
+/// a block decompresses two Jubjub points per Sapling output (`from_bytes_not_small_order` — a
+/// modular square root plus a cofactor multiplication), work Zaino discards, since it keeps only
+/// the compact representation. On sandblast-era blocks that dwarfs everything else the sync does.
+pub(crate) struct FetchedBlock {
+    block: Arc<zebra_chain::block::Block>,
+    tree_roots: crate::chain_index::source::ShieldedTreeRoots,
+}
+
+/// Reads one block and its commitment-tree roots from the source.
+pub(crate) async fn fetch_block_for_indexing<S: BlockchainSource>(
+    source: &S,
+    height_int: u32,
+) -> Result<FetchedBlock, FinalisedStateError> {
     let block = match source
         .get_block(zebra_state::HashOrHeight::Height(
             zebra_chain::block::Height(height_int),
@@ -306,8 +336,29 @@ pub(crate) async fn build_indexed_block_from_source<S: BlockchainSource>(
     let block_hash = BlockHash::from(block.hash().0);
 
     // Fetch sapling / orchard commitment tree data if above the relevant network upgrade.
-    let (sapling_opt, orchard_opt, ironwood_opt) =
-        source.get_commitment_tree_roots(block_hash).await?;
+    let tree_roots = source.get_commitment_tree_roots(block_hash).await?;
+
+    Ok(FetchedBlock { block, tree_roots })
+}
+
+/// Turns a [`FetchedBlock`] into an [`IndexedBlock`], given the chainwork of its parent.
+///
+/// The order-dependent half: `parent_chainwork` chains each block to the one before it, so this
+/// runs in block order even when the fetches above did not. Cheap next to the fetch — no curve
+/// arithmetic, just the metadata assembly and the compact-form conversion.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn assemble_indexed_block(
+    fetched: FetchedBlock,
+    network: zebra_chain::parameters::Network,
+    sapling_activation_height: zebra_chain::block::Height,
+    nu5_activation_height: Option<zebra_chain::block::Height>,
+    nu6_3_activation_height: Option<zebra_chain::block::Height>,
+    height_int: u32,
+    parent_chainwork: Option<ChainWork>,
+) -> Result<IndexedBlock, FinalisedStateError> {
+    let FetchedBlock { block, tree_roots } = fetched;
+    let (sapling_opt, orchard_opt, ironwood_opt) = tree_roots;
+    let block_hash = BlockHash::from(block.hash().0);
 
     let is_sapling_active = height_int >= sapling_activation_height.0;
     let is_orchard_active = nu5_activation_height

--- a/packages/zaino-state/src/chain_index/finalised_state.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state.rs
@@ -312,6 +312,21 @@ pub(crate) struct FetchedBlock {
     tree_roots: crate::chain_index::source::ShieldedTreeRoots,
 }
 
+impl FetchedBlock {
+    /// This block's own proof-of-work contribution.
+    ///
+    /// Lets a caller fold the cumulative chainwork over a run of already-fetched blocks before
+    /// assembling any of them — the fold is the only ordering constraint in block building, and it
+    /// is pure integer arithmetic, so it must not hold the expensive conversion in block order.
+    pub(crate) fn block_work(&self) -> Result<ChainWork, FinalisedStateError> {
+        crate::chain_index::types::helpers::block_work(&self.block.header).map_err(|reason| {
+            FinalisedStateError::BlockchainSourceError(BlockchainSourceError::Unrecoverable(
+                format!("cannot read block work from header: {reason}"),
+            ))
+        })
+    }
+}
+
 /// Reads one block and its commitment-tree roots from the source.
 pub(crate) async fn fetch_block_for_indexing<S: BlockchainSource>(
     source: &S,

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1.rs
@@ -285,6 +285,19 @@ impl LmdbLifecycle for DbV1 {
 ///
 /// Data is stored per-height in “best chain” order and is validated (checksums and continuity)
 /// before being treated as reliable for downstream reads.
+/// Lower bound on LMDB reader slots, whatever the core count.
+///
+/// Each slot is 64 bytes, so this floor costs ~128 KiB — cheap enough that a small host should
+/// not be the reason a node stops serving concurrent readers.
+const MIN_LMDB_READERS: usize = 2048;
+
+/// Upper bound on LMDB reader slots.
+///
+/// 8192 slots is ~512 KiB of shared memory, and leaves headroom above the concurrent-client
+/// counts we benchmark (5000) for Zaino's own internal readers: the sync loop, startup
+/// validation, the chain head, and the mempool all take slots of their own.
+const MAX_LMDB_READERS: usize = 8192;
+
 #[derive(Debug)]
 pub(crate) struct DbV1 {
     /// Shared LMDB environment.
@@ -467,15 +480,28 @@ impl DbV1 {
             fs::create_dir_all(&db_path)?;
         }
 
-        // Check system rescources to set max db reeaders, clamped between 512 and 4096.
+        // LMDB reader slots, from CPU count, clamped to [MIN_LMDB_READERS, MAX_LMDB_READERS].
+        //
+        // A slot is one cache line: the measured `lock.mdb` is 32,896 bytes at 512 readers, so
+        // 64B per slot plus a small header. 8192 readers costs ~512 KiB of shared memory, which
+        // is why the ceiling is set by how many concurrent clients we intend to serve rather
+        // than by memory.
+        //
+        // The bound is a real serving limit, not a tuning hint. `NO_TLS` is set below, so a slot
+        // belongs to a read *transaction* rather than a thread: every concurrent read holds one,
+        // and exhausting the table fails reads with `MDB_READERS_FULL`. The old ceiling of 4096
+        // with a floor of 512 gave exactly 512 on any host with 16 cores or fewer — low enough
+        // that an ordinary load test exhausted it (zingolabs/zaino, benchmark run 2026-08-21).
+        //
+        // Raising this does not make exhaustion safe to hit. A client can still open more
+        // concurrent reads than there are slots, and `MDB_READERS_FULL` is currently treated as
+        // a fatal error by the startup validation in this file, which restarts the node. That
+        // classification is the actual bug; this constant only moves where it bites.
         let cpu_cnt = std::thread::available_parallelism()
             .map(|n| n.get())
             .unwrap_or(4);
 
-        // Sets LMDB max_readers based on CPU count (cpu * 32), clamped between 512 and 4096.
-        // Allows high async read concurrency while keeping memory use low (~192B per slot).
-        // The 512 min ensures reasonable capacity even on low-core systems.
-        let max_readers = u32::try_from((cpu_cnt * 32).clamp(512, 4096))
+        let max_readers = u32::try_from((cpu_cnt * 32).clamp(MIN_LMDB_READERS, MAX_LMDB_READERS))
             .expect("max_readers was clamped to fit in u32");
 
         // Open LMDB environment and set environmental details.

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
@@ -37,6 +37,30 @@ const SYNC_WRITE_BATCH_MAX_BLOCKS: usize = 100_000;
 #[cfg(not(feature = "transparent_address_history_experimental"))]
 const SYNC_PROGRESS_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
 
+/// Upper bound on how many blocks a bulk sync fetches from the source at once.
+///
+/// Bulk sync is CPU-bound inside the source, not in this crate's write path: a profile of a
+/// mainnet sync through the sandblast heights put 91% of cycles in BLS12-381 scalar arithmetic
+/// (`sqrt_tonelli_shanks`, `Scalar::square`/`invert`) — Jubjub point decompression, performed
+/// while deserialising each Sapling output — against 1.3% in LMDB. Fetching one block at a time
+/// left that on a single core with the rest of the machine idle.
+///
+/// The fetches are independent (see `fetch_block_for_indexing`) and the read-state service runs
+/// each on `spawn_blocking`, so issuing them together spreads the decompression across cores. The
+/// order-dependent half still runs in block order.
+#[cfg(not(feature = "transparent_address_history_experimental"))]
+const SYNC_BUILD_CONCURRENCY_LIMIT: usize = 16;
+
+/// Blocks to fetch concurrently: one per core, less one left for the committing thread and the
+/// rest of the node, and never more than [`SYNC_BUILD_CONCURRENCY_LIMIT`].
+#[cfg(not(feature = "transparent_address_history_experimental"))]
+fn sync_build_concurrency() -> usize {
+    std::thread::available_parallelism()
+        .map(|cores| cores.get().saturating_sub(1))
+        .unwrap_or(4)
+        .clamp(1, SYNC_BUILD_CONCURRENCY_LIMIT)
+}
+
 /// Immutable inputs shared by every batch of one bulk-sync run.
 #[cfg(not(feature = "transparent_address_history_experimental"))]
 struct BatchBuild {
@@ -48,6 +72,8 @@ struct BatchBuild {
     target: u32,
     budget_bytes: u64,
     interval: std::time::Duration,
+    /// Blocks fetched from the source at once; see [`sync_build_concurrency`].
+    concurrency: usize,
 }
 
 /// Position carried from one batch to the next.
@@ -82,26 +108,59 @@ async fn fill_sync_batch<S: crate::chain_index::source::BlockchainSource>(
         && batch.len() < SYNC_WRITE_BATCH_MAX_BLOCKS
         && started.elapsed() < build.interval
     {
-        #[cfg(feature = "prometheus")]
-        let build_start = std::time::Instant::now();
-        let block = crate::chain_index::finalised_state::build_indexed_block_from_source(
-            source,
-            build.zebra_network.clone(),
-            build.sapling_activation_height,
-            build.nu5_activation_height,
-            build.nu6_3_activation_height,
-            cursor.next,
-            cursor.parent_chainwork,
-        )
-        .await?;
-        #[cfg(feature = "prometheus")]
-        metrics::histogram!(SYNC_BLOCK_BUILD_SECONDS).record(build_start.elapsed().as_secs_f64());
-        cursor.parent_chainwork = Some(block.context.chainwork);
-        batch_bytes = batch_bytes.saturating_add(approx_indexed_block_bytes(&block));
-        batch.push(block);
-        cursor.next += 1;
+        // One window of heights, fetched together. Capped by the caps themselves so a window
+        // never overshoots the target or the block-count cap; the byte and time caps are checked
+        // per window rather than per block, which can overshoot by at most one window.
+        let remaining_blocks = SYNC_WRITE_BATCH_MAX_BLOCKS.saturating_sub(batch.len());
+        let window = build
+            .concurrency
+            .min(remaining_blocks)
+            .min((build.target - cursor.next + 1) as usize);
+        let heights: Vec<u32> = (cursor.next..cursor.next + window as u32).collect();
 
-        // In-flight progress: the block just built, throttled by time. The committed tip is
+        // `buffered` keeps the results in height order while letting the fetches run together,
+        // so the fold below still sees blocks in the order the chain has them.
+        let fetches = futures::StreamExt::map(
+            futures::stream::iter(heights.iter().copied()),
+            |height_int| async move {
+                #[cfg(feature = "prometheus")]
+                let build_start = std::time::Instant::now();
+                let fetched = crate::chain_index::finalised_state::fetch_block_for_indexing(
+                    source, height_int,
+                )
+                .await;
+                // Per-block cost, so it stays comparable across concurrency settings. With N
+                // fetches in flight the sum of this histogram approaches N x wall-clock; compare
+                // it against wall-clock only after dividing by the concurrency in force.
+                #[cfg(feature = "prometheus")]
+                metrics::histogram!(SYNC_BLOCK_BUILD_SECONDS)
+                    .record(build_start.elapsed().as_secs_f64());
+                fetched
+            },
+        );
+        let fetched: Vec<_> = futures::TryStreamExt::try_collect(futures::StreamExt::buffered(
+            fetches,
+            build.concurrency,
+        ))
+        .await?;
+
+        for (height_int, parts) in heights.into_iter().zip(fetched) {
+            let block = crate::chain_index::finalised_state::assemble_indexed_block(
+                parts,
+                build.zebra_network.clone(),
+                build.sapling_activation_height,
+                build.nu5_activation_height,
+                build.nu6_3_activation_height,
+                height_int,
+                cursor.parent_chainwork,
+            )?;
+            cursor.parent_chainwork = Some(block.context.chainwork);
+            batch_bytes = batch_bytes.saturating_add(approx_indexed_block_bytes(&block));
+            batch.push(block);
+            cursor.next += 1;
+        }
+
+        // In-flight progress: the last block built, throttled by time. The committed tip is
         // reported separately by `note_sync_batch_committed`, and the two now differ by up to a
         // full batch while the pipeline is running.
         if cursor.last_progress_log.elapsed() >= SYNC_PROGRESS_LOG_INTERVAL {
@@ -417,6 +476,7 @@ impl DbWrite for DbV1 {
                 target: height.0,
                 budget_bytes: batch_budget,
                 interval: batch_interval,
+                concurrency: sync_build_concurrency(),
             };
             let mut cursor = BatchCursor {
                 next: start_height,
@@ -2105,4 +2165,26 @@ fn record_block_throughput(block: &IndexedBlock) {
     metrics::counter!(SYNC_TRANSACTIONS_TOTAL).increment(transactions);
     metrics::counter!(SYNC_SAPLING_OUTPUTS_TOTAL).increment(sapling_outputs);
     metrics::counter!(SYNC_ORCHARD_ACTIONS_TOTAL).increment(orchard_actions);
+}
+
+#[cfg(test)]
+mod concurrency_tests {
+    /// The fetch window must leave headroom for the committing thread and never run away on a
+    /// many-core host, and must still be at least one block on a single-core one.
+    #[test]
+    #[cfg(not(feature = "transparent_address_history_experimental"))]
+    fn build_concurrency_stays_within_its_bounds() {
+        let concurrency = super::sync_build_concurrency();
+        assert!(
+            (1..=super::SYNC_BUILD_CONCURRENCY_LIMIT).contains(&concurrency),
+            "concurrency {concurrency} is outside 1..={}",
+            super::SYNC_BUILD_CONCURRENCY_LIMIT
+        );
+        if let Ok(cores) = std::thread::available_parallelism() {
+            assert!(
+                concurrency < cores.get().max(2),
+                "a core must be left for the committing thread"
+            );
+        }
+    }
 }

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
@@ -144,17 +144,60 @@ async fn fill_sync_batch<S: crate::chain_index::source::BlockchainSource>(
         ))
         .await?;
 
+        // Fold the cumulative chainwork over the window, in order. This is the run's only
+        // ordering constraint, and it is a running integer sum over each block's own header — so
+        // it costs microseconds and, once done, every block's `parent_chainwork` is known and the
+        // conversion below no longer has to happen in block order.
+        let mut prepared = Vec::with_capacity(fetched.len());
         for (height_int, parts) in heights.into_iter().zip(fetched) {
-            let block = crate::chain_index::finalised_state::assemble_indexed_block(
-                parts,
-                build.zebra_network.clone(),
-                build.sapling_activation_height,
-                build.nu5_activation_height,
-                build.nu6_3_activation_height,
-                height_int,
-                cursor.parent_chainwork,
-            )?;
-            cursor.parent_chainwork = Some(block.context.chainwork);
+            let parent_chainwork = cursor.parent_chainwork;
+            let block_work = parts.block_work()?;
+            cursor.parent_chainwork = Some(match parent_chainwork {
+                Some(parent) => parent
+                    .add(&block_work)
+                    .map_err(|e| FinalisedStateError::Custom(format!("chainwork overflow: {e}")))?,
+                None => block_work,
+            });
+            prepared.push((height_int, parts, parent_chainwork));
+        }
+
+        // Assemble concurrently. This half is as expensive as the fetch and for the same reason:
+        // converting to the compact form re-serialises the Jubjub points zebra just decompressed,
+        // and going back to affine coordinates costs a field inversion per point. Left in the fold
+        // it was a serial 54% of the sync's CPU, capping the whole run at 1.85x however many cores
+        // the fetches used. `spawn_blocking` because it is CPU-bound and owns everything it needs.
+        let assemblies = futures::StreamExt::map(
+            futures::stream::iter(prepared),
+            |(height_int, parts, parent_chainwork)| {
+                let zebra_network = build.zebra_network.clone();
+                let sapling_activation_height = build.sapling_activation_height;
+                let nu5_activation_height = build.nu5_activation_height;
+                let nu6_3_activation_height = build.nu6_3_activation_height;
+                async move {
+                    tokio::task::spawn_blocking(move || {
+                        crate::chain_index::finalised_state::assemble_indexed_block(
+                            parts,
+                            zebra_network,
+                            sapling_activation_height,
+                            nu5_activation_height,
+                            nu6_3_activation_height,
+                            height_int,
+                            parent_chainwork,
+                        )
+                    })
+                    .await
+                    .map_err(|join| {
+                        FinalisedStateError::Custom(format!("block assembly task failed: {join}"))
+                    })?
+                }
+            },
+        );
+        let assembled: Vec<IndexedBlock> = futures::TryStreamExt::try_collect(
+            futures::StreamExt::buffered(assemblies, build.concurrency),
+        )
+        .await?;
+
+        for block in assembled {
             batch_bytes = batch_bytes.saturating_add(approx_indexed_block_bytes(&block));
             batch.push(block);
             cursor.next += 1;

--- a/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
+++ b/packages/zaino-state/src/chain_index/finalised_state/finalised_source/v1/write_core.rs
@@ -37,6 +37,92 @@ const SYNC_WRITE_BATCH_MAX_BLOCKS: usize = 100_000;
 #[cfg(not(feature = "transparent_address_history_experimental"))]
 const SYNC_PROGRESS_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
 
+/// Immutable inputs shared by every batch of one bulk-sync run.
+#[cfg(not(feature = "transparent_address_history_experimental"))]
+struct BatchBuild {
+    zebra_network: zebra_chain::parameters::Network,
+    sapling_activation_height: zebra_chain::block::Height,
+    nu5_activation_height: Option<zebra_chain::block::Height>,
+    nu6_3_activation_height: Option<zebra_chain::block::Height>,
+    /// Highest block this run will write.
+    target: u32,
+    budget_bytes: u64,
+    interval: std::time::Duration,
+}
+
+/// Position carried from one batch to the next.
+///
+/// Separate from [`BatchBuild`] because the pipeline mutates it while the previous batch is still
+/// being committed: the cursor is where the *builder* has reached, which now runs ahead of the
+/// committed tip by up to one batch.
+#[cfg(not(feature = "transparent_address_history_experimental"))]
+struct BatchCursor {
+    /// Height of the next block to build.
+    next: u32,
+    parent_chainwork: Option<crate::ChainWork>,
+    last_progress_log: std::time::Instant,
+}
+
+/// Builds one bulk-sync batch, stopping at the first of: the byte budget, the block-count cap, the
+/// time cap, or the run's target height.
+///
+/// Returns an empty batch only once the target is reached, which is what ends the pipeline loop.
+#[cfg(not(feature = "transparent_address_history_experimental"))]
+async fn fill_sync_batch<S: crate::chain_index::source::BlockchainSource>(
+    build: &BatchBuild,
+    cursor: &mut BatchCursor,
+    source: &S,
+) -> Result<Vec<IndexedBlock>, FinalisedStateError> {
+    let mut batch: Vec<IndexedBlock> = Vec::new();
+    let mut batch_bytes: u64 = 0;
+    let started = std::time::Instant::now();
+
+    while cursor.next <= build.target
+        && batch_bytes < build.budget_bytes
+        && batch.len() < SYNC_WRITE_BATCH_MAX_BLOCKS
+        && started.elapsed() < build.interval
+    {
+        #[cfg(feature = "prometheus")]
+        let build_start = std::time::Instant::now();
+        let block = crate::chain_index::finalised_state::build_indexed_block_from_source(
+            source,
+            build.zebra_network.clone(),
+            build.sapling_activation_height,
+            build.nu5_activation_height,
+            build.nu6_3_activation_height,
+            cursor.next,
+            cursor.parent_chainwork,
+        )
+        .await?;
+        #[cfg(feature = "prometheus")]
+        metrics::histogram!(SYNC_BLOCK_BUILD_SECONDS).record(build_start.elapsed().as_secs_f64());
+        cursor.parent_chainwork = Some(block.context.chainwork);
+        batch_bytes = batch_bytes.saturating_add(approx_indexed_block_bytes(&block));
+        batch.push(block);
+        cursor.next += 1;
+
+        // In-flight progress: the block just built, throttled by time. The committed tip is
+        // reported separately by `note_sync_batch_committed`, and the two now differ by up to a
+        // full batch while the pipeline is running.
+        if cursor.last_progress_log.elapsed() >= SYNC_PROGRESS_LOG_INTERVAL {
+            #[cfg(feature = "prometheus")]
+            {
+                metrics::gauge!(SYNC_FINALIZED_HEIGHT).set((cursor.next - 1) as f64);
+                metrics::gauge!(SYNC_TARGET_HEIGHT).set(build.target as f64);
+            }
+            info!(
+                current = cursor.next - 1,
+                target = build.target,
+                zebra_network = ?build.zebra_network,
+                "write_blocks_to_height: syncing"
+            );
+            cursor.last_progress_log = std::time::Instant::now();
+        }
+    }
+
+    Ok(batch)
+}
+
 #[cfg(test)]
 use crate::version;
 
@@ -229,9 +315,9 @@ impl DbWrite for DbV1 {
         height: Height,
         source: &S,
     ) -> Result<(), FinalisedStateError> {
-        use crate::chain_index::finalised_state::{
-            build_indexed_block_from_source, PoolActivationHeights,
-        };
+        #[cfg(feature = "transparent_address_history_experimental")]
+        use crate::chain_index::finalised_state::build_indexed_block_from_source;
+        use crate::chain_index::finalised_state::PoolActivationHeights;
 
         let zebra_network = self.config.network.clone();
         let pool_activations = PoolActivationHeights::resolve(&zebra_network);
@@ -246,6 +332,12 @@ impl DbWrite for DbV1 {
         // `get_block_header`, which routes through `resolve_validated_hash_or_height` →
         // `validate_block_blocking` (a full re-validation for any height above `validated_tip`); the
         // tip is already on disk and trusted here, exactly as the v1.2 migration reads block data.
+        // `mut` only under the address-history path, which advances it per block; the pipelined
+        // path moves it into the batch cursor, which owns it from there on.
+        #[cfg_attr(
+            not(feature = "transparent_address_history_experimental"),
+            allow(unused_mut)
+        )]
         let (start_height, mut parent_chainwork): (u32, Option<crate::ChainWork>) =
             match self.tip_height().await? {
                 None => (GENESIS_HEIGHT.0, None),
@@ -290,6 +382,16 @@ impl DbWrite for DbV1 {
         // order (sequential B-tree sweep instead of random faults once the DB exceeds RAM). The
         // address-history feature can't be batched (its prev-output resolution can't see
         // earlier-in-batch uncommitted blocks), so it keeps the per-block path.
+        //
+        // The two halves are *pipelined*: batch N is committed on a scoped thread while batch N+1
+        // is built on this one. Measured on a mainnet sync at height ~1.2M, the serial form spent
+        // 60% of wall-clock building and 40% inside `write_block_batch_blocking` + `env.sync`, with
+        // the builder idle for the whole commit — a mean 79s pause every 120s. Overlapping them
+        // hides the shorter half behind the longer.
+        //
+        // Peak heap for buffered blocks is therefore up to *twice* `sync_write_batch_size`: the
+        // batch being committed is still resident while its successor fills. Size that knob for the
+        // host accordingly — the budget bounds one batch, not the pipeline.
         #[cfg(not(feature = "transparent_address_history_experimental"))]
         {
             // `.max(1)` guards a misconfigured `sync_write_batch_size = 0`: a 0 budget would fail
@@ -306,94 +408,55 @@ impl DbWrite for DbV1 {
             let batch_interval = std::time::Duration::from_secs(
                 self.config.storage.database.sync_checkpoint_interval,
             );
-            let mut next = start_height;
-            let mut last_progress_log = std::time::Instant::now();
-            while next <= height.0 {
-                // Fetch blocks (async; an LMDB write txn is `!Send` and cannot be held across the
-                // await) into a buffer, flushing on the *first* of: byte budget, block-count cap, or
-                // time cap. The count/time caps keep the first commit (and progress, and crash-loss
-                // window) prompt even on the tiny early-chain blocks, where the byte budget alone
-                // would buffer a huge number of blocks before committing.
-                let mut batch: Vec<IndexedBlock> = Vec::new();
-                let mut batch_bytes: u64 = 0;
-                let batch_started = std::time::Instant::now();
-                while next <= height.0
-                    && batch_bytes < batch_budget
-                    && batch.len() < SYNC_WRITE_BATCH_MAX_BLOCKS
-                    && batch_started.elapsed() < batch_interval
-                {
-                    #[cfg(feature = "prometheus")]
-                    let build_start = std::time::Instant::now();
-                    let block = build_indexed_block_from_source(
-                        source,
-                        zebra_network.clone(),
-                        sapling_activation_height,
-                        nu5_activation_height,
-                        nu6_3_activation_height,
-                        next,
-                        parent_chainwork,
-                    )
-                    .await?;
-                    #[cfg(feature = "prometheus")]
-                    metrics::histogram!(SYNC_BLOCK_BUILD_SECONDS)
-                        .record(build_start.elapsed().as_secs_f64());
-                    parent_chainwork = Some(block.context.chainwork);
-                    batch_bytes = batch_bytes.saturating_add(approx_indexed_block_bytes(&block));
-                    batch.push(block);
-                    next += 1;
 
-                    // In-flight progress: the block being fetched, throttled by time. (The committed
-                    // tip is reported by the per-batch commit log below.)
-                    if last_progress_log.elapsed() >= SYNC_PROGRESS_LOG_INTERVAL {
-                        #[cfg(feature = "prometheus")]
-                        {
-                            metrics::gauge!(SYNC_FINALIZED_HEIGHT).set((next - 1) as f64);
-                            metrics::gauge!(SYNC_TARGET_HEIGHT).set(height.0 as f64);
-                        }
-                        info!(
-                            current = next - 1,
-                            target = height.0,
-                            ?zebra_network,
-                            "write_blocks_to_height: syncing"
-                        );
-                        last_progress_log = std::time::Instant::now();
-                    }
-                }
+            let build = BatchBuild {
+                zebra_network,
+                sapling_activation_height,
+                nu5_activation_height,
+                nu6_3_activation_height,
+                target: height.0,
+                budget_bytes: batch_budget,
+                interval: batch_interval,
+            };
+            let mut cursor = BatchCursor {
+                next: start_height,
+                parent_chainwork,
+                last_progress_log: std::time::Instant::now(),
+            };
 
-                if batch.is_empty() {
-                    break;
-                }
+            // Prime the pipeline: the first batch has nothing to overlap with.
+            let mut pending = fill_sync_batch(&build, &mut cursor, source).await?;
 
-                // Write + sort + commit the batch atomically, then force durability. The on-disk
-                // `headers` tip never runs ahead of the indexes, so resume is gap-free.
-                #[cfg(feature = "prometheus")]
-                let write_start = std::time::Instant::now();
-                tokio::task::block_in_place(|| self.write_block_batch_blocking(&batch))?;
-                tokio::task::block_in_place(|| self.env.sync(true)).map_err(|e| {
-                    FinalisedStateError::Custom(format!("LMDB checkpoint sync failed: {e}"))
-                })?;
-                #[cfg(feature = "prometheus")]
-                metrics::histogram!(SYNC_BLOCK_WRITE_SECONDS)
-                    .record(write_start.elapsed().as_secs_f64());
+            while !pending.is_empty() {
+                // `block_in_place` (rather than a plain `thread::scope`) keeps the runtime's
+                // promise that a worker is available while this one is busy: it hands the
+                // remaining tasks to a replacement worker for the duration. Inside it, the scoped
+                // thread commits and `Handle::block_on` drives the builder on this thread, so the
+                // two run genuinely concurrently while both still borrow `self` and `source`
+                // — no `'static` bound, and no `Arc` around either.
+                let (committed, fetched) =
+                    tokio::task::block_in_place(|| {
+                        std::thread::scope(|scope| {
+                            let committer =
+                                scope.spawn(|| self.commit_sync_batch_blocking(&pending));
+                            let fetched = tokio::runtime::Handle::current()
+                                .block_on(fill_sync_batch(&build, &mut cursor, source));
+                            // Propagate a writer panic as a panic, as the serial `block_in_place`
+                            // form did; swallowing it into an error would change how a poisoned
+                            // write surfaces.
+                            let committed = match committer.join() {
+                                Ok(result) => result,
+                                Err(panic) => std::panic::resume_unwind(panic),
+                            };
+                            (committed, fetched)
+                        })
+                    });
 
-                // Only after the batch is committed + synced do we advance the validated tip.
-                for block in &batch {
-                    self.mark_validated(block.context.index.height.0);
-                    #[cfg(feature = "prometheus")]
-                    record_block_throughput(block);
-                }
-                self.status.store(StatusType::Ready);
-                info!(
-                    height = next - 1,
-                    blocks = batch.len(),
-                    "write_blocks_to_height: committed batch"
-                );
-                #[cfg(feature = "prometheus")]
-                {
-                    metrics::gauge!(DB_TIP_HEIGHT).set((next - 1) as f64);
-                    metrics::gauge!(SYNC_LAST_BLOCK_WRITTEN_AT)
-                        .set(crate::chain_index::unix_now_secs());
-                }
+                // Commit first: a fetch error is worth reporting, but a failed *write* is the
+                // one that decides whether the tip may advance.
+                committed?;
+                self.note_sync_batch_committed(&pending);
+                pending = fetched?;
             }
         }
         #[cfg(feature = "transparent_address_history_experimental")]
@@ -441,6 +504,57 @@ impl DbWrite for DbV1 {
 impl DbV1 {
     //! *** DB write / delete methods ***
     //! **These should only ever be used in a single DB control task.**
+
+    /// Writes one bulk-sync batch in a single transaction and forces durability.
+    ///
+    /// Blocking, and deliberately free of `block_in_place`: the pipeline runs this on a scoped
+    /// thread of its own, which is not a runtime worker, so there is no worker to hand off.
+    #[cfg(not(feature = "transparent_address_history_experimental"))]
+    fn commit_sync_batch_blocking(
+        &self,
+        batch: &[IndexedBlock],
+    ) -> Result<(), FinalisedStateError> {
+        #[cfg(feature = "prometheus")]
+        let write_start = std::time::Instant::now();
+        self.write_block_batch_blocking(batch)?;
+        self.env.sync(true).map_err(|e| {
+            FinalisedStateError::Custom(format!("LMDB checkpoint sync failed: {e}"))
+        })?;
+        #[cfg(feature = "prometheus")]
+        metrics::histogram!(SYNC_BLOCK_WRITE_SECONDS).record(write_start.elapsed().as_secs_f64());
+        Ok(())
+    }
+
+    /// Advances the validated tip and reports progress, once a batch is durably committed.
+    ///
+    /// Only ever called after [`Self::commit_sync_batch_blocking`] has returned `Ok`, so the
+    /// on-disk `headers` tip never runs ahead of the indexes and resume stays gap-free.
+    #[cfg(not(feature = "transparent_address_history_experimental"))]
+    fn note_sync_batch_committed(&self, batch: &[IndexedBlock]) {
+        for block in batch {
+            self.mark_validated(block.context.index.height.0);
+            #[cfg(feature = "prometheus")]
+            record_block_throughput(block);
+        }
+        self.status.store(StatusType::Ready);
+
+        let Some(last) = batch.last() else {
+            return;
+        };
+        // Taken from the batch rather than the cursor: the cursor has already moved on to the
+        // batch being built behind this one.
+        let height = last.context.index.height.0;
+        info!(
+            height,
+            blocks = batch.len(),
+            "write_blocks_to_height: committed batch"
+        );
+        #[cfg(feature = "prometheus")]
+        {
+            metrics::gauge!(DB_TIP_HEIGHT).set(height as f64);
+            metrics::gauge!(SYNC_LAST_BLOCK_WRITTEN_AT).set(crate::chain_index::unix_now_secs());
+        }
+    }
 
     /// Writes a given (finalised) [`IndexedBlock`] to FinalisedState.
     ///

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -164,8 +164,12 @@ async fn sync_to_height() {
 /// batch boundary is where the builder's cursor and the committed tip diverge, and where an
 /// off-by-one would land. With the default 8 GiB budget the whole vector fits in a single batch
 /// and none of that machinery runs. `sync_write_batch_size = 0` floors the budget at one byte
-/// (the documented guard), which puts exactly one block in every batch and so crosses a boundary
-/// on every block in the range.
+/// (the documented guard), so every fetch window closes its batch — dozens of boundaries across
+/// the range instead of none.
+///
+/// It covers the concurrent fetch window too: the window is filled by `buffered`, which must yield
+/// blocks in height order for the `parent_chainwork` fold to chain them correctly. Out-of-order
+/// results would pair a block with the wrong height and show up as a gap below.
 ///
 /// multi_thread required: the pipeline commits on a scoped thread while the builder runs under
 /// `block_in_place` on this one, which a current-thread runtime cannot do.

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -198,11 +198,30 @@ async fn sync_to_height_across_many_write_batches() {
     // Gap-free, not just tip-correct: a pipeline that dropped or double-committed a batch could
     // still land on the right tip.
     let reader = std::sync::Arc::new(zaino_db).to_reader();
+    let mut previous_chainwork: Option<crate::chain_index::types::ChainWork> = None;
     for height in 0..=200u32 {
-        assert!(
-            reader.get_block_header(Height(height)).await.is_ok(),
-            "height {height} must be readable after a multi-batch sync"
+        let header = reader
+            .get_block_header(Height(height))
+            .await
+            .unwrap_or_else(|e| panic!("height {height} must be readable after a sync: {e}"));
+
+        // The chainwork fold is the one ordering constraint left in block building: the window is
+        // folded in height order, then assembled concurrently. A fold that paired a block with the
+        // wrong parent still yields a readable, gap-free, strictly-increasing range — so assert the
+        // exact increment against this block's own stored difficulty, which an off-by-one breaks.
+        let chainwork = *header.context.chainwork();
+        let block_work = header.data().bits.to_work();
+        let expected = match previous_chainwork {
+            Some(previous) => previous
+                .add(&block_work)
+                .expect("no overflow in test vectors"),
+            None => block_work,
+        };
+        assert_eq!(
+            chainwork, expected,
+            "chainwork at height {height} must be its parent's plus this block's own work"
         );
+        previous_chainwork = Some(chainwork);
     }
 }
 

--- a/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
+++ b/packages/zaino-state/src/chain_index/tests/finalised_state/v1.rs
@@ -31,15 +31,28 @@ use crate::{AddrScript, Outpoint};
 pub(crate) async fn spawn_v1_zaino_db(
     source: MockSource,
 ) -> Result<(TempDir, FinalisedState<MockSource>), FinalisedStateError> {
+    spawn_v1_zaino_db_with(source, |_database| {}).await
+}
+
+/// `spawn_v1_zaino_db`, with a chance to adjust the database config first.
+///
+/// The tempdir path is set before `tune` runs, so a caller only overrides the knob it cares about.
+async fn spawn_v1_zaino_db_with(
+    source: MockSource,
+    tune: impl FnOnce(&mut DatabaseConfig),
+) -> Result<(TempDir, FinalisedState<MockSource>), FinalisedStateError> {
     let temp_dir: TempDir = tempfile::tempdir().unwrap();
     let db_path: PathBuf = temp_dir.path().to_path_buf();
 
+    let mut database = DatabaseConfig {
+        path: db_path,
+        ..Default::default()
+    };
+    tune(&mut database);
+
     let config = ChainIndexConfig {
         storage: StorageConfig {
-            database: DatabaseConfig {
-                path: db_path,
-                ..Default::default()
-            },
+            database,
             ..Default::default()
         },
         ephemeral: false,
@@ -143,6 +156,50 @@ async fn sync_to_height() {
     let built_db_height = dbg!(zaino_db.db_height().await.unwrap()).unwrap();
 
     assert_eq!(built_db_height, Height(200));
+}
+
+/// Bulk sync must stay correct when the run spans many write batches.
+///
+/// The batches are pipelined — batch N commits on its own thread while batch N+1 is built — so a
+/// batch boundary is where the builder's cursor and the committed tip diverge, and where an
+/// off-by-one would land. With the default 8 GiB budget the whole vector fits in a single batch
+/// and none of that machinery runs. `sync_write_batch_size = 0` floors the budget at one byte
+/// (the documented guard), which puts exactly one block in every batch and so crosses a boundary
+/// on every block in the range.
+///
+/// multi_thread required: the pipeline commits on a scoped thread while the builder runs under
+/// `block_in_place` on this one, which a current-thread runtime cannot do.
+#[tokio::test(flavor = "multi_thread")]
+async fn sync_to_height_across_many_write_batches() {
+    init_tracing();
+
+    let blocks = load_test_vectors().unwrap().blocks;
+    let source = build_mockchain_source(blocks.clone());
+
+    let (_db_dir, zaino_db) = spawn_v1_zaino_db_with(source.clone(), |database| {
+        database.sync_write_batch_size = zaino_common::SyncWriteBatchSize(0);
+    })
+    .await
+    .unwrap();
+
+    zaino_db.sync_to_height(Height(200), &source).await.unwrap();
+    zaino_db.wait_until_synced().await;
+
+    assert_eq!(
+        zaino_db.db_height().await.unwrap(),
+        Some(Height(200)),
+        "the tip must reach the target even when every block is its own batch"
+    );
+
+    // Gap-free, not just tip-correct: a pipeline that dropped or double-committed a batch could
+    // still land on the right tip.
+    let reader = std::sync::Arc::new(zaino_db).to_reader();
+    for height in 0..=200u32 {
+        assert!(
+            reader.get_block_header(Height(height)).await.is_ok(),
+            "height {height} must be readable after a multi-batch sync"
+        );
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/packages/zaino-state/src/chain_index/types/helpers.rs
+++ b/packages/zaino-state/src/chain_index/types/helpers.rs
@@ -310,11 +310,7 @@ impl<'a> BlockWithMetadata<'a> {
             .map(|height| Height(height.0))
             .ok_or_else(|| String::from("Any valid block has a coinbase height"))?;
 
-        let bits = CompactDifficulty::try_from_be_bytes(
-            block.header.difficulty_threshold.bytes_in_display_order(),
-        )
-        .map_err(|e| format!("invalid nBits: {e}"))?;
-        let block_work = bits.to_work();
+        let block_work = block_work(&block.header)?;
         let chainwork = match self.metadata.parent_chainwork {
             Some(parent) => parent
                 .add(&block_work)
@@ -324,6 +320,18 @@ impl<'a> BlockWithMetadata<'a> {
 
         Ok(BlockContext::new(hash, parent_hash, chainwork, height))
     }
+}
+
+/// A block's own proof-of-work contribution, decoded from its header's difficulty threshold.
+///
+/// Depends on nothing but this one header, which is what makes the cumulative chainwork a running
+/// sum that can be folded over already-fetched blocks in a separate pass from assembling them.
+/// Shared so the fold and [`BlockWithMetadata`]'s own assembly cannot drift apart.
+pub(crate) fn block_work(header: &zebra_chain::block::Header) -> Result<ChainWork, String> {
+    let bits =
+        CompactDifficulty::try_from_be_bytes(header.difficulty_threshold.bytes_in_display_order())
+            .map_err(|e| format!("invalid nBits: {e}"))?;
+    Ok(bits.to_work())
 }
 
 impl BlockMetadata {

--- a/packages/zaino-status/CHANGELOG.md
+++ b/packages/zaino-status/CHANGELOG.md
@@ -19,6 +19,10 @@ and this library adheres to Rust's notion of
 - Probing moved with status rather than after it: `Liveness` and `Readiness` are
   blanket impls over `Status`, so the two cannot be separated without giving up
   the blanket impls.
+- `NamedAtomicStatus::apply` replaces the status with `f(current)` in one
+  compare-and-swap loop, for transitions that depend on the current status; a
+  `load` followed by a guarded `store` leaves a window in which a concurrent
+  transition is silently overwritten, and `apply` closes it.
 
 ### Changed
 ### Deprecated

--- a/packages/zaino-status/src/status.rs
+++ b/packages/zaino-status/src/status.rs
@@ -220,16 +220,7 @@ impl NamedAtomicStatus {
 
     /// Sets the value held in the NamedAtomicStatus, logging the transition.
     pub fn store(&self, status: StatusType) {
-        let old = self.load();
-        if old != status {
-            debug!(
-                component = self.name,
-                from = %old,
-                to = %status,
-                "[STATUS] transition"
-            );
-        }
-        self.inner.store(status.into(), Ordering::SeqCst);
+        self.apply(|_| status);
     }
 }
 

--- a/packages/zaino-status/src/status.rs
+++ b/packages/zaino-status/src/status.rs
@@ -195,6 +195,29 @@ impl NamedAtomicStatus {
         StatusType::from(self.inner.load(Ordering::SeqCst))
     }
 
+    /// Atomically replaces the status with `f(current)` in one
+    /// compare-and-swap loop — closing the check-then-store window a
+    /// `load`/`store` pair leaves open — and returns the installed status.
+    pub fn apply(&self, f: impl Fn(StatusType) -> StatusType) -> StatusType {
+        let old = self
+            .inner
+            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |raw| {
+                Some(f(StatusType::from(raw)).into())
+            })
+            .map(StatusType::from)
+            .expect("fetch_update closure always returns Some");
+        let new = f(old);
+        if old != new {
+            debug!(
+                component = self.name,
+                from = %old,
+                to = %new,
+                "[STATUS] transition"
+            );
+        }
+        new
+    }
+
     /// Sets the value held in the NamedAtomicStatus, logging the transition.
     pub fn store(&self, status: StatusType) {
         let old = self.load();
@@ -213,5 +236,36 @@ impl NamedAtomicStatus {
 impl Status for NamedAtomicStatus {
     fn status(&self) -> StatusType {
         self.load()
+    }
+}
+
+#[cfg(test)]
+mod apply {
+    use super::{NamedAtomicStatus, StatusType};
+
+    /// The installed status is `f(current)`, and it is also the return value.
+    #[test]
+    fn installs_and_returns_the_mapped_status() {
+        let status = NamedAtomicStatus::new("test", StatusType::Syncing);
+
+        let installed = status.apply(|_| StatusType::Ready);
+
+        assert_eq!(installed, StatusType::Ready);
+        assert_eq!(status.load(), StatusType::Ready);
+    }
+
+    /// A closure that maps a state to itself leaves the cell unchanged, which
+    /// is how a caller expresses a transition guard.
+    #[test]
+    fn an_identity_arm_holds_the_current_status() {
+        let status = NamedAtomicStatus::new("test", StatusType::Closing);
+
+        let installed = status.apply(|current| match current {
+            StatusType::Closing => StatusType::Closing,
+            _ => StatusType::Ready,
+        });
+
+        assert_eq!(installed, StatusType::Closing);
+        assert_eq!(status.load(), StatusType::Closing);
     }
 }

--- a/packages/zaino-status/usage.md
+++ b/packages/zaino-status/usage.md
@@ -31,6 +31,15 @@ impl Status for MyService {
 // Or hold one directly. Cloning shares the cell.
 let status = NamedAtomicStatus::new("MyService", StatusType::Spawning);
 status.store(StatusType::Ready);
+
+// A transition that depends on the current status goes through `apply`,
+// which runs the closure inside one compare-and-swap loop. A `load`
+// followed by a guarded `store` leaves a window in which another writer's
+// transition is silently overwritten; `apply` closes it.
+status.apply(|current| match current {
+    StatusType::Closing => StatusType::Closing, // shutdown stays observable
+    _ => StatusType::Ready,
+});
 ```
 
 `Liveness` and `Readiness` arrive for free: they are blanket impls over

--- a/tools/scripts/help.sh
+++ b/tools/scripts/help.sh
@@ -58,6 +58,16 @@ workflow matrix"
 echo "  update-test-targets        Update CI workflow matrix to match \
 nextest targets"
 echo "  validate-makefile-tasks    Run minimal validation of all maker tasks"
+echo "  bench [SUB]                Benchmark a running zainod. SUB = sync | \
+concurrent | serve"
+echo "                               sync       time an initial sync via \
+zainod's /metrics endpoint"
+echo "                               concurrent load-test with N concurrent \
+block-range clients"
+echo "                               serve      single-stream block serve \
+rate + chain check"
+echo "                             See docs/perf.md for results and the \
+measured config."
 echo "  verify-all                 Exercise every task for correctness \
 (idempotent)"
 echo "  hello-rust                 Test rust-script functionality"


### PR DESCRIPTION
## Summary

Adds `zaino-bench`, a benchmark harness for sync time / connection ceiling / serve rate, then uses it to measure mainnet — and fixes the three bulk-sync bottlenecks the measurements exposed. `docs/perf.md` carries the numbers and the configuration that produced them.

## Results (mainnet, Direct backend, NVMe, 16-core)

| | Persistent | Ephemeral |
|---|---|---|
| Full sync from genesis | **4h 43m**, 196 blocks/s mean | n/a |
| Concurrent connections | **5,000 @ 100%** | **5,000 @ 100%** |
| Aggregate throughput | ~200,000 blocks/s | ~9,400 blocks/s |
| Single-stream serve | **154,203 blocks/s** | 399 blocks/s (timed out) |

Zero chain breaks anywhere. The ~390× serve gap between modes is the value of the index stated plainly.

**The sync mean hides the shape of the run.** Heights 1,705,519–1,823,494 — the sandblast band — are **3.5% of the chain and 68% of the wall-clock**, at 10.3 blocks/s against 2,151 blocks/s below 1.7M. A profile there puts ~91% of cycles in BLS12-381 scalar arithmetic: zebra decompresses two Jubjub points per Sapling output on read, and Zaino re-serialises them for the compact form. Both directions are work Zaino doesn't need.

## Changes

**`zaino-bench`** (new crate, not a `default-member`, so a bare `cargo nextest run` never builds it) — `sync`, `concurrent`, `serve`.

**Three bulk-sync perf changes**, each measured before and after:
- Pipeline batch commits with block building — the commit was 40% of wall-clock with the builder idle throughout.
- Fetch blocks concurrently — parallelises the Jubjub decompression across cores.
- Assemble blocks concurrently — profiling showed 54% of CPU still on one thread doing the re-serialisation; chainwork is a running sum over each block's own header, so the fold no longer holds the conversion in block order.

**Two harness fixes found by using it:**
- Completion/stall detection watched the fetch pointer, not the durable tip, so a finished sync read as a stall.
- Connections are now held at a barrier until all have dialled. Without it, reads shorter than the spawn ramp retired as fast as they were created — a sweep asking for 10,000 never had more than 38 open. Every concurrency figure here depends on this fix.

**One production fix:** LMDB `max_readers` was `(cpu × 32).clamp(512, 4096)`, i.e. exactly 512 on any host with ≤16 cores. Raised the floor to 2048.

## Please read before merging

**A client can still restart a node.** With `NO_TLS` a reader slot belongs to a read *transaction*, so concurrent reads exhaust the table. `MDB_READERS_FULL` is backpressure, but the startup block scan treats any error as fatal (`finalised_source/v1.rs`, next to an existing `TODO: Handle error better?`) → `CriticalError` → restart → into the same load → restart. The earlier 10,000-connection sweep hit exactly this and looped. **Raising the floor moved where it bites and fixed nothing.** The reclassification is a few hours' work and is not in this PR.

Also: `(cpu × 32).clamp(2048, 8192)` still returns the floor on anything up to 256 cores, so the ceiling never engages in practice. Worth reshaping.

**The numbers are this branch, not `dev`** — they include the three perf changes. `perf.md` says so in its status banner. A `dev` measurement would be materially slower.

**Known limits of the measurement**, all recorded inline in `perf.md`: 5,000 is the largest count tested rather than a ceiling (neither sweep found a knee); `ulimit -n` was 8192 against the ~10,000 that 5,000 connections need, so that row is partly client-bound; persistent figures are warm-cache (first run ~110k blocks/s vs ~200k warm, two warm runs within 5%); and the harness's t0 misses the first 107,349 blocks, since the progress gauge only appears once the write loop's throttled branch fires.

## Testing

`cargo nextest run` — 611 pass, 3 skipped. Clippy and fmt clean on production crates (pre-existing warnings remain in `live-tests`). `makers lint-boundary-conversions` passes. The `transparent_address_history_experimental` feature does not compile, but did not before this branch either — same three errors with the changes stashed.
