### PR TITLE
build: bump crate versions and section changelogs for 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5952,7 +5952,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-common"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "rustls",
  "serde",
@@ -5974,7 +5974,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-convert-zebra"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "thiserror 2.0.18",
  "zaino-consensus",
@@ -5984,7 +5984,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-mempool"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "futures",
@@ -5996,7 +5996,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-mempool-service"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "arc-swap",
  "async-stream",
@@ -6014,14 +6014,14 @@ dependencies = [
 
 [[package]]
 name = "zaino-primitives"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "zaino-proto"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "prost",
  "tonic",
@@ -6034,7 +6034,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-rpc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "reqwest 0.13.1",
  "serde",
@@ -6048,7 +6048,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-serve"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "futures",
  "hex",
@@ -6076,7 +6076,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-source"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "thiserror 2.0.18",
  "tokio",
@@ -6095,7 +6095,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-source-zebra"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "tokio",
  "zaino-primitives",
@@ -6106,7 +6106,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-source-zebra-readstate"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "serde_json",
@@ -6123,7 +6123,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-source-zebra-rpc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "hex",
  "incrementalmerkletree",
@@ -6143,7 +6143,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-state"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arc-swap",
  "bitflags 2.13.0",
@@ -6206,7 +6206,7 @@ dependencies = [
 
 [[package]]
 name = "zaino-status"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "tracing",
 ]
@@ -6243,7 +6243,7 @@ dependencies = [
 
 [[package]]
 name = "zainod"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "clap",
  "config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,7 +152,7 @@ zainod = { path = "packages/zainod" }
 # Service status and health-probe vocabulary. A leaf with one dependency
 # (`tracing`), so any subsystem can report its status without inheriting a
 # dependency graph to do it.
-zaino-status = { path = "packages/zaino-status", version = "0.1.0" }
+zaino-status = { path = "packages/zaino-status", version = "0.1.1" }
 # Consensus-derived constants (reorg bound, coinbase maturity, block size limit)
 # and the protocol-limit validation built on them. A leaf that depends on no
 # node implementation, so referencing a consensus fact costs neither a
@@ -161,30 +161,30 @@ zaino-consensus = { path = "packages/zaino-consensus", version = "0.1.0" }
 # Zero-dependency domain vocabulary. Every crate that needs chain-level types
 # (heights, hashes, blocks, transactions) depends on this rather than on
 # `zebra-chain` or on another zaino crate. See docs/adr/0010.
-zaino-primitives = { path = "packages/zaino-primitives", version = "0.1.0" }
+zaino-primitives = { path = "packages/zaino-primitives", version = "0.2.0" }
 # Zcash address parsing and classification, for the two address-validation RPCs.
 # A leaf: it isolates the librustzcash address stack from everything else.
 zaino-address = { path = "packages/zaino-address", version = "0.1.0" }
 # Driven port traits for validator access: one trait per question a consumer can
 # ask, so each consumer's bound names exactly the capabilities it uses and an
 # adapter that cannot answer a question simply does not implement it.
-zaino-source = { path = "packages/zaino-source", version = "0.1.0" }
+zaino-source = { path = "packages/zaino-source", version = "0.2.0" }
 zaino-source-macros = { path = "packages/zaino-source-macros", version = "0.1.0" }
-zaino-mempool = { path = "packages/zaino-mempool", version = "0.1.0" }
-zaino-mempool-service = { path = "packages/zaino-mempool-service", version = "0.1.0" }
+zaino-mempool = { path = "packages/zaino-mempool", version = "0.2.0" }
+zaino-mempool-service = { path = "packages/zaino-mempool-service", version = "0.2.0" }
 # JSON-RPC 2.0 transport shared by the RPC-backed source adapters.
-zaino-rpc = { path = "packages/zaino-rpc", version = "0.1.0" }
+zaino-rpc = { path = "packages/zaino-rpc", version = "0.2.0" }
 # The single place `zebra_chain` types are translated into domain types.
-zaino-convert-zebra = { path = "packages/zaino-convert-zebra", version = "0.1.0" }
+zaino-convert-zebra = { path = "packages/zaino-convert-zebra", version = "0.2.0" }
 # Source adapters. The RPC adapter answers every question over the Zcash
 # JSON-RPC interface; the ReadState adapter answers the subset zebra's
 # in-process state can serve, and simply does not implement the rest.
-zaino-source-zebra-rpc = { path = "packages/zaino-source-zebra-rpc", version = "0.1.0" }
-zaino-source-zebra-readstate = { path = "packages/zaino-source-zebra-readstate", version = "0.1.0" }
+zaino-source-zebra-rpc = { path = "packages/zaino-source-zebra-rpc", version = "0.2.0" }
+zaino-source-zebra-readstate = { path = "packages/zaino-source-zebra-readstate", version = "0.2.0" }
 # Composite over the two adapters: capability decides what each can answer,
 # this decides which to ask.
-zaino-source-zebra = { path = "packages/zaino-source-zebra", version = "0.1.0" }
-zaino-common = { path = "packages/zaino-common", version = "0.5.0" }
+zaino-source-zebra = { path = "packages/zaino-source-zebra", version = "0.2.0" }
+zaino-common = { path = "packages/zaino-common", version = "0.5.1" }
 # ChainHead: the bounded non-finalised block graph, its canonical chain, and the
 # competing branches retained alongside it. This crate is the domain half —
 # types and ports only, no runtime — so a consumer can name what ChainHead
@@ -195,9 +195,9 @@ zaino-chain-head = { path = "packages/zaino-chain-head", version = "0.1.0" }
 # crate so a consumer can name what ChainHead answers without depending on the
 # machinery that answers it.
 zaino-chain-head-service = { path = "packages/zaino-chain-head-service", version = "0.1.0" }
-zaino-proto = { path = "packages/zaino-proto", version = "0.4.0" }
-zaino-state = { path = "packages/zaino-state", version = "0.7.0", default-features = false }
-zaino-serve = { path = "packages/zaino-serve", version = "0.6.0", default-features = false }
+zaino-proto = { path = "packages/zaino-proto", version = "0.5.0" }
+zaino-state = { path = "packages/zaino-state", version = "0.8.0", default-features = false }
+zaino-serve = { path = "packages/zaino-serve", version = "0.7.0", default-features = false }
 zaino-testutils = { path = "live-tests/zaino-testutils" }
 
 # Zingo-infra (validator launcher driving the live tests; not a prod dep).

--- a/packages/zaino-chain-head-service/CHANGELOG.md
+++ b/packages/zaino-chain-head-service/CHANGELOG.md
@@ -8,6 +8,14 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.1.0] - 2026-08-28
+
+### Added
 - New crate. The chain head runtime: carries over the synchronisation, reorg
   handling and retention logic from `zaino-state`'s
   `chain_index/non_finalised_state.rs`, now owning its own writer task. See

--- a/packages/zaino-chain-head/CHANGELOG.md
+++ b/packages/zaino-chain-head/CHANGELOG.md
@@ -8,6 +8,14 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.1.0] - 2026-08-28
+
+### Added
 - New crate. The domain half of the chain head subsystem: vocabulary and ports
   for the bounded, non-finalised head of the chain, with no runtime and no data
   structures. The runtime is `zaino-chain-head-service`. See ADR-0011.

--- a/packages/zaino-common/CHANGELOG.md
+++ b/packages/zaino-common/CHANGELOG.md
@@ -13,6 +13,17 @@ and this library adheres to Rust's notion of
 ### Removed
 ### Fixed
 
+## [0.5.1] - 2026-08-28
+
+### Added
+### Changed
+- Documentation-only republish: a comment on `SyncWriteBatchSize::default`
+  now notes that bulk sync is pipelined, so peak memory is up to twice the
+  batch bound. No code change.
+### Deprecated
+### Removed
+### Fixed
+
 ## [0.5.0] - 2026-08-14
 
 ### Added

--- a/packages/zaino-common/Cargo.toml
+++ b/packages/zaino-common/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.5.0"
+version = "0.5.1"
 
 [dependencies]
 # Zebra

--- a/packages/zaino-convert-zebra/CHANGELOG.md
+++ b/packages/zaino-convert-zebra/CHANGELOG.md
@@ -8,6 +8,25 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.2.0] - 2026-08-28
+
+### Added
+### Changed
+- `header_from_zebra` and `header_from_parts` populate the new
+  `zaino-primitives` 0.2.0 header fields `version` and `solution`, converting
+  zebra's Equihash solution into `types::EquihashSolution`.
+### Deprecated
+### Removed
+### Fixed
+
+## [0.1.0] - 2026-08-14
+
+### Added
 - New crate. `zebra-chain` → `zaino-primitives` conversions:
   `block_from_zebra`, `header_from_zebra`, `header_from_parts`,
   `transaction_from_zebra`, and `ConvertError`.

--- a/packages/zaino-convert-zebra/Cargo.toml
+++ b/packages/zaino-convert-zebra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zaino-convert-zebra"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/packages/zaino-mempool-service/CHANGELOG.md
+++ b/packages/zaino-mempool-service/CHANGELOG.md
@@ -8,6 +8,25 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.2.0] - 2026-08-28
+
+### Added
+### Changed
+- The coherence layer keys on `zaino_primitives::types::ChainStateEpoch` — the
+  chain head subsystem's epoch — following `zaino-mempool` 0.2.0's
+  `NfsEpochObserver` port.
+### Deprecated
+### Removed
+### Fixed
+
+## [0.1.0] - 2026-08-14
+
+### Added
 - New crate: `zaino-mempool-service`, the hexagonal *adapter/implementation* layer of
   the mempool subsystem. It supplies the concrete runtime for the ports defined
   in `zaino-mempool`; dependencies point inward (it depends on `zaino-mempool`,

--- a/packages/zaino-mempool-service/Cargo.toml
+++ b/packages/zaino-mempool-service/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 # Mempool ports + foundational types

--- a/packages/zaino-mempool/CHANGELOG.md
+++ b/packages/zaino-mempool/CHANGELOG.md
@@ -8,6 +8,31 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.2.0] - 2026-08-28
+
+### Added
+### Changed
+- `MempoolSource` bounds the renamed single-attempt ports of `zaino-source`
+  0.2.0 (`OneShotGetMempoolTxids`, `OneShotGetMempoolMetadata`,
+  `OneShotGetRawMempoolTransaction`, `OneShotGetMempoolSourceTip`).
+- `NfsEpochObserver::current_epoch` and
+  `TipAwareMempool::stream_transactions_until_tip_change` speak
+  `zaino_primitives::types::ChainStateEpoch`.
+### Deprecated
+### Removed
+- `NonFinalizedEpoch` — replaced by `zaino_primitives::types::ChainStateEpoch`,
+  which is field-identical and shared with the chain head subsystem that
+  publishes it.
+### Fixed
+
+## [0.1.0] - 2026-08-14
+
+### Added
 - New crate: `zaino-mempool`, the hexagonal *ports + foundational types* of
   Zaino's mempool subsystem — a bounded, coherent, local read model of the
   validator's mempool, separated from `zaino-state` (see
@@ -27,7 +52,7 @@ and this library adheres to Rust's notion of
     crate's, so there is one canonical type rather than a mempool-local copy.
   - Under `tip_aware_mempool`: the `NfsEpochObserver` port (with `NoNfs`), the
     `TipAwareMempool` port (`coherent_snapshot` + the ready-made
-    `stream_transactions_until_tip_change` loop), the
+    `stream_transactions_until_tip_change` loop), `NonFinalizedEpoch`, the
     coherent-view types (`CoherentSnapshot`, `MempoolMode`, `FreezeReason`,
     `ObservedTips`, `TipChange`), and the coherent-stream `MempoolEvent`.
     `ObservedTips` names the V side as a plain `BlockRef`: the field carries the
@@ -139,7 +164,7 @@ and this library adheres to Rust's notion of
   silently wrap on a narrowing cast at ingest.
 
 ### Fixed
-- `ChainStateEpoch::generation` documentation: it increments when the
+- `NonFinalizedEpoch::generation` documentation: it increments when the
   publisher's best tip *changes*, not on every republication. The code was
   already correct; the doc claimed the opposite.
 

--- a/packages/zaino-mempool/Cargo.toml
+++ b/packages/zaino-mempool/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.0"
+version = "0.2.0"
 
 [dependencies]
 # The domain vocabulary. This crate names no wire, node, or `zaino-state` type.

--- a/packages/zaino-primitives/CHANGELOG.md
+++ b/packages/zaino-primitives/CHANGELOG.md
@@ -8,6 +8,31 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.2.0] - 2026-08-28
+
+### Added
+- `types::EquihashSolution`, and `version` / `solution` on `BlockHeader`. A
+  header now carries everything needed to re-derive its own hash. Breaking for
+  code that constructs `BlockHeader` literals.
+- `types::ChainStateEpoch` — a generation plus the tip it describes, naming
+  *which* chain state a published view represents. Lives here because two
+  subsystems need the vocabulary and neither may depend on the other: the chain
+  head publishes epochs, and the mempool's coherence layer freezes and thaws
+  against them. It replaces `zaino_chain_head::ChainHeadEpoch` and
+  `zaino_mempool::NonFinalizedEpoch`, which were field-identical.
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.1.0] - 2026-08-14
+
+### Added
 - New crate. Zaino's domain vocabulary: chain types (`Block`, `BlockHeader`,
   `Transaction`, `BlockHash`, `TransactionHash`, `Height`, `TreeRoot`,
   `Treestate`, `ShieldedPool`, `ChainMetadata`, `Zatoshis`, `SignedZatoshis`)
@@ -16,16 +41,6 @@ and this library adheres to Rust's notion of
   `ChainTip`, `MempoolInfo`, `MiningInfo`, `NodeInfo`, `PeerInfo`, `SpentInfo`,
   `TxOut`, `TxOutSetInfo`, `BlockSubsidy`, `AddressBalance`, `AddressDelta`,
   `Utxo`, `SubtreeRoot`).
-- `types::BlockRef` — a hash and a height together, so the two cannot be passed
-  in the wrong order or observed torn apart.
-- `types::EquihashSolution`, and `version` / `solution` on `BlockHeader`. A
-  header now carries everything needed to re-derive its own hash.
-- `types::ChainStateEpoch` — a generation plus the tip it describes, naming
-  *which* chain state a published view represents. Lives here because two
-  subsystems need the vocabulary and neither may depend on the other: the chain
-  head publishes epochs, and the mempool's coherence layer freezes and thaws
-  against them. It replaces `zaino_chain_head::ChainHeadEpoch` and
-  `zaino_mempool::NonFinalizedEpoch`, which were field-identical.
 - Ironwood (NU6.3) throughout: `ChainMetadata::ironwood_tree_size`,
   `Treestate::ironwood`, `TreeRoots::ironwood`, `ShieldedPool::Ironwood`.
   Uniformly `Option` per pool, with defaulting applied at the conversion

--- a/packages/zaino-primitives/Cargo.toml
+++ b/packages/zaino-primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zaino-primitives"
 description = "Zero-dependency Zcash chain-level domain types (heights, hashes, blocks, transactions) for the Zaino indexer."
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/packages/zaino-proto/CHANGELOG.md
+++ b/packages/zaino-proto/CHANGELOG.md
@@ -13,6 +13,17 @@ and this library adheres to Rust's notion of
 ### Removed
 ### Fixed
 
+## [0.5.0] - 2026-08-28
+
+### Added
+- `ShieldedProtocol::Ironwood` (`ironwood = 2` in `service.proto`), so
+  `GetSubtreeRoots` can name the Ironwood note commitment tree. Breaking for
+  Rust consumers that match exhaustively on `ShieldedProtocol`.
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
 ## [0.4.0] - 2026-08-14
 
 ### Added

--- a/packages/zaino-proto/Cargo.toml
+++ b/packages/zaino-proto/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.4.0"
+version = "0.5.0"
 
 [features]
 default = ["heavy"]

--- a/packages/zaino-rpc/CHANGELOG.md
+++ b/packages/zaino-rpc/CHANGELOG.md
@@ -8,6 +8,25 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.2.0] - 2026-08-28
+
+### Added
+### Changed
+- Republished against `zaino-source` 0.2.0. The `RpcError` ->
+  `zaino_source::FetchError` conversion is unchanged; the retrying consumer it
+  serves is now named `ValidatorClient` (formerly `Resilient`).
+### Deprecated
+### Removed
+### Fixed
+
+## [0.1.0] - 2026-08-14
+
+### Added
 - New crate. The JSON-RPC transport, replacing `zaino-fetch`'s
   `JsonRpSeeConnector`: HTTP, the request/response envelope, authentication,
   and retry-on-`-1`.
@@ -26,7 +45,7 @@ and this library adheres to Rust's notion of
   misconfigured, or impersonated validator exhaust the process's memory with a
   single reply. Bodies are now abandoned part-way rather than buffered, and the
   new `RpcError::ResponseBodyTooLarge` classifies as `FailureMode::Parse` so
-  `ValidatorClient` does not re-issue the request and buffer the same body again.
+  `Resilient` does not re-issue the request and buffer the same body again.
 - `RpcClient::call_with_timeout` and `HEAVY_METHOD_TIMEOUT` (120s), for the few
   methods that are inherently heavy on the validator (`getrawmempool verbose`
   walks the whole mempool). The client-wide timeout (30s) stays tight for the

--- a/packages/zaino-rpc/Cargo.toml
+++ b/packages/zaino-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zaino-rpc"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/packages/zaino-serve/CHANGELOG.md
+++ b/packages/zaino-serve/CHANGELOG.md
@@ -13,6 +13,17 @@ and this library adheres to Rust's notion of
 ### Removed
 ### Fixed
 
+## [0.7.0] - 2026-08-28
+
+### Added
+### Changed
+- `z_getsubtreesbyindex` accepts the pool name `"ironwood"`; previously the
+  interface deliberately rejected it. `GetSubtreeRoots` serves the same pool
+  over gRPC through `zaino-proto` 0.5.0's `ShieldedProtocol::Ironwood`.
+### Deprecated
+### Removed
+### Fixed
+
 ## [0.6.0] - 2026-08-14
 
 ### Added

--- a/packages/zaino-serve/Cargo.toml
+++ b/packages/zaino-serve/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.6.0"
+version = "0.7.0"
 
 [features]
 default = []

--- a/packages/zaino-source-macros/CHANGELOG.md
+++ b/packages/zaino-source-macros/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+All notable changes to this library will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this library adheres to Rust's notion of
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.1.0] - 2026-08-28
+
+### Added
+- New crate. The `#[resilient_port]` proc-macro: applied to a `OneShot*` port
+  trait in `zaino-source`, it derives the canonical resilient twin trait and
+  the `ValidatorClient<V>` blanket impl, rewriting `QueryError<E>` ->
+  `SourceError<E>` so the twin's signature is never restated.
+### Changed
+### Deprecated
+### Removed
+### Fixed

--- a/packages/zaino-source-zebra-readstate/CHANGELOG.md
+++ b/packages/zaino-source-zebra-readstate/CHANGELOG.md
@@ -8,6 +8,24 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.2.0] - 2026-08-28
+
+### Added
+### Changed
+- `ZebraReadStateAdapter` implements `zaino-source` 0.2.0's renamed
+  single-attempt ports (`OneShotGetBlock` and peers); behaviour is unchanged.
+### Deprecated
+### Removed
+### Fixed
+
+## [0.1.0] - 2026-08-14
+
+### Added
 - New crate. `ZebraReadStateAdapter` implements 22 `zaino-source` ports by
   reading Zebra's state database directly, with no RPC round trip. Carries over
   the ~1,100 lines of `ReadStateService` query logic from the deleted

--- a/packages/zaino-source-zebra-readstate/Cargo.toml
+++ b/packages/zaino-source-zebra-readstate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zaino-source-zebra-readstate"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/packages/zaino-source-zebra-rpc/CHANGELOG.md
+++ b/packages/zaino-source-zebra-rpc/CHANGELOG.md
@@ -8,6 +8,24 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.2.0] - 2026-08-28
+
+### Added
+### Changed
+- `ZebraRpcAdapter` implements `zaino-source` 0.2.0's renamed single-attempt
+  ports (`OneShotGetBlock` and peers); behaviour is unchanged.
+### Deprecated
+### Removed
+### Fixed
+
+## [0.1.0] - 2026-08-14
+
+### Added
 - New crate. `ZebraRpcAdapter` implements every `zaino-source` port that
   JSON-RPC can answer, so it is the one transport always present in a
   deployment; the read-state adapter is an optional accelerator.

--- a/packages/zaino-source-zebra-rpc/Cargo.toml
+++ b/packages/zaino-source-zebra-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zaino-source-zebra-rpc"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/packages/zaino-source-zebra/CHANGELOG.md
+++ b/packages/zaino-source-zebra/CHANGELOG.md
@@ -8,6 +8,24 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.2.0] - 2026-08-28
+
+### Added
+### Changed
+- `ZebraValidator` implements `zaino-source` 0.2.0's renamed single-attempt
+  ports (`OneShotGetBlock` and peers); routing behaviour is unchanged.
+### Deprecated
+### Removed
+### Fixed
+
+## [0.1.0] - 2026-08-14
+
+### Added
 - New crate. `ZebraValidator` — the composite holding both Zebra adapters and
   implementing every `zaino-source` port by routing each question to whichever
   transport can answer it.

--- a/packages/zaino-source-zebra/Cargo.toml
+++ b/packages/zaino-source-zebra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zaino-source-zebra"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/packages/zaino-source/CHANGELOG.md
+++ b/packages/zaino-source/CHANGELOG.md
@@ -8,6 +8,42 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.2.0] - 2026-08-28
+
+### Added
+- Two port layers. Each question is both a single-attempt `OneShot*` port
+  (returning `QueryError`, implemented by adapters) and a canonical resilient
+  port under the unqualified name (`GetBlock`, `GetChainTip`, … returning
+  `SourceError`, bound by consumers). The resilient port is the default name
+  because resilience is the default; reaching the single-attempt contract means
+  naming the awkward `OneShot*`. The resilient ports are sealed, so only
+  `ValidatorClient` implements them: a value satisfying a canonical port has
+  provably been through the retry ladder.
+- `#[resilient_port]` (in the new `zaino-source-macros` crate) — an attribute
+  on a `OneShot*` trait that derives its resilient twin and the
+  `ValidatorClient<V>` blanket impl, rewriting `QueryError<E>` ->
+  `SourceError<E>`. The twin's signature is never restated and the
+  retry/translation lives once in `ValidatorClient::with_retry`.
+### Changed
+- Every one-shot query port is renamed `GetX` -> `OneShotGetX`, freeing the
+  canonical names for the resilient twins.
+- `Resilient<V>` is renamed `ValidatorClient<V>`. It now implements the
+  canonical resilient ports rather than carrying its own inherent methods, and
+  forwards `SubscribeBlocks` / `SubscribeChainTip` unchanged.
+  `SendRawTransaction` gets no resilient port — retrying a non-idempotent send
+  risks a double-submit.
+### Deprecated
+### Removed
+### Fixed
+
+## [0.1.0] - 2026-08-14
+
+### Added
 - New crate. The driven ports for validator access: 36 single-method traits,
   one per question a consumer can ask about the chain, declared in
   `zaino-primitives` vocabulary with a per-question error type.
@@ -18,21 +54,11 @@ and this library adheres to Rust's notion of
   (`Connection | Timeout | HttpStatus(u16) | RpcError(i64) | Parse | Auth`),
   so retry policy is a function of the type and a zcashd legacy code can
   survive from the validator to the served response.
-- Two port layers. Each question is both a single-attempt `OneShot*` port
-  (returning `QueryError`, implemented by adapters) and a canonical resilient
-  port under the unqualified name (`GetBlock`, `GetChainTip`, … returning
-  `SourceError`, bound by consumers). The resilient port is the default name
-  because resilience is the default; reaching the single-attempt contract means
-  naming the awkward `OneShot*`.
-- `#[resilient_port]` (in `zaino-source-macros`) — an attribute on a `OneShot*`
-  trait that derives its resilient twin and the `ValidatorClient<V>` blanket impl,
-  rewriting `QueryError<E>` -> `SourceError<E>`. The twin's signature is never
-  restated and the retry/translation lives once in `ValidatorClient::with_retry`.
-- `ValidatorClient<V>` / `RetryPolicy` — retry with exponential backoff, replacing
+- `Resilient<V>` / `RetryPolicy` — retry with exponential backoff, replacing
   the hand-rolled consecutive-failure ladder in the ChainIndex sync loop.
-  Implements the canonical resilient ports (sealed, so only `ValidatorClient` can),
-  and forwards subscriptions unchanged. `SendRawTransaction` gets no resilient
-  port — retrying a non-idempotent send risks a double-submit.
+  Deliberately does *not* implement the port traits: it has its own methods
+  returning `SourceError`, so a consumer cannot be handed a bare adapter by
+  mistake.
 - `SourceLifecycle` (shutdown), `SubscribeChainTip` / `SubscribeBlocks`, and
   `PolledChainTip` (built and tested; not yet wired to a consumer).
 - `mock::MockChain` behind the `testing` feature — an in-memory chain with

--- a/packages/zaino-source/Cargo.toml
+++ b/packages/zaino-source/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "zaino-source"
 description = "Driven-port traits for Zcash validator access, backing the Zaino indexer's source adapters."
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true

--- a/packages/zaino-state/CHANGELOG.md
+++ b/packages/zaino-state/CHANGELOG.md
@@ -8,6 +8,14 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.8.0] - 2026-08-28
+
+### Added
 - Progress logging for the from-genesis txout-set accumulator rebuild. The
   rebuild previously logged two lines up front and nothing again until it
   committed, so a multi-shard full-chain scan — tens of minutes on a

--- a/packages/zaino-state/Cargo.toml
+++ b/packages/zaino-state/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.7.0"
+version = "0.8.0"
 
 [features]
 default = []

--- a/packages/zaino-status/CHANGELOG.md
+++ b/packages/zaino-status/CHANGELOG.md
@@ -8,6 +8,26 @@ and this library adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.1.1] - 2026-08-28
+
+### Added
+- `NamedAtomicStatus::apply` replaces the status with `f(current)` in one
+  compare-and-swap loop, for transitions that depend on the current status; a
+  `load` followed by a guarded `store` leaves a window in which a concurrent
+  transition is silently overwritten, and `apply` closes it.
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.1.0] - 2026-08-14
+
+### Added
 - New crate. How a Zaino component reports whether it is working, moved out of
   `zaino-common` — `StatusType`, `Status`, `NamedAtomicStatus`, and the
   `Liveness` / `Readiness` / `VitalsProbe` probing traits.
@@ -19,10 +39,6 @@ and this library adheres to Rust's notion of
 - Probing moved with status rather than after it: `Liveness` and `Readiness` are
   blanket impls over `Status`, so the two cannot be separated without giving up
   the blanket impls.
-- `NamedAtomicStatus::apply` replaces the status with `f(current)` in one
-  compare-and-swap loop, for transitions that depend on the current status; a
-  `load` followed by a guarded `store` leaves a window in which a concurrent
-  transition is silently overwritten, and `apply` closes it.
 
 ### Changed
 ### Deprecated

--- a/packages/zaino-status/Cargo.toml
+++ b/packages/zaino-status/Cargo.toml
@@ -6,7 +6,7 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-version = "0.1.0"
+version = "0.1.1"
 
 [dependencies]
 tracing = { workspace = true }

--- a/packages/zainod/CHANGELOG.md
+++ b/packages/zainod/CHANGELOG.md
@@ -9,6 +9,14 @@ and this crate adheres to Rust's notion of
 ## [Unreleased]
 
 ### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+## [0.9.0] - 2026-08-28
+
+### Added
 - An `fs_mode` field on the periodic `Zaino status check` log line, reporting
   whether finalised-state reads are served by the persistent database
   (`persistent`), by the ephemeral passthrough during sync or migration

--- a/packages/zainod/Cargo.toml
+++ b/packages/zainod/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zainod"
-version = "0.8.0"
+version = "0.9.0"
 description = "Crate containing the Zaino Indexer binary."
 authors = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
## What

The 0.9.0 version-bump commit, per the plan in #1475. The branch is cut from
`rc/0.9.0`, so until #1496 merges this diff shows the whole release payload.
The bump itself is one commit: `78030dd4`.

### Crate versions

| Crate | 0.8.0 | 0.9.0 | Reason |
|---|---|---|---|
| zainod | 0.8.0 | **0.9.0** | release-defining binary |
| zaino-state | 0.7.0 | **0.8.0** | BREAKING — non-finalised state removed (ADR-0011) |
| zaino-serve | 0.6.0 | **0.7.0** | BREAKING deps; `z_getsubtreesbyindex` accepts "ironwood" |
| zaino-proto | 0.4.0 | **0.5.0** | BREAKING — new `ShieldedProtocol::Ironwood` variant |
| zaino-source | 0.1.0 | **0.2.0** | BREAKING — `GetX` -> `OneShotGetX`, `Resilient` -> `ValidatorClient` |
| zaino-primitives | 0.1.0 | **0.2.0** | BREAKING — new `BlockHeader` fields `version`, `solution` |
| zaino-source-zebra{,-rpc,-readstate} | 0.1.0 | **0.2.0** | public dep on zaino-source 0.2.0 |
| zaino-convert-zebra | 0.1.0 | **0.2.0** | public dep on zaino-primitives 0.2.0 |
| zaino-rpc | 0.1.0 | **0.2.0** | public dep on zaino-source 0.2.0 |
| zaino-mempool | 0.1.0 | **0.2.0** | BREAKING — `NonFinalizedEpoch` removed; `ChainStateEpoch` in port signatures |
| zaino-mempool-service | 0.1.0 | **0.2.0** | public dep on zaino-mempool 0.2.0 |
| zaino-status | 0.1.0 | 0.1.1 | additive — `NamedAtomicStatus::apply` |
| zaino-common | 0.5.0 | 0.5.1 | comment-only; the version-reuse gate blocks republishing changed content |
| zaino-address, zaino-consensus | 0.1.0 | 0.1.0 | unchanged since 0.8.0 |
| zaino-chain-head, zaino-chain-head-service, zaino-source-macros | — | 0.1.0 | first publish |
| zaino-bench | — | — | `publish = false` |

Bumps were applied with `cargo set-version`, which also updates the
`workspace.dependencies` requirements and the lockfile.

### Changelogs

Each bumped crate's `[Unreleased]` is rolled into a dated section. The crates
first published with the 0.8.0 release still carried their initial entries
under `[Unreleased]`; those entries now sit in a `[0.1.0] - 2026-08-14`
section, and this cycle's entries in the new version's section. Retroactive
renames of 0.1.0-era text (`Resilient`, `NonFinalizedEpoch`) are restored in
the 0.1.0 sections and recorded as changes under 0.2.0. `zaino-source-macros`
gains a changelog. The root `CHANGELOG.md` is untouched, as in every bump
commit since 0.5.0.

## Verification

`check-published-versions --mode blocking` — the gate CI runs on rc/stable —
passes for all 20 publishable crates. `cargo tree -p zainod` resolves.

## After merge

Tag `0.9.0-rc.1` on `rc/0.9.0` → Docker/GitHub prerelease → deploy for manual
testing, per #1475.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ER3Q8Rc8g8iJDSg2pXSqZk
