### PR TITLE
chain-head-service: route tip lookup through a single tip_block accessor

### DIFF
--- a/packages/zaino-chain-head-service/src/service.rs
+++ b/packages/zaino-chain-head-service/src/service.rs
@@ -413,8 +413,7 @@ impl<S: ChainHeadBlockSource> ChainHeadService<S> {
             if parent_hash == graph.best_tip().hash {
                 // Normal chain progression
                 let prev_block = graph
-                    .blocks
-                    .get(&graph.best_tip().hash)
+                    .tip_block()
                     .ok_or_else(|| {
                         ChainHeadAdvanceError::ReorgFailure(format!(
                             "graph is missing its own tip {:?}",
@@ -457,16 +456,12 @@ impl<S: ChainHeadBlockSource> ChainHeadService<S> {
         // flip the tip away from the block the validator just told us is
         // canonical. On a tie the validator's answer — which the walk above has
         // already applied — wins.
-        let tip_work = graph
-            .blocks
-            .get(&graph.best_tip().hash)
-            .map(|block| block.work)
-            .ok_or_else(|| {
-                ChainHeadAdvanceError::ReorgFailure(format!(
-                    "graph is missing its own tip {:?}",
-                    graph.best_tip()
-                ))
-            })?;
+        let tip_work = graph.tip_block().map(|block| block.work).ok_or_else(|| {
+            ChainHeadAdvanceError::ReorgFailure(format!(
+                "graph is missing its own tip {:?}",
+                graph.best_tip()
+            ))
+        })?;
         let heaviest = graph
             .blocks
             .values()

--- a/packages/zaino-chain-head-service/src/snapshot.rs
+++ b/packages/zaino-chain-head-service/src/snapshot.rs
@@ -57,6 +57,18 @@ impl MapBackedSnapshot {
         self.blocks.len()
     }
 
+    /// The block this snapshot names as its own tip, if the graph retains it.
+    ///
+    /// The tip is stored as a [`BlockRef`] alongside the block set, not within
+    /// it, so nothing at the type level guarantees the referenced block is
+    /// present: "the graph contains its own tip" is an invariant, not a
+    /// structural fact. This accessor is the single home of that lookup — a
+    /// `None` here means the invariant has been violated — so the check lives
+    /// in one place rather than being re-asserted at every call site.
+    pub(crate) fn tip_block(&self) -> Option<&ChainHeadBlock> {
+        self.blocks.get(&self.best_tip.hash)
+    }
+
     /// Stamp the generation this publication carries.
     ///
     /// The rule lives here rather than at the call site because it is an


### PR DESCRIPTION
The "graph contains its own tip" invariant was re-asserted at runtime in `next_graph`: two `graph.blocks.get(&best_tip.hash)` lookups (`service.rs:411,457`), each with its own `ok_or(ReorgFailure("graph is missing its own tip"))`.

This adds a single `MapBackedSnapshot::tip_block(&self) -> Option<&ChainHeadBlock>` accessor that becomes the one home of that lookup, and collapses both `ok_or` sites onto it. Behaviour is unchanged.

## Scope — accessor only
This is the **minimal, mechanical** step the issue calls for. It deliberately does **not** do the larger rework of folding the tip into the graph type so the invariant becomes structural (which would also let the `expect("a graph always retains at least its anchor")` at `service.rs:466` go away — that site is a separate `max_by_key` lookup over all blocks, not the tip lookup, so it is left untouched here).

## Refs #1482 — please keep open
Because this is only the accessor step, **#1482 should stay open** for the structural follow-up. Using `Refs` rather than `Closes` so merging this PR does not auto-close the issue.

## Verification
- `cargo build -p zaino-chain-head-service` — pass
- `cargo test -p zaino-chain-head-service` — pass (22 tests)
- `cargo clippy -p zaino-chain-head-service` — clean
- `cargo fmt -p zaino-chain-head-service -- --check` — clean

Refs #1482