### PR TITLE
perf: overlap the block and tree-roots fetches in the catch-up walk

### DIFF
--- a/packages/zaino-chain-head-service/CHANGELOG.md
+++ b/packages/zaino-chain-head-service/CHANGELOG.md
@@ -8,6 +8,10 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+- The catch-up walk fetches each block and its tree roots concurrently, via the
+  height-addressed `GetCommitmentTreeRootsByHeight` port. The two reads can
+  straddle a reorg, so the walk compares the hash the roots answer names
+  against the block it fetched, and refetches the roots by hash on a mismatch.
 - New crate. The chain head runtime: carries over the synchronisation, reorg
   handling and retention logic from `zaino-state`'s
   `chain_index/non_finalised_state.rs`, now owning its own writer task. See

--- a/packages/zaino-chain-head-service/src/service.rs
+++ b/packages/zaino-chain-head-service/src/service.rs
@@ -402,10 +402,17 @@ impl<S: ChainHeadBlockSource> ChainHeadService<S> {
         //
         // see https://github.com/ZcashFoundation/zebra/issues/9541
         while u32::from(graph.best_tip().height) < u32::from(chain_height) {
-            let Some(block) = self
-                .block_at_height(next_height(graph.best_tip().height))
-                .await?
-            else {
+            let next = next_height(graph.best_tip().height);
+            // Both reads address the best-chain block at `next`, so they are
+            // independent and run concurrently; the hash check below closes
+            // the reorg race the concurrency opens.
+            let (block, roots) = tokio::join!(
+                self.block_at_height(next),
+                self.source.get_commitment_tree_roots_by_height(next),
+            );
+            let Some(block) = block? else {
+                // Past the tip; the roots result is dropped unexamined, since
+                // its `HeightNotFound` there is expected, not a failure.
                 break;
             };
 
@@ -422,7 +429,14 @@ impl<S: ChainHeadBlockSource> ChainHeadService<S> {
                         ))
                     })?
                     .clone();
-                let chainblock = self.block_to_chainblock(&prev_block, &block).await?;
+                let roots = match roots {
+                    Ok((roots_hash, roots)) if roots_hash == block.header.hash => roots,
+                    // A reorg swapped the best-chain block between the two
+                    // reads, or the height-addressed read failed; the hash we
+                    // hold is authoritative, so refetch by it.
+                    _ => self.tree_roots(block.header.hash).await?,
+                };
+                let chainblock = chain_head_block(block.clone(), &roots, Some(prev_block.work))?;
                 info!(
                     height = u32::from(chainblock.height()),
                     hash = %chainblock.hash(),

--- a/packages/zaino-chain-head-service/src/tests.rs
+++ b/packages/zaino-chain-head-service/src/tests.rs
@@ -33,6 +33,7 @@ use zaino_primitives::types::{
 use zaino_source::{
     FailureMode, FetchError, GetBlock, GetBlockByHash, GetBlockByHashError, GetBlockError,
     GetChainTip, GetChainTipError, GetChainTips, GetChainTipsError, GetCommitmentTreeRoots,
+    GetCommitmentTreeRootsByHeight, GetCommitmentTreeRootsByHeightError,
     GetCommitmentTreeRootsError, QueryError, SubscribeBlocks,
 };
 
@@ -213,6 +214,30 @@ impl GetCommitmentTreeRoots for MockValidator {
             orchard: None,
             ironwood: None,
         })
+    }
+}
+
+impl GetCommitmentTreeRootsByHeight for MockValidator {
+    async fn get_commitment_tree_roots_by_height(
+        &self,
+        height: Height,
+    ) -> Result<(BlockHash, TreeRoots), QueryError<GetCommitmentTreeRootsByHeightError>> {
+        let hash = self
+            .lock()
+            .best_chain
+            .get(u32::from(height) as usize)
+            .copied()
+            .ok_or(QueryError::Domain(
+                GetCommitmentTreeRootsByHeightError::HeightNotFound(height),
+            ))?;
+        Ok((
+            hash,
+            TreeRoots {
+                sapling: None,
+                orchard: None,
+                ironwood: None,
+            },
+        ))
     }
 }
 

--- a/packages/zaino-chain-head/CHANGELOG.md
+++ b/packages/zaino-chain-head/CHANGELOG.md
@@ -32,8 +32,8 @@ and this library adheres to Rust's notion of
   for a chain store to ingest without re-fetching. A separate trait so a
   consumer bounds on it only when it wants the handoff. The stream is
   best-effort: see ADR-0011 for why gaps are expected rather than exceptional.
-- `ChainHeadBlockSource` — the driven port, a bound alias over five
-  `zaino-source` ports with a blanket impl, so any source answering all five
+- `ChainHeadBlockSource` — the driven port, a bound alias over six
+  `zaino-source` ports with a blanket impl, so any source answering all six
   satisfies it without being taught to. Deliberately not `Clone`: a source may
   own connections and a database handle that must not be duplicated.
 - `ChainHeadBlock` — a retained block: a `zaino_primitives::Block` with its

--- a/packages/zaino-chain-head/src/ports.rs
+++ b/packages/zaino-chain-head/src/ports.rs
@@ -64,6 +64,7 @@ pub trait ChainHeadBlockSource:
     + zaino_source::GetBlock
     + zaino_source::GetBlockByHash
     + zaino_source::GetCommitmentTreeRoots
+    + zaino_source::GetCommitmentTreeRootsByHeight
     + zaino_source::SubscribeBlocks
     + Send
     + Sync
@@ -76,6 +77,7 @@ impl<T> ChainHeadBlockSource for T where
         + zaino_source::GetBlock
         + zaino_source::GetBlockByHash
         + zaino_source::GetCommitmentTreeRoots
+        + zaino_source::GetCommitmentTreeRootsByHeight
         + zaino_source::SubscribeBlocks
         + Send
         + Sync

--- a/packages/zaino-source-zebra-readstate/src/adapter.rs
+++ b/packages/zaino-source-zebra-readstate/src/adapter.rs
@@ -730,6 +730,40 @@ impl zaino_source::GetCommitmentTreeRoots for ZebraReadStateAdapter {
     }
 }
 
+impl zaino_source::GetCommitmentTreeRootsByHeight for ZebraReadStateAdapter {
+    async fn get_commitment_tree_roots_by_height(
+        &self,
+        height: Height,
+    ) -> Result<
+        (BlockHash, zaino_primitives::types::TreeRoots),
+        QueryError<zaino_source::GetCommitmentTreeRootsByHeightError>,
+    > {
+        let zebra_height = zebra_chain::block::Height(u32::from(height));
+        let hash = match read(&self.state, ReadRequest::BestChainBlockHash(zebra_height)).await? {
+            ReadResponse::BlockHash(Some(hash)) => BlockHash::from(hash.0),
+            ReadResponse::BlockHash(None) => {
+                return Err(QueryError::Domain(
+                    zaino_source::GetCommitmentTreeRootsByHeightError::HeightNotFound(height),
+                ))
+            }
+            _ => return Err(unexpected_response("BlockHash").into()),
+        };
+        // The hash-addressed read can no longer miss: the hash was just
+        // resolved from the same state, so its `BlockNotFound` is a fault.
+        let roots = zaino_source::GetCommitmentTreeRoots::get_commitment_tree_roots(self, hash)
+            .await
+            .map_err(|error| match error {
+                QueryError::Domain(zaino_source::GetCommitmentTreeRootsError::BlockNotFound(_)) => {
+                    QueryError::Domain(
+                        zaino_source::GetCommitmentTreeRootsByHeightError::HeightNotFound(height),
+                    )
+                }
+                QueryError::Fetch(fetch) => QueryError::Fetch(fetch),
+            })?;
+        Ok((hash, roots))
+    }
+}
+
 impl zaino_source::GetTreestateByHash for ZebraReadStateAdapter {
     async fn get_treestate_by_hash(
         &self,

--- a/packages/zaino-source-zebra-rpc/src/adapter.rs
+++ b/packages/zaino-source-zebra-rpc/src/adapter.rs
@@ -789,6 +789,24 @@ impl zaino_source::GetCommitmentTreeRoots for ZebraRpcAdapter {
     }
 }
 
+impl zaino_source::GetCommitmentTreeRootsByHeight for ZebraRpcAdapter {
+    async fn get_commitment_tree_roots_by_height(
+        &self,
+        height: Height,
+    ) -> Result<
+        (BlockHash, zaino_primitives::types::TreeRoots),
+        QueryError<zaino_source::GetCommitmentTreeRootsByHeightError>,
+    > {
+        self.call_parsed_or_absent(
+            "z_gettreestate",
+            vec![serde_json::Value::String(u32::from(height).to_string())],
+            parse::parse_tree_roots_with_hash,
+            || zaino_source::GetCommitmentTreeRootsByHeightError::HeightNotFound(height),
+        )
+        .await
+    }
+}
+
 impl zaino_source::GetSubtreeRoots for ZebraRpcAdapter {
     async fn get_subtree_roots(
         &self,

--- a/packages/zaino-source-zebra-rpc/src/parse.rs
+++ b/packages/zaino-source-zebra-rpc/src/parse.rs
@@ -787,6 +787,16 @@ pub(crate) fn parse_tree_roots(value: &serde_json::Value) -> Result<TreeRoots, P
     parse_tree_roots_inner(value)
 }
 
+/// Parse a `z_gettreestate` response into tree roots plus the answering block's hash.
+pub(crate) fn parse_tree_roots_with_hash(
+    value: &serde_json::Value,
+) -> Result<(BlockHash, TreeRoots), ParseError> {
+    Ok((
+        parse_block_hash(field(value, "hash")?)?,
+        parse_tree_roots_inner(value)?,
+    ))
+}
+
 /// The serialised tree for one pool, if the response carries that pool at all.
 fn pool_final_state(pool: Option<&serde_json::Value>) -> Result<Option<Vec<u8>>, ParseError> {
     let Some(pool) = pool else { return Ok(None) };

--- a/packages/zaino-source-zebra/src/routing.rs
+++ b/packages/zaino-source-zebra/src/routing.rs
@@ -236,6 +236,15 @@ impl GetCommitmentTreeRoots for ZebraValidator {
     }
 }
 
+impl GetCommitmentTreeRootsByHeight for ZebraValidator {
+    async fn get_commitment_tree_roots_by_height(
+        &self,
+        height: Height,
+    ) -> Result<(BlockHash, TreeRoots), QueryError<GetCommitmentTreeRootsByHeightError>> {
+        fast_or_slow!(self, get_commitment_tree_roots_by_height, height)
+    }
+}
+
 impl GetSubtreeRoots for ZebraValidator {
     async fn get_subtree_roots(
         &self,

--- a/packages/zaino-source/CHANGELOG.md
+++ b/packages/zaino-source/CHANGELOG.md
@@ -8,6 +8,10 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+- `GetCommitmentTreeRootsByHeight` — tree roots at the best-chain block at a
+  height, answering with the block's hash alongside the roots. The hash names
+  which block answered, so a consumer pairing this query with a concurrent
+  hash-addressed read can detect a reorg between the two.
 - New crate. The driven ports for validator access: 36 single-method traits,
   one per question a consumer can ask about the chain, declared in
   `zaino-primitives` vocabulary with a per-question error type.

--- a/packages/zaino-source/src/get_commitment_tree_roots_by_height.rs
+++ b/packages/zaino-source/src/get_commitment_tree_roots_by_height.rs
@@ -1,0 +1,31 @@
+//! Query: fetch commitment tree roots and sizes at a best-chain height.
+
+use std::future::Future;
+
+use zaino_primitives::types::{BlockHash, Height, TreeRoots};
+
+use super::QueryError;
+
+/// Domain error for [`GetCommitmentTreeRootsByHeight`].
+#[derive(Debug, thiserror::Error, Clone, PartialEq, Eq)]
+pub enum GetCommitmentTreeRootsByHeightError {
+    /// No best-chain block exists at this height.
+    #[error("no best-chain block at height {0}")]
+    HeightNotFound(Height),
+}
+
+/// Fetch commitment tree roots and sizes at the best-chain block at a height.
+///
+/// The answer names the block it describes: the best chain can reorganise
+/// between a height-addressed read and a hash-addressed one, so a consumer
+/// pairing this query with another must compare the returned hash against the
+/// block it holds.
+pub trait GetCommitmentTreeRootsByHeight: Send + Sync {
+    /// Fetch tree roots at the best-chain block at this height, reporting which block answered.
+    fn get_commitment_tree_roots_by_height(
+        &self,
+        height: Height,
+    ) -> impl Future<
+        Output = Result<(BlockHash, TreeRoots), QueryError<GetCommitmentTreeRootsByHeightError>>,
+    > + Send;
+}

--- a/packages/zaino-source/src/lib.rs
+++ b/packages/zaino-source/src/lib.rs
@@ -25,6 +25,7 @@ mod get_blockchain_info;
 mod get_chain_tip;
 mod get_chain_tips;
 mod get_commitment_tree_roots;
+mod get_commitment_tree_roots_by_height;
 mod get_compact_block;
 mod get_difficulty;
 mod get_mempool_metadata;
@@ -67,6 +68,9 @@ pub use get_blockchain_info::{GetBlockchainInfo, GetBlockchainInfoError};
 pub use get_chain_tip::{GetChainTip, GetChainTipError};
 pub use get_chain_tips::{GetChainTips, GetChainTipsError};
 pub use get_commitment_tree_roots::{GetCommitmentTreeRoots, GetCommitmentTreeRootsError};
+pub use get_commitment_tree_roots_by_height::{
+    GetCommitmentTreeRootsByHeight, GetCommitmentTreeRootsByHeightError,
+};
 pub use get_compact_block::GetPreIndexCompactBlock;
 pub use get_difficulty::{GetDifficulty, GetDifficultyError};
 pub use get_mempool_metadata::{GetMempoolMetadata, GetMempoolMetadataError, MempoolTxMeta};

--- a/packages/zaino-source/usage.md
+++ b/packages/zaino-source/usage.md
@@ -20,6 +20,14 @@ async fn sync_one<V: GetBlock + GetChainTip>(validator: &V) -> Result<(), MyErro
 A bound is a statement of dependency, and a short one is a design signal. If a
 function needs eleven ports, it is probably doing eleven things.
 
+Some questions exist in a height-addressed and a hash-addressed form, each as
+its own port (`GetTreestate` / `GetTreestateByHash`, `GetCommitmentTreeRoots` /
+`GetCommitmentTreeRootsByHeight`). A height names a best-chain position that a
+reorg can reassign, so a height-addressed answer that will be paired with other
+reads names the block it describes: `get_commitment_tree_roots_by_height`
+returns the answering block's hash alongside the roots, and the consumer
+compares it against the block it holds before combining the two.
+
 ## The error model, which is the point
 
 ```rust

--- a/packages/zaino-state/src/chain_index/source/mockchain_source.rs
+++ b/packages/zaino-state/src/chain_index/source/mockchain_source.rs
@@ -788,6 +788,34 @@ impl zaino_source::GetCommitmentTreeRoots for MockchainSource {
     }
 }
 
+impl zaino_source::GetCommitmentTreeRootsByHeight for MockchainSource {
+    async fn get_commitment_tree_roots_by_height(
+        &self,
+        height: domain::Height,
+    ) -> Result<
+        (domain::BlockHash, domain::TreeRoots),
+        PortError<zaino_source::GetCommitmentTreeRootsByHeightError>,
+    > {
+        let Some(index) = self.served_index_at_height(height) else {
+            return Err(PortError::Domain(
+                zaino_source::GetCommitmentTreeRootsByHeightError::HeightNotFound(height),
+            ));
+        };
+        let hash = domain::BlockHash::from(self.blocks[index].hash().0);
+        let roots = zaino_source::GetCommitmentTreeRoots::get_commitment_tree_roots(self, hash)
+            .await
+            .map_err(|error| match error {
+                // The hash was just resolved from this same chain, so a
+                // missing block is the mock's own fault, not an answer.
+                PortError::Domain(zaino_source::GetCommitmentTreeRootsError::BlockNotFound(
+                    hash,
+                )) => port_fault(format!("mockchain lost block {hash} it just indexed")),
+                PortError::Fetch(fetch) => PortError::Fetch(fetch),
+            })?;
+        Ok((hash, roots))
+    }
+}
+
 impl zaino_source::GetBlockVerboseByHash for MockchainSource {
     async fn get_block_verbose_by_hash(
         &self,

--- a/packages/zaino-state/src/chain_index/tests/proptest_blockgen.rs
+++ b/packages/zaino-state/src/chain_index/tests/proptest_blockgen.rs
@@ -1314,6 +1314,43 @@ impl zaino_source::GetMempoolSourceTip for ProptestMockchain {
     }
 }
 
+impl zaino_source::GetCommitmentTreeRootsByHeight for ProptestMockchain {
+    async fn get_commitment_tree_roots_by_height(
+        &self,
+        height: zaino_primitives::types::Height,
+    ) -> Result<
+        (
+            zaino_primitives::types::BlockHash,
+            zaino_primitives::types::TreeRoots,
+        ),
+        PortError<zaino_source::GetCommitmentTreeRootsByHeightError>,
+    > {
+        let block = zaino_source::GetBlock::get_block(self, height)
+            .await
+            .map_err(|error| match error {
+                PortError::Domain(zaino_source::GetBlockError::HeightNotFound(height)) => {
+                    PortError::Domain(
+                        zaino_source::GetCommitmentTreeRootsByHeightError::HeightNotFound(height),
+                    )
+                }
+                PortError::Fetch(fetch) => PortError::Fetch(fetch),
+            })?;
+        let hash = block.header.hash;
+        let roots = zaino_source::GetCommitmentTreeRoots::get_commitment_tree_roots(self, hash)
+            .await
+            .map_err(|error| match error {
+                // The hash-addressed mock answers every hash, known or not.
+                PortError::Domain(zaino_source::GetCommitmentTreeRootsError::BlockNotFound(
+                    hash,
+                )) => super::super::source::mockchain_source::port_fault(format!(
+                    "proptest mockchain lost block {hash} it just served"
+                )),
+                PortError::Fetch(fetch) => PortError::Fetch(fetch),
+            })?;
+        Ok((hash, roots))
+    }
+}
+
 impl zaino_source::GetCommitmentTreeRoots for ProptestMockchain {
     async fn get_commitment_tree_roots(
         &self,


### PR DESCRIPTION
This PR speeds up zainod's startup wait. Since cc30eb28, the chain
head publishes Ready only after its first catch-up tick completes,
and zainod opens its listeners only on Ready. That tick's walk from
the anchor fetched each block and then its tree roots in sequence,
because the roots query needed the hash the block fetch returned.
That dependency cost two serial validator round trips per block, over
a window of up to `MAX_NONFINALISED_DEPTH` blocks.

The reworked walk makes two reads for each height. The first read
fetches the block at that height. The second read fetches the
commitment tree roots at that height through the new
`GetCommitmentTreeRootsByHeight` port, whose answer carries the
answering block's hash so the walk can detect a reorg.

The walk now issues both reads under one `tokio::join!` and keeps the
roots only when their hash matches the fetched block. On a mismatch or
a failed by-height read, it refetches by the authoritative hash. The
reorg path is unchanged and stays hash-addressed.