### PR TITLE
chain-head-service: carry transport cause in ChainHeadAdvanceError

### DIFF
--- a/packages/zaino-chain-head-service/CHANGELOG.md
+++ b/packages/zaino-chain-head-service/CHANGELOG.md
@@ -37,7 +37,12 @@ and this library adheres to Rust's notion of
   graph is rebuilt from a single block and starts at zero.
 - `ChainHeadAdvanceError` (`SourceUnavailable` / `InconsistentSource` /
   `ReorgFailure`) and `ChainHeadInitError`, for a chain head that could not
-  anchor.
+  anchor. `SourceUnavailable` carries the transport `FetchError` as its
+  `#[source]`, so `Error::source()` yields the underlying cause — and its
+  machine-readable `FailureMode` — instead of a flattened string; a source
+  `QueryError` is classified at the boundary, transport failures becoming
+  `SourceUnavailable` and domain rejections staying message-only under
+  `InconsistentSource`.
 - Reorg metrics, moved here from `zaino-state` with their existing metric
   strings unchanged, behind the `prometheus` feature.
 - `spawn_without_writer` and `advance_once`, behind `#[cfg(any(test, feature =

--- a/packages/zaino-chain-head-service/src/error.rs
+++ b/packages/zaino-chain-head-service/src/error.rs
@@ -1,5 +1,7 @@
 //! Failures the runtime can report.
 
+use zaino_source::FetchError;
+
 /// The chain head could not advance against its source.
 ///
 /// The non-finalised state's `SyncError` and `UpdateError`, merged and renamed:
@@ -16,8 +18,13 @@ pub enum ChainHeadAdvanceError {
     ///
     /// Transient by assumption: the writer task backs off and retries, and only
     /// escalates after a run of them.
+    ///
+    /// Carries the transport [`FetchError`] as its `#[source]`, so
+    /// [`Error::source`](std::error::Error::source) yields the underlying cause
+    /// — and with it the machine-readable [`FailureMode`](zaino_source::FailureMode)
+    /// — rather than a flattened string.
     #[error("validator unavailable: {0}")]
-    SourceUnavailable(String),
+    SourceUnavailable(#[source] FetchError),
 
     /// The validator answered, but with data that cannot be reconciled — a
     /// block missing whose child it just served, a header whose difficulty does

--- a/packages/zaino-chain-head-service/src/service.rs
+++ b/packages/zaino-chain-head-service/src/service.rs
@@ -32,6 +32,7 @@
 //! reorg or a partially-extended window.
 
 use std::{
+    fmt,
     sync::{Arc, Mutex},
     time::Duration,
 };
@@ -636,11 +637,7 @@ impl<S: ChainHeadBlockSource> ChainHeadService<S> {
         self.source
             .get_commitment_tree_roots(hash)
             .await
-            .map_err(|error| {
-                ChainHeadAdvanceError::InconsistentSource(format!(
-                    "tree roots for block {hash}: {error}"
-                ))
-            })
+            .map_err(|error| advance_error(error, &format!("tree roots for block {hash}")))
     }
 
     /// Resolve the chain head's anchor (root) block at `anchor_height`.
@@ -672,7 +669,7 @@ impl<S: ChainHeadBlockSource> ChainHeadService<S> {
             .source
             .get_chain_tip()
             .await
-            .map_err(|error| ChainHeadAdvanceError::SourceUnavailable(error.to_string()))?;
+            .map_err(|error| advance_error(error, "chain tip"))?;
         Ok(BlockRef { hash, height })
     }
 
@@ -694,7 +691,10 @@ impl<S: ChainHeadBlockSource> ChainHeadService<S> {
                 debug!(height = %missing, "block_at_height: source reports no block; treating as absent");
                 Ok(None)
             }
-            Err(error) => Err(ChainHeadAdvanceError::SourceUnavailable(error.to_string())),
+            // Transport failure carries its cause through unchanged.
+            Err(zaino_source::QueryError::Fetch(fetch)) => {
+                Err(ChainHeadAdvanceError::SourceUnavailable(fetch))
+            }
         }
     }
 
@@ -714,7 +714,10 @@ impl<S: ChainHeadBlockSource> ChainHeadService<S> {
                 debug!(hash = %missing, "block_at_hash: source reports no block; treating as absent");
                 Ok(None)
             }
-            Err(error) => Err(ChainHeadAdvanceError::SourceUnavailable(error.to_string())),
+            // Transport failure carries its cause through unchanged.
+            Err(zaino_source::QueryError::Fetch(fetch)) => {
+                Err(ChainHeadAdvanceError::SourceUnavailable(fetch))
+            }
         }
     }
 }
@@ -760,6 +763,28 @@ fn next_status(current: StatusType, outcome: TickOutcome) -> StatusType {
         (_, TickOutcome::Advanced) => StatusType::Ready,
         (_, TickOutcome::Retrying) => StatusType::RecoverableError,
         (_, TickOutcome::GaveUp) => StatusType::CriticalError,
+    }
+}
+
+/// Classifies a source [`QueryError`](zaino_source::QueryError) into a
+/// [`ChainHeadAdvanceError`], the single home of the transport-vs-domain split.
+///
+/// A transport failure is threaded through unchanged as the `#[source]` of
+/// [`SourceUnavailable`](ChainHeadAdvanceError::SourceUnavailable), so
+/// `Error::source()` yields the underlying [`FetchError`](zaino_source::FetchError)
+/// and its machine-readable failure mode. A domain rejection wraps no external
+/// error, so it stays message-only under
+/// [`InconsistentSource`](ChainHeadAdvanceError::InconsistentSource), tagged
+/// with `context` to name the query that was refused.
+fn advance_error<E: fmt::Debug + fmt::Display>(
+    error: zaino_source::QueryError<E>,
+    context: &str,
+) -> ChainHeadAdvanceError {
+    match error {
+        zaino_source::QueryError::Fetch(fetch) => ChainHeadAdvanceError::SourceUnavailable(fetch),
+        zaino_source::QueryError::Domain(domain) => {
+            ChainHeadAdvanceError::InconsistentSource(format!("{context}: {domain}"))
+        }
     }
 }
 
@@ -847,18 +872,23 @@ async fn anchor<S: ChainHeadBlockSource>(
     let (_, tip_height) = source
         .get_chain_tip()
         .await
-        .map_err(|error| ChainHeadAdvanceError::SourceUnavailable(error.to_string()))?;
+        .map_err(|error| advance_error(error, "chain tip"))?;
 
     let anchor_height = height_below(tip_height, config.max_depth());
 
     let block = source
         .get_block(anchor_height)
         .await
-        .map_err(|error| ChainHeadAdvanceError::SourceUnavailable(error.to_string()))?;
+        .map_err(|error| advance_error(error, &format!("anchor block {anchor_height}")))?;
     let tree_roots = source
         .get_commitment_tree_roots(block.header.hash)
         .await
-        .map_err(|error| ChainHeadAdvanceError::InconsistentSource(error.to_string()))?;
+        .map_err(|error| {
+            advance_error(
+                error,
+                &format!("tree roots for block {}", block.header.hash),
+            )
+        })?;
 
     Ok(MapBackedSnapshot::from_initial_block(chain_head_block(
         block,


### PR DESCRIPTION
`ChainHeadAdvanceError::SourceUnavailable` held a `String`, and every source failure was `.to_string()`'d at the boundary — flattening the structured `zaino_source::QueryError` (whose `Fetch(FetchError)` arm carries a machine-readable `FailureMode`) so `Error::source()` returned nothing.

## Change
- `SourceUnavailable(String)` → `SourceUnavailable(#[source] FetchError)`, preserving the `FailureMode`. `Error::source()` now yields the transport cause for the unavailable case.
- New single `advance_error()` classifier that every source-error boundary routes through:
  - `QueryError::Fetch(FetchError)` (transport) → `SourceUnavailable(fetch)` (typed, `#[source]`).
  - `QueryError::Domain(_)` rejections → stay message-only under `InconsistentSource`, tagged with the query that was refused (they wrap no external error).

**No behavioural change:** nothing branches on the variant, so retry / give-up is unchanged — the difference is purely observability (`source()` chain + preserved `FailureMode`).

## Per-site mapping
| site | query | before | after |
|------|-------|--------|-------|
| `chain_tip()` | `get_chain_tip` | `SourceUnavailable(to_string)` | Fetch → `SourceUnavailable(fetch)`; Domain → `InconsistentSource` |
| `block_at_height()` | `get_block` | `SourceUnavailable(to_string)` | Fetch → `SourceUnavailable(fetch)` (Domain already `Ok(None)`) |
| `block_at_hash()` | `get_block_by_hash` | `SourceUnavailable(to_string)` | Fetch → `SourceUnavailable(fetch)` (Domain already `Ok(None)`) |
| `tree_roots()` | `get_commitment_tree_roots` | `InconsistentSource(to_string)` | Fetch → `SourceUnavailable(fetch)`; Domain → `InconsistentSource` |
| `anchor()` tip | `get_chain_tip` | `SourceUnavailable(to_string)` | Fetch → `SourceUnavailable(fetch)`; Domain → `InconsistentSource` |
| `anchor()` block | `get_block` | `SourceUnavailable(to_string)` | Fetch → `SourceUnavailable(fetch)`; Domain → `InconsistentSource` |
| `anchor()` roots | `get_commitment_tree_roots` | `InconsistentSource(to_string)` | Fetch → `SourceUnavailable(fetch)`; Domain → `InconsistentSource` |

Note the two `tree_roots`/`anchor`-roots sites: a *transport* failure fetching tree roots was previously classed `InconsistentSource`; it is now correctly `SourceUnavailable` (carrying the cause), while a genuine domain rejection stays `InconsistentSource`.

The `block_at_height`/`block_at_hash` `Domain` named-variant matches this builds on landed via #1487 (issue #1479); this PR only replaces their trailing `Err(error)` arm with a typed `Fetch` arm.

## Verification
- `cargo build -p zaino-chain-head-service` — pass
- `cargo test -p zaino-chain-head-service` — pass (22 tests)
- `cargo clippy -p zaino-chain-head-service` — clean
- `cargo fmt -p zaino-chain-head-service -- --check` — clean

Closes #1478