### PR TITLE
build: complete and enforce publish metadata (clippy::cargo_common_metadata)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,14 @@ repository = "https://github.com/zingolabs"
 homepage = "https://www.zingolabs.org/"
 edition = "2021"
 license = "Apache-2.0"
+# Publish metadata shared by every published crate, inherited via
+# `readme.workspace = true` etc. crates.io requires `description` + `license`;
+# `readme`/`keywords`/`categories` round out what `clippy::cargo_common_metadata`
+# checks (see the `clippy` task in tools/makefiles/lints.toml). `readme` is
+# resolved from the workspace root.
+readme = "README.md"
+keywords = ["zcash", "blockchain", "indexer", "lightwallet"]
+categories = ["cryptography::cryptocurrencies"]
 
 
 [workspace.dependencies]

--- a/packages/zaino-address/Cargo.toml
+++ b/packages/zaino-address/Cargo.toml
@@ -7,6 +7,9 @@ repository.workspace = true
 homepage.workspace = true
 edition.workspace = true
 license.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 sapling-crypto.workspace = true

--- a/packages/zaino-chain-head-service/Cargo.toml
+++ b/packages/zaino-chain-head-service/Cargo.toml
@@ -6,6 +6,9 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
 version = "0.1.0"
 
 [features]

--- a/packages/zaino-chain-head/Cargo.toml
+++ b/packages/zaino-chain-head/Cargo.toml
@@ -6,6 +6,9 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
 version = "0.1.0"
 
 [features]

--- a/packages/zaino-common/Cargo.toml
+++ b/packages/zaino-common/Cargo.toml
@@ -6,6 +6,9 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
 version = "0.5.0"
 
 [dependencies]

--- a/packages/zaino-consensus/Cargo.toml
+++ b/packages/zaino-consensus/Cargo.toml
@@ -6,6 +6,9 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
 version = "0.1.0"
 
 [dependencies]

--- a/packages/zaino-convert-zebra/Cargo.toml
+++ b/packages/zaino-convert-zebra/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "Convert zebra-chain types to zaino-primitives domain types."
 
 [dependencies]

--- a/packages/zaino-mempool-service/Cargo.toml
+++ b/packages/zaino-mempool-service/Cargo.toml
@@ -6,6 +6,9 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
 version = "0.1.0"
 
 [dependencies]

--- a/packages/zaino-mempool/Cargo.toml
+++ b/packages/zaino-mempool/Cargo.toml
@@ -6,6 +6,9 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
 version = "0.1.0"
 
 [dependencies]

--- a/packages/zaino-primitives/Cargo.toml
+++ b/packages/zaino-primitives/Cargo.toml
@@ -7,6 +7,9 @@ authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 thiserror = { workspace = true }

--- a/packages/zaino-proto/Cargo.toml
+++ b/packages/zaino-proto/Cargo.toml
@@ -6,6 +6,9 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
 version = "0.4.0"
 
 [features]

--- a/packages/zaino-rpc/Cargo.toml
+++ b/packages/zaino-rpc/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "Shared JSON-RPC 2.0 client: envelope, retry, auth. No validator knowledge."
 
 [features]

--- a/packages/zaino-serve/Cargo.toml
+++ b/packages/zaino-serve/Cargo.toml
@@ -6,6 +6,9 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
 version = "0.6.0"
 
 [features]

--- a/packages/zaino-source-macros/Cargo.toml
+++ b/packages/zaino-source-macros/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 name = "zaino-source-macros"
 version = "0.1.0"
+description = "Procedural macros for zaino-source: derive the resilient validator-port traits from their single-attempt OneShot* twins."
 edition.workspace = true
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 proc-macro = true

--- a/packages/zaino-source-zebra-readstate/Cargo.toml
+++ b/packages/zaino-source-zebra-readstate/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "Zebra ReadState adapter: direct DB reads, no RPC."
 
 [dependencies]

--- a/packages/zaino-source-zebra-rpc/Cargo.toml
+++ b/packages/zaino-source-zebra-rpc/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "Zebra JSON-RPC adapter implementing zaino-source query traits."
 
 [dependencies]

--- a/packages/zaino-source-zebra/Cargo.toml
+++ b/packages/zaino-source-zebra/Cargo.toml
@@ -6,6 +6,9 @@ authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 description = "Composite Zebra source: routes each query to the transport that can answer it."
 
 [dependencies]

--- a/packages/zaino-source/Cargo.toml
+++ b/packages/zaino-source/Cargo.toml
@@ -7,6 +7,9 @@ authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
 license.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 zaino-primitives = { workspace = true }

--- a/packages/zaino-state/Cargo.toml
+++ b/packages/zaino-state/Cargo.toml
@@ -6,6 +6,9 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
 version = "0.7.0"
 
 [features]

--- a/packages/zaino-status/Cargo.toml
+++ b/packages/zaino-status/Cargo.toml
@@ -6,6 +6,9 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
 version = "0.1.0"
 
 [dependencies]

--- a/packages/zainod/Cargo.toml
+++ b/packages/zainod/Cargo.toml
@@ -7,6 +7,9 @@ repository = { workspace = true }
 homepage = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
+readme = { workspace = true }
+keywords = { workspace = true }
+categories = { workspace = true }
 
 [[bin]]
 name = "zainod"

--- a/tools/makefiles/lints.toml
+++ b/tools/makefiles/lints.toml
@@ -4,7 +4,13 @@ args = ["fmt", "--all", "--", "--check"]
 
 [tasks.clippy]
 command = "cargo"
-args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings"]
+# `clippy::cargo_common_metadata` (a clippy `cargo`-group lint, off by default)
+# fails the build when a published crate is missing the manifest metadata
+# crates.io needs — description, license, repository, readme, keywords,
+# categories. It skips `publish = false` crates. This stops an unreleasable crate
+# from reaching a release cut, where the gap would otherwise surface only as a
+# 400 from crates.io mid-publish.
+args = ["clippy", "--all-targets", "--all-features", "--", "-D", "warnings", "-D", "clippy::cargo_common_metadata"]
 
 [tasks.doc]
 env = { RUSTDOCFLAGS = "-D warnings" }


### PR DESCRIPTION
## Why

The 0.9.0 crates.io publish failed mid-run: `zaino-source-macros` was new this
cycle and shipped without a `description`, so crates.io rejected it with
`400: missing or empty metadata fields: description`, stopping the workspace
publish after three crates. Nothing caught it before release — `cargo publish
--dry-run` only *warns* on missing `description` (crates.io enforces it
server-side), and the publish-dry-run workflow is masked by version-reuse until
the RC lands.

## What

Make published-crate metadata complete, and enforce it in CI so this can't
recur.

- **`[workspace.package]`** gains `readme` / `keywords` / `categories`; each of
  the 20 publishable crates inherits them via `<field>.workspace = true`
  (`description` / `license` / `repository` were already present).
- **`makers clippy`** now denies `clippy::cargo_common_metadata` — it fails the
  build if any `publish != false` crate is missing description, license,
  repository, readme, keywords, or categories. Caught **pre-merge**, not as a
  crates.io 400 mid-publish.
- **`zaino-source-macros`** gets its `description` (the fix already on `stable`
  via #1498, backported to `dev` here).

## Verification

- `cargo metadata` confirms all 20 publishable crates resolve with the six
  required fields.
- `clippy::cargo_common_metadata` fires on a missing field and passes when
  present (verified on `zaino-status` with the CLI flag, and end-to-end in an
  isolated workspace).

## Notes

- Enabled via the clippy-task flag rather than `[workspace.lints]` on purpose:
  the declarative route needs `[lints] workspace = true` on every crate, which
  cargo forbids alongside the 15 crates' existing `[lints.rust]`. Consolidating
  those into `[workspace.lints]` is a larger, separate cleanup (tracked for a
  follow-up).
- **Unrelated, pre-existing:** `cargo clippy --all-features` does not compile on
  `dev` today — `zaino-state::…::write_core.rs` fails with `E0425` under the
  `transparent_address_history_experimental` feature. Since `makers clippy` uses
  `--all-features`, that job is red on `dev` independent of this PR. Flagging so
  a red clippy job isn't mistaken for this change; worth its own fix.
