### PR TITLE
chain-head-service: match named domain not-found variant exhaustively

### DIFF
--- a/packages/zaino-chain-head-service/src/service.rs
+++ b/packages/zaino-chain-head-service/src/service.rs
@@ -684,8 +684,16 @@ impl<S: ChainHeadBlockSource> ChainHeadService<S> {
         match self.source.get_block(height).await {
             Ok(block) => Ok(Some(block)),
             // Absent, not failed: the extension loop reads past the tip by
-            // design, which is how it learns where the tip is.
-            Err(zaino_source::QueryError::Domain(_)) => Ok(None),
+            // design, which is how it learns where the tip is. Matched by name
+            // rather than a wildcard so a future second domain variant breaks
+            // the build here — the one site that must reclassify it — instead
+            // of being silently read as end-of-chain.
+            Err(zaino_source::QueryError::Domain(zaino_source::GetBlockError::HeightNotFound(
+                missing,
+            ))) => {
+                debug!(height = %missing, "block_at_height: source reports no block; treating as absent");
+                Ok(None)
+            }
             Err(error) => Err(ChainHeadAdvanceError::SourceUnavailable(error.to_string())),
         }
     }
@@ -697,7 +705,15 @@ impl<S: ChainHeadBlockSource> ChainHeadService<S> {
     ) -> Result<Option<zaino_primitives::types::Block>, ChainHeadAdvanceError> {
         match self.source.get_block_by_hash(hash).await {
             Ok(block) => Ok(Some(block)),
-            Err(zaino_source::QueryError::Domain(_)) => Ok(None),
+            // Absent, not failed. Matched by name, not a wildcard, so a future
+            // second domain variant is caught by the compiler here rather than
+            // silently reclassified as absent.
+            Err(zaino_source::QueryError::Domain(zaino_source::GetBlockByHashError::NotFound(
+                missing,
+            ))) => {
+                debug!(hash = %missing, "block_at_hash: source reports no block; treating as absent");
+                Ok(None)
+            }
             Err(error) => Err(ChainHeadAdvanceError::SourceUnavailable(error.to_string())),
         }
     }


### PR DESCRIPTION
`block_at_height` and `block_at_hash` mapped `QueryError::Domain(_) => Ok(None)` with a bare wildcard and no trace (`service.rs:679,691`).

This changes both sites to match the *named* domain variant exhaustively:
- `QueryError::Domain(GetBlockError::HeightNotFound(_))`
- `QueryError::Domain(GetBlockByHashError::NotFound(_))`

and adds a `debug!` trace of the discard.

**Behaviour is unchanged today** — both domain enums have exactly one variant, so the only `Domain` value still means "absent" and still maps to `Ok(None)`. The point is exhaustiveness + observability: a future second domain variant (e.g. `Pruned`, `AboveCeiling`) now breaks the build at the one site that must reclassify it, instead of being silently read as end-of-chain, and the discard is now traced.

## Verification
- `cargo build -p zaino-chain-head-service` — pass
- `cargo test -p zaino-chain-head-service` — pass (22 tests)
- `cargo clippy -p zaino-chain-head-service` — clean
- `cargo fmt -p zaino-chain-head-service -- --check` — clean

Closes #1479