### PR TITLE
Add Ironwood subtree root RPC plumbing

### DIFF
--- a/packages/zaino-proto/lightwallet-protocol/walletrpc/service.proto
+++ b/packages/zaino-proto/lightwallet-protocol/walletrpc/service.proto
@@ -186,6 +186,7 @@ message TreeState {
 enum ShieldedProtocol {
     sapling = 0;
     orchard = 1;
+    ironwood = 2;
 }
 
 message GetSubtreeRootsArg {
@@ -291,7 +292,7 @@ service CompactTxStreamer {
     rpc GetLatestTreeState(Empty) returns (TreeState) {}
 
     // Returns a stream of information about roots of subtrees of the note commitment tree
-    // for the specified shielded protocol (Sapling or Orchard).
+    // for the specified shielded protocol (Sapling, Orchard, or Ironwood).
     rpc GetSubtreeRoots(GetSubtreeRootsArg) returns (stream SubtreeRoot) {}
 
     rpc GetAddressUtxos(GetAddressUtxosArg) returns (GetAddressUtxosReplyList) {}

--- a/packages/zaino-proto/src/proto/service.rs
+++ b/packages/zaino-proto/src/proto/service.rs
@@ -358,6 +358,7 @@ impl PoolType {
 pub enum ShieldedProtocol {
     Sapling = 0,
     Orchard = 1,
+    Ironwood = 2,
 }
 impl ShieldedProtocol {
     /// String value of the enum field names used in the ProtoBuf definition.
@@ -368,6 +369,7 @@ impl ShieldedProtocol {
         match self {
             Self::Sapling => "sapling",
             Self::Orchard => "orchard",
+            Self::Ironwood => "ironwood",
         }
     }
     /// Creates an enum from field names used in the ProtoBuf definition.
@@ -375,6 +377,7 @@ impl ShieldedProtocol {
         match value {
             "sapling" => Some(Self::Sapling),
             "orchard" => Some(Self::Orchard),
+            "ironwood" => Some(Self::Ironwood),
             _ => None,
         }
     }
@@ -934,7 +937,7 @@ pub mod compact_tx_streamer_client {
             self.inner.unary(req, path, codec).await
         }
         /// Returns a stream of information about roots of subtrees of the note commitment tree
-        /// for the specified shielded protocol (Sapling or Orchard).
+        /// for the specified shielded protocol (Sapling, Orchard, or Ironwood).
         pub async fn get_subtree_roots(
             &mut self,
             request: impl tonic::IntoRequest<super::GetSubtreeRootsArg>,
@@ -1267,7 +1270,7 @@ pub mod compact_tx_streamer_server {
             + std::marker::Send
             + 'static;
         /// Returns a stream of information about roots of subtrees of the note commitment tree
-        /// for the specified shielded protocol (Sapling or Orchard).
+        /// for the specified shielded protocol (Sapling, Orchard, or Ironwood).
         async fn get_subtree_roots(
             &self,
             request: tonic::Request<super::GetSubtreeRootsArg>,

--- a/packages/zaino-serve/src/rpc/grpc/service.rs
+++ b/packages/zaino-serve/src/rpc/grpc/service.rs
@@ -200,7 +200,7 @@ where
         values also (even though they can be obtained using GetBlock).
         The block can be specified by either height or hash."
         get_tree_state(BlockId) -> TreeState,
-        "Returns a stream of information about roots of subtrees of the Sapling and Orchard \
+        "Returns a stream of information about roots of subtrees of the Sapling, Orchard, and Ironwood \
         note commitment trees."
         get_subtree_roots(GetSubtreeRootsArg) -> Self::GetSubtreeRootsStream as streaming,
         "Returns all unspent outputs for a list of addresses. \

--- a/packages/zaino-serve/src/rpc/jsonrpc/service.rs
+++ b/packages/zaino-serve/src/rpc/jsonrpc/service.rs
@@ -323,7 +323,7 @@ pub trait ZcashIndexerRpc {
         hash_or_height: String,
     ) -> Result<GetTreestateResponse, ErrorObjectOwned>;
 
-    /// Returns information about a range of Sapling or Orchard subtrees.
+    /// Returns information about a range of Sapling, Orchard, or Ironwood subtrees.
     ///
     /// zcashd reference: [`z_getsubtreesbyindex`](https://zcash.github.io/rpc/z_getsubtreesbyindex.html) - TODO: fix link
     /// method: post
@@ -331,7 +331,7 @@ pub trait ZcashIndexerRpc {
     ///
     /// # Parameters
     ///
-    /// - `pool`: (string, required) The pool from which subtrees should be returned. Either "sapling" or "orchard".
+    /// - `pool`: (string, required) The pool from which subtrees should be returned. Either "sapling", "orchard", or "ironwood".
     /// - `start_index`: (number, required) The index of the first 2^16-leaf subtree to return.
     /// - `limit`: (number, optional) The maximum number of subtree values to return.
     ///

--- a/packages/zaino-serve/src/rpc/jsonrpc/wire/subtrees.rs
+++ b/packages/zaino-serve/src/rpc/jsonrpc/wire/subtrees.rs
@@ -9,20 +9,19 @@ use zebra_rpc::client::{GetSubtreesByIndexResponse, SubtreeRpcData};
 
 /// A pool name this interface does not accept.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[error("invalid pool name \"{0}\", must be \"sapling\" or \"orchard\"")]
+#[error("invalid pool name \"{0}\", must be \"sapling\", \"orchard\", or \"ironwood\"")]
 pub struct UnknownPoolName(String);
 
 /// Reads the client's pool name into the domain vocabulary.
 ///
 /// Wire → business, so this is the external-input validation step.
 ///
-/// Ironwood is deliberately not accepted, matching the interface as it stands:
-/// `z_getsubtreesbyindex` predates the pool and no client asks for it by that
-/// name. Adding it is a served-surface change, not a rewire.
+/// Accepts every shielded pool supported by the domain subtree-root service.
 pub fn pool_into_domain(pool: &str) -> Result<ShieldedPool, UnknownPoolName> {
     match pool {
         "sapling" => Ok(ShieldedPool::Sapling),
         "orchard" => Ok(ShieldedPool::Orchard),
+        "ironwood" => Ok(ShieldedPool::Ironwood),
         other => Err(UnknownPoolName(other.to_string())),
     }
 }
@@ -72,6 +71,7 @@ mod tests {
         for (name, pool) in [
             ("sapling", ShieldedPool::Sapling),
             ("orchard", ShieldedPool::Orchard),
+            ("ironwood", ShieldedPool::Ironwood),
         ] {
             assert_eq!(pool_into_domain(name), Ok(pool));
 
@@ -91,8 +91,6 @@ mod tests {
             pool_into_domain("plasma"),
             Err(UnknownPoolName("plasma".to_string()))
         );
-        // Not a typo: see `pool_into_domain`.
-        assert!(pool_into_domain("ironwood").is_err());
     }
 
     /// A commitment-tree root is not an identifier, so it is hex-encoded in its

--- a/packages/zaino-state/src/indexer.rs
+++ b/packages/zaino-state/src/indexer.rs
@@ -439,7 +439,7 @@ pub trait ZcashIndexer: Send + Sync + 'static {
         hash_or_height: String,
     ) -> impl SendFut<Result<zaino_primitives::types::Treestate, Self::Error>>;
 
-    /// Returns information about a range of Sapling or Orchard subtrees.
+    /// Returns information about a range of Sapling, Orchard, or Ironwood subtrees.
     ///
     /// zcashd reference: [`z_getsubtreesbyindex`](https://zcash.github.io/rpc/z_getsubtreesbyindex.html) - TODO: fix link
     /// method: post
@@ -447,7 +447,7 @@ pub trait ZcashIndexer: Send + Sync + 'static {
     ///
     /// # Parameters
     ///
-    /// - `pool`: (string, required) The pool from which subtrees should be returned. Either "sapling" or "orchard".
+    /// - `pool`: (string, required) The pool from which subtrees should be returned. Either "sapling", "orchard", or "ironwood".
     /// - `start_index`: (number, required) The index of the first 2^16-leaf subtree to return.
     /// - `limit`: (number, optional) The maximum number of subtree values to return.
     ///
@@ -764,7 +764,7 @@ pub trait LightWalletIndexer: Send + Sync + Clone + ZcashIndexer + 'static {
     /// Helper function to get timeout and channel size from config
     fn timeout_channel_size(&self) -> (u32, u32);
 
-    /// Returns a stream of information about roots of subtrees of the Sapling and Orchard
+    /// Returns a stream of information about roots of subtrees of the Sapling, Orchard, and Ironwood
     /// note commitment trees.
     fn get_subtree_roots(
         &self,
@@ -774,6 +774,9 @@ pub trait LightWalletIndexer: Send + Sync + Clone + ZcashIndexer + 'static {
             let pool = match ShieldedProtocol::try_from(request.shielded_protocol) {
                 Ok(ShieldedProtocol::Sapling) => zaino_primitives::types::ShieldedPool::Sapling,
                 Ok(ShieldedProtocol::Orchard) => zaino_primitives::types::ShieldedPool::Orchard,
+                Ok(ShieldedProtocol::Ironwood) => {
+                    zaino_primitives::types::ShieldedPool::Ironwood
+                }
                 Err(_) => {
                     return Err(<Self as ZcashIndexer>::Error::from(
                         tonic::Status::invalid_argument("Error: Invalid shielded protocol value."),

--- a/packages/zaino-state/src/indexer/node_backed_indexer.rs
+++ b/packages/zaino-state/src/indexer/node_backed_indexer.rs
@@ -958,7 +958,7 @@ impl<Source: BlockchainSource + WithChainHeadSource> ZcashIndexer
             .await?)
     }
 
-    /// Returns information about a range of Sapling or Orchard subtrees.
+    /// Returns information about a range of Sapling, Orchard, or Ironwood subtrees.
     ///
     /// zcashd reference: [`z_getsubtreesbyindex`](https://zcash.github.io/rpc/z_getsubtreesbyindex.html) - TODO: fix link
     /// method: post
@@ -966,7 +966,7 @@ impl<Source: BlockchainSource + WithChainHeadSource> ZcashIndexer
     ///
     /// # Parameters
     ///
-    /// - `pool`: (string, required) The pool from which subtrees should be returned. Either "sapling" or "orchard".
+    /// - `pool`: (string, required) The pool from which subtrees should be returned. Either "sapling", "orchard", or "ironwood".
     /// - `start_index`: (number, required) The index of the first 2^16-leaf subtree to return.
     /// - `limit`: (number, optional) The maximum number of subtree values to return.
     ///


### PR DESCRIPTION
Completes the Ironwood subtree-root portion of #1343.

Zaino already models and stores Ironwood subtree roots internally, but the lightwallet gRPC `ShieldedProtocol` remained Sapling/Orchard-only. As a result, standard librustzcash requests for Ironwood subtree roots failed with:

`Invalid shielded protocol value.`

This PR:

- adds canonical `ShieldedProtocol::Ironwood = 2`;
- routes gRPC `GetSubtreeRoots(Ironwood)` to the existing internal `ShieldedPool::Ironwood` implementation;
- exposes Ironwood through `z_getsubtreesbyindex`, matching current Zebra behavior;
- updates related RPC documentation and regression coverage.

This does not introduce a new subtree implementation; it completes the existing Ironwood plumbing already present in Zaino.

Addresses the subtree-root portion of #1343.