### PR TITLE
fix(zaino-source-macros): add description required for crates.io publish

### DIFF
--- a/packages/zaino-source-macros/Cargo.toml
+++ b/packages/zaino-source-macros/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "zaino-source-macros"
 version = "0.1.0"
+description = "Procedural macros for zaino-source: derive the resilient validator-port traits from their single-attempt OneShot* twins."
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
`zaino-source-macros` (new crate this cycle, first publish) shipped without a `description`, so the 0.9.0 crates.io publish failed on it with `400: missing or empty metadata fields: description` — stopping the workspace publish after zaino-common/zaino-primitives/zaino-proto.

This adds a description so the release publish can complete. Metadata-only, no code or version change.

After merge: retag 0.9.0 to include this, then finish publishing the remaining crates. Backport to dev separately.