### PR TITLE
Review fixes for #1483: typed capability errors, sealed capabilities, full read-path metrics

### DIFF
--- a/packages/zaino-chain-store-zainodb/src/adapter.rs
+++ b/packages/zaino-chain-store-zainodb/src/adapter.rs
@@ -74,50 +74,45 @@ use crate::store::reader::DbReader;
 use crate::store::FinalisedState;
 use crate::types::{Height, Outpoint, TransactionHash};
 
-/// Which chunked read a duration belongs to.
-///
-/// A marker rather than the metric name itself, because `metric_names` is
-/// behind the `prometheus` feature and naming a constant from it at the call
-/// site would put a `cfg` on every read.
-#[derive(Debug, Clone, Copy)]
-enum ChunkRead {
-    Stored,
-    Compact,
-}
-
-/// How long a chunked read took.
+/// How long a read took, recorded against `DB_READ_SECONDS` under its `op`.
 ///
 /// A type rather than a bare `Instant` so the `prometheus` feature is handled
 /// once: without it this compiles to nothing and no call site needs a `cfg`.
+///
+/// The whole read surface shares one histogram, split by an `op` label naming
+/// the read. The label is the port method's own name, so a new read is
+/// instrumented by starting a timer with its name rather than by minting a
+/// metric.
+///
+/// Recorded on drop, so a read that returns early through `?` still records: a
+/// read that fails slowly is the symptom worth seeing, and dropping those
+/// samples would make a degrading store look faster as it got worse.
 struct ReadTimer {
+    #[cfg(feature = "prometheus")]
+    op: &'static str,
     #[cfg(feature = "prometheus")]
     started: std::time::Instant,
 }
 
 impl ReadTimer {
-    fn start() -> Self {
+    /// Starts timing a read labelled `op` — the port method's own name.
+    fn start(op: &'static str) -> Self {
+        #[cfg(not(feature = "prometheus"))]
+        let _ = op;
         Self {
+            #[cfg(feature = "prometheus")]
+            op,
             #[cfg(feature = "prometheus")]
             started: std::time::Instant::now(),
         }
     }
+}
 
-    /// Records the elapsed time against `read`'s metric.
-    ///
-    /// Recorded whether the read succeeded or failed: a read that fails slowly
-    /// is the symptom worth seeing, and dropping those samples would make a
-    /// degrading store look faster as it got worse.
-    fn record(self, read: ChunkRead) {
-        #[cfg(feature = "prometheus")]
-        {
-            let metric = match read {
-                ChunkRead::Stored => crate::metric_names::DB_BLOCK_READ_SECONDS,
-                ChunkRead::Compact => crate::metric_names::DB_COMPACT_READ_SECONDS,
-            };
-            metrics::histogram!(metric).record(self.started.elapsed().as_secs_f64());
-        }
-        #[cfg(not(feature = "prometheus"))]
-        let _ = read;
+#[cfg(feature = "prometheus")]
+impl Drop for ReadTimer {
+    fn drop(&mut self) {
+        metrics::histogram!(crate::metric_names::DB_READ_SECONDS, "op" => self.op)
+            .record(self.started.elapsed().as_secs_f64());
     }
 }
 
@@ -135,21 +130,25 @@ impl<T: ChainStoreSource> ChainStoreReader for DbReader<T> {
         Ok(store_schema(&metadata))
     }
 
+    #[tracing::instrument(skip(self), fields(height = %height))]
     async fn block_hash(
         &self,
         height: DomainHeight,
     ) -> Result<Option<DomainBlockHash>, ChainStoreError> {
         self.bounded(height)?;
+        let _timer = ReadTimer::start("block_hash");
         Ok(DbReader::get_block_hash(self, stored_height(height))
             .await
             .map_err(chain_store_error)?
             .map(domain_hash))
     }
 
+    #[tracing::instrument(skip(self), fields(hash = %hash))]
     async fn block_height(
         &self,
         hash: DomainBlockHash,
     ) -> Result<Option<DomainHeight>, ChainStoreError> {
+        let _timer = ReadTimer::start("block_height");
         match DbReader::get_block_height(self, stored_hash(hash))
             .await
             .map_err(chain_store_error)?
@@ -290,10 +289,12 @@ impl<T: ChainStoreSource> DbReader<T> {
 }
 
 impl<T: ChainStoreSource> TransactionIndex for DbReader<T> {
+    #[tracing::instrument(skip(self), fields(txid = %txid))]
     async fn tx_position(
         &self,
         txid: &TransactionId,
     ) -> Result<Option<BlockTxPosition>, ChainStoreError> {
+        let _timer = ReadTimer::start("tx_position");
         match self
             .get_tx_location(&TransactionHash((*txid).into()))
             .await
@@ -304,6 +305,7 @@ impl<T: ChainStoreSource> TransactionIndex for DbReader<T> {
         }
     }
 
+    #[tracing::instrument(skip(self), fields(position = ?position))]
     async fn txid_at(
         &self,
         position: BlockTxPosition,
@@ -312,6 +314,7 @@ impl<T: ChainStoreSource> TransactionIndex for DbReader<T> {
         let Some(location) = tx_location(position) else {
             return Ok(None);
         };
+        let _timer = ReadTimer::start("txid_at");
         // The backend errors on a miss where the domain answers `None`: asking
         // about a position past the end of a block is a reasonable question.
         match self.get_txid(location).await {
@@ -323,10 +326,12 @@ impl<T: ChainStoreSource> TransactionIndex for DbReader<T> {
 }
 
 impl<T: ChainStoreSource> SpentOutputIndex for DbReader<T> {
+    #[tracing::instrument(skip(self, outpoints), fields(outpoints = outpoints.len()))]
     async fn outpoint_spenders(
         &self,
         outpoints: &[DomainOutpoint],
     ) -> Result<Vec<Option<SpenderRef>>, ChainStoreError> {
+        let _timer = ReadTimer::start("outpoint_spenders");
         let stored: Vec<Outpoint> = outpoints.iter().map(stored_outpoint).collect();
         let locations = DbReader::get_outpoint_spenders(self, stored)
             .await
@@ -350,10 +355,12 @@ impl<T: ChainStoreSource> SpentOutputIndex for DbReader<T> {
         Ok(spenders)
     }
 
+    #[tracing::instrument(skip(self, outpoints), fields(outpoints = outpoints.len()))]
     async fn previous_outputs(
         &self,
         outpoints: &[DomainOutpoint],
     ) -> Result<Vec<Option<StoredTxOut>>, ChainStoreError> {
+        let _timer = ReadTimer::start("previous_outputs");
         let mut outputs = Vec::with_capacity(outpoints.len());
         for outpoint in outpoints {
             outputs.push(self.previous_output(outpoint).await?);
@@ -361,10 +368,12 @@ impl<T: ChainStoreSource> SpentOutputIndex for DbReader<T> {
         Ok(outputs)
     }
 
+    #[tracing::instrument(skip(self), fields(outpoint = ?outpoint))]
     async fn unspent_output(
         &self,
         outpoint: DomainOutpoint,
     ) -> Result<Option<StoredTxOut>, ChainStoreError> {
+        let _timer = ReadTimer::start("unspent_output");
         let Some(output) = self.previous_output(&outpoint).await? else {
             return Ok(None);
         };
@@ -376,6 +385,7 @@ impl<T: ChainStoreSource> SpentOutputIndex for DbReader<T> {
         Ok((!spent).then_some(output))
     }
 
+    #[tracing::instrument(skip(self), fields(position = ?position))]
     async fn transparent_outputs(
         &self,
         position: BlockTxPosition,
@@ -384,6 +394,7 @@ impl<T: ChainStoreSource> SpentOutputIndex for DbReader<T> {
         let Some(location) = tx_location(position) else {
             return Ok(None);
         };
+        let _timer = ReadTimer::start("transparent_outputs");
         match DbReader::get_transparent(self, location)
             .await
             .map_err(chain_store_error)?
@@ -414,7 +425,9 @@ impl<T: ChainStoreSource> DbReader<T> {
 }
 
 impl<T: ChainStoreSource> TxOutSetIndex for DbReader<T> {
+    #[tracing::instrument(skip(self))]
     async fn txout_set(&self) -> Result<TxOutSetAccumulator, ChainStoreError> {
+        let _timer = ReadTimer::start("txout_set");
         let accumulator = self
             .get_tx_out_set_info_accumulator()
             .await
@@ -442,18 +455,14 @@ impl<T: ChainStoreSource> StoredBlockRead for DbReader<T> {
         // Timed around the chunk rather than the block: one read transaction
         // covers the range, so a per-block figure would divide one duration by
         // a count rather than measure anything.
-        let read = ReadTimer::start();
+        let _timer = ReadTimer::start("blocks_chunk");
 
-        let blocks: Result<Vec<_>, _> = self
-            .get_chain_block_range(start, end)
+        self.get_chain_block_range(start, end)
             .await
             .map_err(chain_store_error)?
             .into_iter()
             .map(stored_block)
-            .collect();
-
-        read.record(ChunkRead::Stored);
-        blocks
+            .collect()
     }
 
     async fn blocks_stream(
@@ -494,14 +503,11 @@ impl<T: ChainStoreSource> CompactBlockRead for DbReader<T> {
 
         // The wallet-sync hot path: a syncing wallet spends almost all of its
         // time here, so this is the read whose latency a dashboard needs.
-        let read = ReadTimer::start();
+        let _timer = ReadTimer::start("compact_chunk");
 
-        let blocks = DbReader::get_compact_block_range(self, start, end, pools)
+        DbReader::get_compact_block_range(self, start, end, pools)
             .await
-            .map_err(chain_store_error);
-
-        read.record(ChunkRead::Compact);
-        blocks
+            .map_err(chain_store_error)
     }
 
     async fn compact_stream(

--- a/packages/zaino-chain-store-zainodb/src/adapter/error_map.rs
+++ b/packages/zaino-chain-store-zainodb/src/adapter/error_map.rs
@@ -28,43 +28,38 @@ use crate::store::capability::CapabilityRequest;
 pub(super) fn chain_store_error(error: StoreError) -> ChainStoreError {
     match error {
         StoreError::DataUnavailable(what) => ChainStoreError::MissingRow(what),
-        StoreError::FeatureUnavailable(feature) => {
-            ChainStoreError::Unavailable(capability_for_feature(feature))
+        StoreError::FeatureUnavailable(request) => {
+            ChainStoreError::Unavailable(capability_for_feature(request))
         }
+        StoreError::V1BackendUnavailable(_) => ChainStoreError::NotReady,
         other => ChainStoreError::backend_because(other.to_string(), other),
     }
 }
 
-/// Which domain capability a routing refusal was about.
+/// Which domain capability a refusal was about.
 ///
-/// The router refuses with a static feature name, which is this crate's
-/// vocabulary; the domain's is coarser. Anything unrecognised maps to
-/// [`StoreCapability::Core`], which is the conservative reading: a store that
-/// cannot say which capability it lacks is reported as lacking the one every
-/// store must have, so the caller routes elsewhere rather than retrying.
+/// The refusal carries the [`CapabilityRequest`] itself, so producer and matcher
+/// cannot drift: the crate's finer request vocabulary is folded onto the
+/// domain's coarser one here, and the match is total. The three index requests
+/// name their own domain capability; every core and block-extension request
+/// folds to [`StoreCapability::Core`], the one capability every store must
+/// have, so a caller routes elsewhere rather than retrying.
 ///
-/// # Why the names come from `CapabilityRequest` rather than from literals
-///
-/// A routing refusal carries [`CapabilityRequest::name`], so matching on
-/// hand-written literals lets producer and matcher drift: the two vocabularies
-/// look alike enough that a mismatch reads as correct and every refusal
-/// silently collapses to `Core`. Matching the constants the router itself
-/// produces makes the drift impossible — a rename in `capability.rs` moves both
-/// sides at once.
-///
-/// The lowercase arms are the second producer: `finalised_source` raises those
-/// names directly rather than through a [`CapabilityRequest`], so they have no
-/// constant to borrow and must be spelled out.
-fn capability_for_feature(feature: &str) -> StoreCapability {
-    const SPENT_OUTPUT_INDEX: &str = CapabilityRequest::SpentOutputIndex.name();
-    const TXOUT_SET_INDEX: &str = CapabilityRequest::TxOutSetIndex.name();
-    const TRANSPARENT_HIST_INDEX: &str = CapabilityRequest::TransparentHistIndex.name();
-
-    match feature {
-        SPENT_OUTPUT_INDEX | "spent_output_index" => StoreCapability::SpentOutputs,
-        TXOUT_SET_INDEX | "txout_set_index" => StoreCapability::TxOutSet,
-        TRANSPARENT_HIST_INDEX | "transparent_history" => StoreCapability::TransparentHistory,
-        _ => StoreCapability::Core,
+/// The grouping is explicit rather than a `_` catch-all so that adding a
+/// [`CapabilityRequest`] variant is a compile error here until it is classified,
+/// rather than silently collapsing to `Core`.
+fn capability_for_feature(request: CapabilityRequest) -> StoreCapability {
+    match request {
+        CapabilityRequest::SpentOutputIndex => StoreCapability::SpentOutputs,
+        CapabilityRequest::TxOutSetIndex => StoreCapability::TxOutSet,
+        CapabilityRequest::TransparentHistIndex => StoreCapability::TransparentHistory,
+        CapabilityRequest::ReadCore
+        | CapabilityRequest::WriteCore
+        | CapabilityRequest::BlockCoreExt
+        | CapabilityRequest::BlockTransparentExt
+        | CapabilityRequest::BlockShieldedExt
+        | CapabilityRequest::CompactBlockExt
+        | CapabilityRequest::IndexedBlockExt => StoreCapability::Core,
     }
 }
 
@@ -239,66 +234,60 @@ mod tests {
         assert!(matches!(error, ChainStoreSourceError::Unavailable { .. }));
     }
 
-    /// A routing refusal names the capability the caller was denied.
+    /// Each index request names the capability the caller was denied.
     ///
-    /// Fed from [`CapabilityRequest::name`] rather than from hand-written
-    /// strings, because the router is what produces these names and a test that
-    /// invents its own cannot see the two vocabularies drift apart. An earlier
-    /// version of this test passed against literals the router never emits
-    /// while every real refusal collapsed to `Core`.
+    /// The refusal carries the [`CapabilityRequest`] itself, so producer and
+    /// matcher share one vocabulary and cannot drift — the failure an earlier,
+    /// string-matching version had, where literals the producer never emitted
+    /// read as correct while every real refusal collapsed to `Core`.
     #[test]
-    fn a_routing_refusal_maps_to_the_capability_it_denied() {
+    fn an_index_refusal_maps_to_the_capability_it_denied() {
         assert_eq!(
-            capability_for_feature(CapabilityRequest::SpentOutputIndex.name()),
+            capability_for_feature(CapabilityRequest::SpentOutputIndex),
             StoreCapability::SpentOutputs
         );
         assert_eq!(
-            capability_for_feature(CapabilityRequest::TxOutSetIndex.name()),
+            capability_for_feature(CapabilityRequest::TxOutSetIndex),
             StoreCapability::TxOutSet
         );
         assert_eq!(
-            capability_for_feature(CapabilityRequest::TransparentHistIndex.name()),
+            capability_for_feature(CapabilityRequest::TransparentHistIndex),
             StoreCapability::TransparentHistory
         );
     }
 
-    /// The names `finalised_source` raises directly map too.
+    /// Every core and block-extension request folds to `Core`.
     ///
-    /// A second producer, which does not route through [`CapabilityRequest`]
-    /// and so spells its features in its own lowercase vocabulary. It is the
-    /// path that happened to match while the router's did not, so it gets its
-    /// own test rather than sharing one.
+    /// The domain does not distinguish these, so a refusal of any of them is
+    /// reported as the one capability every store must have; the caller routes
+    /// elsewhere rather than over-claiming which index is missing. The typed,
+    /// total match replaces the old catch-all — there is no longer an
+    /// "unrecognised name" case, because there is no name.
     #[test]
-    fn a_direct_refusal_maps_to_the_capability_it_denied() {
-        assert_eq!(
-            capability_for_feature("spent_output_index"),
-            StoreCapability::SpentOutputs
-        );
-        assert_eq!(
-            capability_for_feature("txout_set_index"),
-            StoreCapability::TxOutSet
-        );
-        assert_eq!(
-            capability_for_feature("transparent_history"),
-            StoreCapability::TransparentHistory
-        );
+    fn a_core_or_block_refusal_maps_to_core() {
+        for request in [
+            CapabilityRequest::ReadCore,
+            CapabilityRequest::WriteCore,
+            CapabilityRequest::BlockCoreExt,
+            CapabilityRequest::BlockTransparentExt,
+            CapabilityRequest::BlockShieldedExt,
+            CapabilityRequest::CompactBlockExt,
+            CapabilityRequest::IndexedBlockExt,
+        ] {
+            assert_eq!(capability_for_feature(request), StoreCapability::Core);
+        }
     }
 
-    /// An unrecognised name falls back to `Core`.
+    /// A missing v1 backend is transient, so it reaches the domain as `NotReady`.
     ///
-    /// Rather than to the capability that happens to be nearest: over-claiming
-    /// which index is missing would send a consumer to reroute a query that
-    /// would have worked. `READ_CORE` is a real router name that lands here
-    /// legitimately; the other is a name no producer emits.
+    /// It is a backend-state refusal, not a capability one: the concrete v1
+    /// backend is absent only while a migration runs and returns once it
+    /// completes, which is exactly what [`ChainStoreError::NotReady`] means.
     #[test]
-    fn an_unrecognised_refusal_falls_back_to_core() {
-        assert_eq!(
-            capability_for_feature(CapabilityRequest::ReadCore.name()),
-            StoreCapability::Core
-        );
-        assert_eq!(
-            capability_for_feature("no_such_feature"),
-            StoreCapability::Core
-        );
+    fn a_missing_v1_backend_maps_to_not_ready() {
+        let error = chain_store_error(StoreError::V1BackendUnavailable(
+            "v1 spent db not available",
+        ));
+        assert!(matches!(error, ChainStoreError::NotReady));
     }
 }

--- a/packages/zaino-chain-store-zainodb/src/adapter/history.rs
+++ b/packages/zaino-chain-store-zainodb/src/adapter/history.rs
@@ -8,6 +8,7 @@
 use super::error_map::chain_store_error;
 use super::from_domain::stored_script_tag;
 use super::to_domain::{block_tx_position, domain_txid, stored_tx_out};
+use super::ReadTimer;
 use zaino_chain_store::{ChainStoreError, ChainStoreSource, StoredAddress};
 use zaino_primitives::types::{Outpoint as DomainOutpoint, TransactionId};
 
@@ -26,6 +27,10 @@ use crate::types::{Outpoint, TxOutCompact};
 /// result over costs nothing and saves the consumer a second round trip.
 #[cfg(feature = "transparent_address_history_experimental")]
 impl<T: ChainStoreSource> zaino_chain_store::TransparentHistoryIndex for DbReader<T> {
+    #[tracing::instrument(
+        skip(self, query),
+        fields(start = %query.start, end = %query.end, addresses = query.addresses.len())
+    )]
     async fn address_effects(
         &self,
         query: &zaino_chain_store::TransparentHistoryQuery,
@@ -41,6 +46,8 @@ impl<T: ChainStoreSource> zaino_chain_store::TransparentHistoryIndex for DbReade
         let Some((start, end)) = self.clamped_range(query.start, query.end)? else {
             return Ok(StoreAddressEffects::default());
         };
+
+        let _timer = ReadTimer::start("address_effects");
 
         let mut effects = StoreAddressEffects::default();
 

--- a/packages/zaino-chain-store-zainodb/src/adapter/to_domain.rs
+++ b/packages/zaino-chain-store-zainodb/src/adapter/to_domain.rs
@@ -12,9 +12,10 @@
 
 use super::error_map::{corrupt_row, corrupt_row_because};
 use zaino_chain_store::{
-    ChainStoreError, ChainStoreReader, CompactBlockRead, MigrationState, SchemaVersion,
-    SpentOutputIndex, StoreCapabilities, StoreCapability, StoreSchema, StoredAddress, StoredBlock,
-    StoredBlockRead, StoredTx, StoredTxOut, TransactionIndex, TxOutSetIndex,
+    ChainStoreError, ChainStoreReaderCapability, CompactBlockReadCapability, MigrationState,
+    SchemaVersion, SpentOutputIndexCapability, StoreCapabilities, StoreCapability, StoreSchema,
+    StoredAddress, StoredBlock, StoredBlockReadCapability, StoredTx, StoredTxOut,
+    TransactionIndexCapability, TxOutSetIndexCapability,
 };
 use zaino_primitives::types::{
     BlockHash as DomainBlockHash, BlockHeader, BlockRef, BlockTxPosition,
@@ -351,13 +352,17 @@ pub(super) fn tree_roots(data: &CommitmentTreeData) -> TreeRoots {
 ///
 /// # Why this is generic over the reader
 ///
-/// Every capability is named as `<R as SomePort>::CAPABILITY` rather than as a
-/// [`StoreCapability`] variant, so the advertisement is tied to the port that
-/// answers it. Choosing variants by hand let the two drift in both directions:
-/// a store could advertise an index it does not serve, or serve one it never
-/// advertises, and both compile. Now a capability can only be advertised for a
-/// port `R` actually implements — drop one of these impls and this stops
-/// compiling instead of quietly over-promising.
+/// Every capability is named as `<R as SomePortCapability>::CAPABILITY` rather
+/// than as a [`StoreCapability`] variant, so the advertisement is tied to the
+/// port that answers it. Choosing variants by hand let the two drift in both
+/// directions: a store could advertise an index it does not serve, or serve one
+/// it never advertises, and both compile. Now a capability can only be
+/// advertised for a port `R` actually implements — drop one of these impls and
+/// this stops compiling instead of quietly over-promising.
+///
+/// The `CAPABILITY` comes from the sealed carrier trait, not the port, so the
+/// pairing cannot be restated by an implementor even by accident; see
+/// [`sealed_capability`](zaino_chain_store::ChainStoreReaderCapability).
 ///
 /// It does not make the runtime bits agree with the compile-time impls; that
 /// is what the bits are for, since this backend implements every port and
@@ -365,14 +370,14 @@ pub(super) fn tree_roots(data: &CommitmentTreeData) -> TreeRoots {
 /// the two being restated here rather than read from the port.
 pub(super) fn store_capabilities<R>(capability: Capability) -> StoreCapabilities
 where
-    R: ChainStoreReader
-        + StoredBlockRead
-        + CompactBlockRead
-        + TransactionIndex
-        + SpentOutputIndex
-        + TxOutSetIndex,
+    R: ChainStoreReaderCapability
+        + StoredBlockReadCapability
+        + CompactBlockReadCapability
+        + TransactionIndexCapability
+        + SpentOutputIndexCapability
+        + TxOutSetIndexCapability,
 {
-    let mut capabilities = vec![<R as ChainStoreReader>::CAPABILITY];
+    let mut capabilities = vec![<R as ChainStoreReaderCapability>::CAPABILITY];
 
     // Stored blocks need the header, the txids and every per-pool surface: a
     // block missing one of them is not a block this store can hand over.
@@ -382,22 +387,22 @@ where
             .union(Capability::BLOCK_TRANSPARENT_EXT)
             .union(Capability::BLOCK_SHIELDED_EXT),
     ) {
-        capabilities.push(<R as StoredBlockRead>::CAPABILITY);
+        capabilities.push(<R as StoredBlockReadCapability>::CAPABILITY);
     }
     if capability.has(Capability::COMPACT_BLOCK_EXT) {
-        capabilities.push(<R as CompactBlockRead>::CAPABILITY);
+        capabilities.push(<R as CompactBlockReadCapability>::CAPABILITY);
     }
     if capability.has(Capability::BLOCK_CORE_EXT) {
-        capabilities.push(<R as TransactionIndex>::CAPABILITY);
+        capabilities.push(<R as TransactionIndexCapability>::CAPABILITY);
     }
     // Both halves: the domain's spent-output surface answers "what did this
     // outpoint hold" from the transparent rows as well as "who spent it" from
     // the spent index, and a store with only one of them cannot serve it.
     if capability.has(Capability::SPENT_OUTPUT_INDEX.union(Capability::BLOCK_TRANSPARENT_EXT)) {
-        capabilities.push(<R as SpentOutputIndex>::CAPABILITY);
+        capabilities.push(<R as SpentOutputIndexCapability>::CAPABILITY);
     }
     if capability.has(Capability::TXOUT_SET_INDEX) {
-        capabilities.push(<R as TxOutSetIndex>::CAPABILITY);
+        capabilities.push(<R as TxOutSetIndexCapability>::CAPABILITY);
     }
     // The one capability still named directly rather than read off its port.
     // `TransparentHistoryIndex` is implemented behind a feature, so it cannot
@@ -445,8 +450,8 @@ mod tests {
     use super::*;
     use crate::store::reader::DbReader;
     use zaino_chain_store::{
-        ChainStoreReader, CompactBlockRead, SpentOutputIndex, StoredBlockRead, TransactionIndex,
-        TxOutSetIndex,
+        ChainStoreReaderCapability, CompactBlockReadCapability, SpentOutputIndexCapability,
+        StoredBlockReadCapability, TransactionIndexCapability, TxOutSetIndexCapability,
     };
 
     /// The concrete reader whose ports the capability mapping is read from.
@@ -546,12 +551,12 @@ mod tests {
         let everything = advertised(Capability::all());
 
         let ports = [
-            <Reader as ChainStoreReader>::CAPABILITY,
-            <Reader as StoredBlockRead>::CAPABILITY,
-            <Reader as CompactBlockRead>::CAPABILITY,
-            <Reader as TransactionIndex>::CAPABILITY,
-            <Reader as SpentOutputIndex>::CAPABILITY,
-            <Reader as TxOutSetIndex>::CAPABILITY,
+            <Reader as ChainStoreReaderCapability>::CAPABILITY,
+            <Reader as StoredBlockReadCapability>::CAPABILITY,
+            <Reader as CompactBlockReadCapability>::CAPABILITY,
+            <Reader as TransactionIndexCapability>::CAPABILITY,
+            <Reader as SpentOutputIndexCapability>::CAPABILITY,
+            <Reader as TxOutSetIndexCapability>::CAPABILITY,
         ];
 
         for capability in everything.iter() {
@@ -564,7 +569,7 @@ mod tests {
             assert!(
                 ports.contains(&capability)
                     || capability
-                        == <Reader as zaino_chain_store::TransparentHistoryIndex>::CAPABILITY,
+                        == <Reader as zaino_chain_store::TransparentHistoryIndexCapability>::CAPABILITY,
                 "{capability} is advertised but answered by no port"
             );
         }

--- a/packages/zaino-chain-store-zainodb/src/error.rs
+++ b/packages/zaino-chain-store-zainodb/src/error.rs
@@ -10,6 +10,7 @@
 
 use zaino_chain_store::ChainStoreSourceError;
 
+use crate::store::capability::CapabilityRequest;
 use crate::types::BlockHash;
 
 /// Something went wrong inside the store.
@@ -48,8 +49,22 @@ pub enum StoreError {
 
     /// Returned when a caller asks for a feature that the
     /// currently-opened database version does not advertise.
+    ///
+    /// Carries the [`CapabilityRequest`] that was refused, not a name for it, so
+    /// the producer and any consumer that classifies the refusal share one
+    /// vocabulary and cannot drift apart.
     #[error("feature unavailable: {0}")]
-    FeatureUnavailable(&'static str),
+    FeatureUnavailable(CapabilityRequest),
+
+    /// A maintenance accessor needed the concrete v1 backend, but the store is
+    /// in an ephemeral/migration state and has no live v1 backend to hand out.
+    ///
+    /// Distinct from [`StoreError::FeatureUnavailable`]: that names a capability
+    /// this deployment does not build, whereas this is a backend that is
+    /// temporarily absent while a migration runs and returns once it completes.
+    /// The string names the handle the caller asked for, for the operator's log.
+    #[error("v1 backend unavailable: {0}")]
+    V1BackendUnavailable(&'static str),
 
     /// Critical Errors, Restart Zaino.
     #[error("Critical error: {0}")]

--- a/packages/zaino-chain-store-zainodb/src/metric_names.rs
+++ b/packages/zaino-chain-store-zainodb/src/metric_names.rs
@@ -37,10 +37,12 @@ pub const FINALISED_EPHEMERAL: &str = "zaino.db.finalised_ephemeral";
 pub const ACCUMULATOR_BUILT_HEIGHT: &str = "zaino.db.accumulator_built_height";
 pub const ACCUMULATOR_REBUILD_ACTIVE: &str = "zaino.db.accumulator_rebuild_active";
 
-// Read path. The write path has been instrumented since before the move; these
-// are the reads, which had nothing. A wallet syncing against this store spends
-// almost all of its time in `compact_chunk`, so a store that is slow or rotting
-// was invisible from a dashboard while every write metric looked healthy.
-pub const DB_BLOCK_READ_SECONDS: &str = "zaino.db.block_read_seconds";
-pub const DB_COMPACT_READ_SECONDS: &str = "zaino.db.compact_read_seconds";
+// Read path. The write path has been instrumented since before the move; the
+// reads had nothing. A wallet syncing against this store spends almost all of
+// its time in `compact_chunk`, so a store that is slow or rotting was invisible
+// from a dashboard while every write metric looked healthy. One histogram
+// covers the whole read surface, split by an `op` label naming the read — the
+// port method's own name — so a new read is instrumented by labelling it rather
+// than by minting a metric. See `adapter::ReadTimer` for how the label is set.
+pub const DB_READ_SECONDS: &str = "zaino.db.read_seconds";
 pub const DB_CORRUPT_ROWS_TOTAL: &str = "zaino.db.corrupt_rows_total";

--- a/packages/zaino-chain-store-zainodb/src/store/capability.rs
+++ b/packages/zaino-chain-store-zainodb/src/store/capability.rs
@@ -237,8 +237,13 @@ impl Capability {
 /// The router uses the request to select a backend that advertises the requested capability.
 /// If no backend advertises the capability, the call must fail with
 /// [`StoreError::FeatureUnavailable`].
+// `pub` (not `pub(crate)`) for the same reason as [`DbMetadata`]: it is carried
+// by [`StoreError::FeatureUnavailable`], and `error` is a `pub` module, so the
+// rustc `private_interfaces` check requires the variant's type to be at least as
+// visible as the variant. The `capability` module is itself `pub(crate)`, so
+// this does not widen the type beyond the crate; it only satisfies that check.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub(crate) enum CapabilityRequest {
+pub enum CapabilityRequest {
     /// Request the [`DbRead`] core surface.
     ReadCore,
 
@@ -310,6 +315,14 @@ impl CapabilityRequest {
             CapabilityRequest::SpentOutputIndex => "SPENT_OUTPUT_INDEX",
             CapabilityRequest::TxOutSetIndex => "TXOUT_SET_INDEX",
         }
+    }
+}
+
+/// Renders the stable feature name, so [`StoreError::FeatureUnavailable`] and
+/// logs share the vocabulary routing uses.
+impl fmt::Display for CapabilityRequest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
     }
 }
 

--- a/packages/zaino-chain-store-zainodb/src/store/finalised_source.rs
+++ b/packages/zaino-chain-store-zainodb/src/store/finalised_source.rs
@@ -100,7 +100,7 @@ use tokio::{
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-use super::capability::Capability;
+use super::capability::{Capability, CapabilityRequest};
 
 /// Lifecycle scaffolding shared by every `DbVx` finalised-state backend.
 ///
@@ -328,15 +328,18 @@ impl<T: ChainStoreSource> FinalisedSource<T> {
         }
     }
 
-    /// Borrow the underlying v1 backend, or return `FeatureUnavailable(feature)` for the ephemeral
+    /// Borrow the underlying v1 backend, or return `V1BackendUnavailable(feature)` for the ephemeral
     /// passthrough.
     ///
-    /// Shared by the v1-only accessors below so each call site is a single line that names the
-    /// feature it requires; `feature` is the message used when the backend is ephemeral.
+    /// Shared by the v1-only maintenance accessors below so each call site is a single line that
+    /// names the handle it requires; `feature` names that handle in the error when the backend is
+    /// ephemeral. This is a backend-state refusal, not a capability refusal: the concrete v1 backend
+    /// is temporarily absent while a migration runs, so it maps to a transient error rather than to
+    /// [`StoreError::FeatureUnavailable`].
     fn require_v1(&self, feature: &'static str) -> Result<&DbV1, StoreError> {
         match self {
             Self::V1(db) => Ok(db.as_ref()),
-            Self::Ephemeral(_) => Err(StoreError::FeatureUnavailable(feature)),
+            Self::Ephemeral(_) => Err(StoreError::V1BackendUnavailable(feature)),
         }
     }
 
@@ -528,9 +531,10 @@ impl<T: ChainStoreSource> DbWrite for FinalisedSource<T> {
 //
 // Each extension trait corresponds to a distinct capability group. The dispatch rules are:
 // - If the backend supports the capability, delegate to the concrete implementation.
-// - If unsupported, return `StoreError::FeatureUnavailable("<capability_name>")`.
+// - If unsupported, return `StoreError::FeatureUnavailable(CapabilityRequest::<Variant>)`.
 //
-// These names must remain consistent with the capability wiring in `capability.rs`.
+// The refusal carries the `CapabilityRequest` variant itself, so it stays in step with the
+// capability wiring in `capability.rs` by construction rather than by matching names.
 
 impl<T: ChainStoreSource> BlockCoreExt for FinalisedSource<T> {
     async fn get_block_header(&self, height: Height) -> Result<BlockHeaderData, StoreError> {
@@ -807,7 +811,9 @@ impl<T: ChainStoreSource> TransparentHistExt for FinalisedSource<T> {
     ) -> Result<Option<Vec<crate::types::AddrEventBytes>>, StoreError> {
         match self {
             Self::V1(db) => db.addr_records(script).await,
-            _ => Err(StoreError::FeatureUnavailable("transparent_history")),
+            _ => Err(StoreError::FeatureUnavailable(
+                CapabilityRequest::TransparentHistIndex,
+            )),
         }
     }
 
@@ -818,7 +824,9 @@ impl<T: ChainStoreSource> TransparentHistExt for FinalisedSource<T> {
     ) -> Result<Option<Vec<crate::types::AddrEventBytes>>, StoreError> {
         match self {
             Self::V1(db) => db.addr_and_index_records(script, tx_location).await,
-            _ => Err(StoreError::FeatureUnavailable("transparent_history")),
+            _ => Err(StoreError::FeatureUnavailable(
+                CapabilityRequest::TransparentHistIndex,
+            )),
         }
     }
 
@@ -830,7 +838,9 @@ impl<T: ChainStoreSource> TransparentHistExt for FinalisedSource<T> {
     ) -> Result<Option<Vec<TxLocation>>, StoreError> {
         match self {
             Self::V1(db) => db.addr_tx_locations_by_range(script, start, end).await,
-            _ => Err(StoreError::FeatureUnavailable("transparent_history")),
+            _ => Err(StoreError::FeatureUnavailable(
+                CapabilityRequest::TransparentHistIndex,
+            )),
         }
     }
 
@@ -842,7 +852,9 @@ impl<T: ChainStoreSource> TransparentHistExt for FinalisedSource<T> {
     ) -> Result<Option<Vec<AddrUtxo>>, StoreError> {
         match self {
             Self::V1(db) => db.addr_utxos_by_range(script, start, end).await,
-            _ => Err(StoreError::FeatureUnavailable("transparent_history")),
+            _ => Err(StoreError::FeatureUnavailable(
+                CapabilityRequest::TransparentHistIndex,
+            )),
         }
     }
 
@@ -854,7 +866,9 @@ impl<T: ChainStoreSource> TransparentHistExt for FinalisedSource<T> {
     ) -> Result<i64, StoreError> {
         match self {
             Self::V1(db) => db.addr_balance_by_range(script, start, end).await,
-            _ => Err(StoreError::FeatureUnavailable("transparent_history")),
+            _ => Err(StoreError::FeatureUnavailable(
+                CapabilityRequest::TransparentHistIndex,
+            )),
         }
     }
 }
@@ -866,7 +880,9 @@ impl<T: ChainStoreSource> SpentOutputExt for FinalisedSource<T> {
     ) -> Result<Option<TxLocation>, StoreError> {
         match self {
             Self::V1(db) => db.get_outpoint_spender(outpoint).await,
-            _ => Err(StoreError::FeatureUnavailable("spent_output_index")),
+            _ => Err(StoreError::FeatureUnavailable(
+                CapabilityRequest::SpentOutputIndex,
+            )),
         }
     }
 
@@ -876,7 +892,9 @@ impl<T: ChainStoreSource> SpentOutputExt for FinalisedSource<T> {
     ) -> Result<Vec<Option<TxLocation>>, StoreError> {
         match self {
             Self::V1(db) => db.get_outpoint_spenders(outpoints).await,
-            _ => Err(StoreError::FeatureUnavailable("spent_output_index")),
+            _ => Err(StoreError::FeatureUnavailable(
+                CapabilityRequest::SpentOutputIndex,
+            )),
         }
     }
 }
@@ -887,7 +905,9 @@ impl<T: ChainStoreSource> TxOutSetExt for FinalisedSource<T> {
     ) -> Result<FinalisedTxOutSetInfoAccumulator, StoreError> {
         match self {
             Self::V1(database) => database.get_tx_out_set_info_accumulator().await,
-            _ => Err(StoreError::FeatureUnavailable("txout_set_index")),
+            _ => Err(StoreError::FeatureUnavailable(
+                CapabilityRequest::TxOutSetIndex,
+            )),
         }
     }
 }

--- a/packages/zaino-chain-store-zainodb/src/store/finalised_source/ephemeral.rs
+++ b/packages/zaino-chain-store-zainodb/src/store/finalised_source/ephemeral.rs
@@ -249,8 +249,11 @@ impl<T: ChainStoreSource> EphemeralFinalisedState<T> {
         self.status.store(status);
     }
 
-    fn feature_unavailable(feature_name: &'static str) -> StoreError {
-        StoreError::FeatureUnavailable(feature_name)
+    /// The concrete v1 backend a read needs is absent because this backend is
+    /// the ephemeral migration passthrough. A backend-state refusal, not a
+    /// capability one; `handle` names what was asked for, for the operator's log.
+    fn v1_backend_unavailable(handle: &'static str) -> StoreError {
+        StoreError::V1BackendUnavailable(handle)
     }
 
     /// The block at `height`, or `None` when the validator has no such block.
@@ -452,8 +455,8 @@ impl<T: ChainStoreSource> DbRead for EphemeralFinalisedState<T> {
     }
 
     async fn get_metadata(&self) -> Result<DbMetadata, StoreError> {
-        Err(Self::feature_unavailable(
-            "READ_CORE:metadata requires an active DB",
+        Err(Self::v1_backend_unavailable(
+            "metadata read requires an active v1 backend",
         ))
     }
 }

--- a/packages/zaino-chain-store-zainodb/src/store/router.rs
+++ b/packages/zaino-chain-store-zainodb/src/store/router.rs
@@ -559,7 +559,7 @@ impl<T: ChainStoreSource> Router<T> {
             return Ok(self.primary.load_full());
         }
 
-        Err(StoreError::FeatureUnavailable(cap.name()))
+        Err(StoreError::FeatureUnavailable(cap))
     }
 
     // ***** Ephemeral finalised state control *****

--- a/packages/zaino-chain-store/src/lib.rs
+++ b/packages/zaino-chain-store/src/lib.rs
@@ -67,8 +67,10 @@ pub use config::ChainStoreConfig;
 pub use error::{ChainStoreError, ChainStoreSourceError};
 pub use output::{SpenderRef, StoredAddress, StoredTxOut};
 pub use ports::{
-    ChainStoreFreezeSink, ChainStoreIngest, ChainStoreReader, ChainStoreService, ChainStoreSource,
-    CompactBlockRead, SpentOutputIndex, StoredBlockRead, TransactionIndex, TxOutSetIndex,
+    ChainStoreFreezeSink, ChainStoreIngest, ChainStoreReader, ChainStoreReaderCapability,
+    ChainStoreService, ChainStoreSource, CompactBlockRead, CompactBlockReadCapability,
+    SpentOutputIndex, SpentOutputIndexCapability, StoredBlockRead, StoredBlockReadCapability,
+    TransactionIndex, TransactionIndexCapability, TxOutSetIndex, TxOutSetIndexCapability,
 };
 pub use txout_set::{
     canonical_entry, canonical_entry_parts, entry_digest, entry_digest_parts, is_unspendable,
@@ -77,6 +79,6 @@ pub use txout_set::{
 };
 
 #[cfg(feature = "transparent_address_history_experimental")]
-pub use ports::TransparentHistoryIndex;
+pub use ports::{TransparentHistoryIndex, TransparentHistoryIndexCapability};
 #[cfg(feature = "transparent_address_history_experimental")]
 pub use transparent::{LocatedOutput, LocatedSpend, StoreAddressEffects, TransparentHistoryQuery};

--- a/packages/zaino-chain-store/src/ports.rs
+++ b/packages/zaino-chain-store/src/ports.rs
@@ -123,15 +123,6 @@ pub trait ChainStoreService: Clone + Send + Sync + 'static {
 /// beyond this is an index a deployment may or may not build, and is a
 /// separate trait so that a bound names exactly what its holder uses.
 pub trait ChainStoreReader: Clone + Send + Sync + core::fmt::Debug + 'static {
-    /// The capability this port answers for.
-    ///
-    /// Always `Core`: a store that cannot answer heights, hashes and the
-    /// watermark is not a store.
-    ///
-    /// Stated on the trait so the port and the capability that names it cannot
-    /// drift; see the note on the other read ports.
-    const CAPABILITY: StoreCapability = StoreCapability::Core;
-
     /// The highest block this store can answer for.
     ///
     /// Infallible and synchronous: it is held in memory and updated on commit,
@@ -181,15 +172,6 @@ pub trait ChainStoreReader: Clone + Send + Sync + core::fmt::Debug + 'static {
 /// Optional: a deployment serving only wallet sync builds compact blocks and
 /// never materialises these.
 pub trait StoredBlockRead: ChainStoreReader {
-    /// The capability this port answers for.
-    ///
-    /// Stated on the trait so the port and the capability that names it cannot
-    /// drift: a store assembling its runtime set reads this rather than
-    /// choosing a variant by hand, which is what made it possible to advertise
-    /// one index while implementing another. Defaulted because it is a fact
-    /// about the port, not a choice an implementor makes.
-    const CAPABILITY: StoreCapability = StoreCapability::StoredBlocks;
-
     /// The blocks in `start..=end`, inclusive and ascending.
     ///
     /// One transaction, one batch. This is the primitive: a single block is
@@ -231,15 +213,6 @@ pub trait StoredBlockRead: ChainStoreReader {
 /// wallet pay to decode orchard and ironwood data, and the commitment tree
 /// roots, for every block of its sync.
 pub trait CompactBlockRead: ChainStoreReader {
-    /// The capability this port answers for.
-    ///
-    /// Stated on the trait so the port and the capability that names it cannot
-    /// drift: a store assembling its runtime set reads this rather than
-    /// choosing a variant by hand, which is what made it possible to advertise
-    /// one index while implementing another. Defaulted because it is a fact
-    /// about the port, not a choice an implementor makes.
-    const CAPABILITY: StoreCapability = StoreCapability::CompactBlocks;
-
     /// The compact blocks in `start..=end`, inclusive and ascending.
     ///
     /// One transaction, one batch. A single block is
@@ -269,15 +242,6 @@ pub trait CompactBlockRead: ChainStoreReader {
 
 /// Finding transactions, and finding what is at a position.
 pub trait TransactionIndex: ChainStoreReader {
-    /// The capability this port answers for.
-    ///
-    /// Stated on the trait so the port and the capability that names it cannot
-    /// drift: a store assembling its runtime set reads this rather than
-    /// choosing a variant by hand, which is what made it possible to advertise
-    /// one index while implementing another. Defaulted because it is a fact
-    /// about the port, not a choice an implementor makes.
-    const CAPABILITY: StoreCapability = StoreCapability::Transactions;
-
     /// Where `txid` was mined, if the store holds it.
     ///
     /// One position, not many: the store indexes the best chain only, and a
@@ -301,15 +265,6 @@ pub trait TransactionIndex: ChainStoreReader {
 
 /// Transparent outputs and what became of them.
 pub trait SpentOutputIndex: ChainStoreReader {
-    /// The capability this port answers for.
-    ///
-    /// Stated on the trait so the port and the capability that names it cannot
-    /// drift: a store assembling its runtime set reads this rather than
-    /// choosing a variant by hand, which is what made it possible to advertise
-    /// one index while implementing another. Defaulted because it is a fact
-    /// about the port, not a choice an implementor makes.
-    const CAPABILITY: StoreCapability = StoreCapability::SpentOutputs;
-
     /// Who spent each outpoint, in the order asked.
     ///
     /// Batched because every caller asks about many at once and the store
@@ -362,15 +317,6 @@ pub trait SpentOutputIndex: ChainStoreReader {
 
 /// The store's running totals over the unspent transparent output set.
 pub trait TxOutSetIndex: ChainStoreReader {
-    /// The capability this port answers for.
-    ///
-    /// Stated on the trait so the port and the capability that names it cannot
-    /// drift: a store assembling its runtime set reads this rather than
-    /// choosing a variant by hand, which is what made it possible to advertise
-    /// one index while implementing another. Defaulted because it is a fact
-    /// about the port, not a choice an implementor makes.
-    const CAPABILITY: StoreCapability = StoreCapability::TxOutSet;
-
     /// The accumulator as of the watermark.
     ///
     /// A partial fold, not an answer: it describes the set up to the finalised
@@ -390,15 +336,6 @@ pub trait TxOutSetIndex: ChainStoreReader {
 /// merged — neither alone is an address's history.
 #[cfg(feature = "transparent_address_history_experimental")]
 pub trait TransparentHistoryIndex: ChainStoreReader {
-    /// The capability this port answers for.
-    ///
-    /// Stated on the trait so the port and the capability that names it cannot
-    /// drift: a store assembling its runtime set reads this rather than
-    /// choosing a variant by hand, which is what made it possible to advertise
-    /// one index while implementing another. Defaulted because it is a fact
-    /// about the port, not a choice an implementor makes.
-    const CAPABILITY: StoreCapability = StoreCapability::TransparentHistory;
-
     /// What happened to `query`'s addresses within its height range.
     ///
     /// Range-bounded, always. The store answers for heights up to the
@@ -410,6 +347,87 @@ pub trait TransparentHistoryIndex: ChainStoreReader {
         query: &crate::transparent::TransparentHistoryQuery,
     ) -> impl Future<Output = Result<crate::transparent::StoreAddressEffects, ChainStoreError>> + Send;
 }
+
+/// The capability a read port answers for, as a sealed fact no backend can set.
+///
+/// Each read port has one capability, and that pairing must never disagree with
+/// what a store advertises — a store answering [`SpentOutputIndex`] but naming
+/// [`StoreCapability::CompactBlocks`] would over-promise silently, and a defaulted
+/// associated const on the port let exactly that compile: an implementor could
+/// override it with the wrong variant.
+///
+/// This lifts the pairing off the implementable port onto a carrier trait whose
+/// value no implementor can restate. For a port `$port` answering `$cap`, the
+/// macro declares a carrier `$carrier: $port` whose `CAPABILITY` is fixed by the
+/// *sole* blanket impl over every `T: $port`. No second impl of the carrier can
+/// exist:
+///
+/// - one for some `T: $port` overlaps the blanket impl, which coherence rejects
+///   (E0119, conflicting implementations);
+/// - one for a `T` that does not implement the port fails the `$port` supertrait
+///   bound.
+///
+/// So every type reaches its carrier only through the blanket impl, and the value
+/// is a fixed fact of the port rather than a choice — which is also the seal: the
+/// port supertrait means the only implementors are those the blanket impl already
+/// covers, so downstream cannot hand-write the carrier at all.
+///
+/// The `$port` supertrait is load-bearing twice over: it seals the carrier, and it
+/// lets a consumer bound on the carrier alone and still call the port's methods and
+/// name `<R as $carrier>::CAPABILITY` — a bare `T: $port` bound would not resolve
+/// the carrier's const.
+macro_rules! sealed_capability {
+    ($(#[$meta:meta])* $carrier:ident, $port:path, $cap:expr) => {
+        $(#[$meta])*
+        /// The capability its port answers for, identical for every implementor.
+        pub trait $carrier: $port {
+            /// The one capability every implementor of the port advertises.
+            const CAPABILITY: StoreCapability;
+        }
+
+        $(#[$meta])*
+        impl<T: $port> $carrier for T {
+            const CAPABILITY: StoreCapability = $cap;
+        }
+    };
+}
+
+sealed_capability!(
+    ChainStoreReaderCapability,
+    ChainStoreReader,
+    StoreCapability::Core
+);
+sealed_capability!(
+    StoredBlockReadCapability,
+    StoredBlockRead,
+    StoreCapability::StoredBlocks
+);
+sealed_capability!(
+    CompactBlockReadCapability,
+    CompactBlockRead,
+    StoreCapability::CompactBlocks
+);
+sealed_capability!(
+    TransactionIndexCapability,
+    TransactionIndex,
+    StoreCapability::Transactions
+);
+sealed_capability!(
+    SpentOutputIndexCapability,
+    SpentOutputIndex,
+    StoreCapability::SpentOutputs
+);
+sealed_capability!(
+    TxOutSetIndexCapability,
+    TxOutSetIndex,
+    StoreCapability::TxOutSet
+);
+sealed_capability!(
+    #[cfg(feature = "transparent_address_history_experimental")]
+    TransparentHistoryIndexCapability,
+    TransparentHistoryIndex,
+    StoreCapability::TransparentHistory
+);
 
 /// Driving a chain store forward.
 ///

--- a/packages/zaino-chain-store/usage.md
+++ b/packages/zaino-chain-store/usage.md
@@ -34,11 +34,14 @@ Where absence *cannot* be a compile-time fact it is a runtime one:
 `capabilities()` exists because a store on an older schema genuinely lacks an
 index until it has migrated. That is a fact about a database, not a type.
 
-The two are tied together by an associated const. Each read port names the
-capability it answers for:
+The two are tied together by a per-port capability *carrier* trait. Each read
+port `X` has a sibling `XCapability: X` — `TxOutSetIndexCapability`,
+`SpentOutputIndexCapability`, and so on — carrying the one capability that port
+answers for:
 
 ```rust
-const CAPABILITY: StoreCapability = StoreCapability::TxOutSet;   // on TxOutSetIndex
+// The value lives on the carrier, fixed by its sole blanket impl.
+<Self as TxOutSetIndexCapability>::CAPABILITY   // == StoreCapability::TxOutSet
 ```
 
 An implementation assembles its advertised set from those rather than by
@@ -47,14 +50,22 @@ choosing variants:
 ```rust
 // Only compiles for a capability whose port `Self` actually implements.
 StoreCapabilities::new([
-    <Self as ChainStoreReader>::CAPABILITY,
-    <Self as TxOutSetIndex>::CAPABILITY,
+    <Self as ChainStoreReaderCapability>::CAPABILITY,
+    <Self as TxOutSetIndexCapability>::CAPABILITY,
 ])
 ```
 
-Do not hand-write the variant. Naming `StoreCapability::TxOutSet` directly
-compiles whether or not you implement `TxOutSetIndex`, which is how a store ends
-up advertising an index it cannot serve.
+The value cannot be restated by a backend. The carrier's `CAPABILITY` is set by
+one blanket impl over every `T: X`, and because `X` is a supertrait of the
+carrier the blanket impl is the *only* impl that can exist: a manual
+`impl TxOutSetIndexCapability for MyStore` overlaps it (coherence rejects it,
+E0119), and one for a type that does not implement the port fails the supertrait
+bound. So the port↔capability pairing is a sealed fact, not a defaulted const an
+implementor can override with the wrong variant.
+
+Do not hand-write the variant either. Naming `StoreCapability::TxOutSet`
+directly compiles whether or not you implement `TxOutSetIndex`, which is how a
+store ends up advertising an index it cannot serve.
 
 ## The watermark is the boundary, and a read past it is not a miss
 

--- a/packages/zaino-state/src/error.rs
+++ b/packages/zaino-state/src/error.rs
@@ -456,6 +456,9 @@ impl From<FinalisedStateError> for ChainIndexError {
             FinalisedStateError::FeatureUnavailable(err) => {
                 format!("unhandled missing feature: {err}")
             }
+            FinalisedStateError::V1BackendUnavailable(handle) => {
+                format!("v1 backend unavailable: {handle}")
+            }
             FinalisedStateError::InvalidBlock {
                 height,
                 hash: _,

--- a/packages/zaino-state/src/lib.rs
+++ b/packages/zaino-state/src/lib.rs
@@ -48,11 +48,6 @@ pub mod metric_names {
     pub const SYNC_HAS_REACHED_TIP: &str = "zaino.sync.has_reached_tip";
     pub const SYNC_REACHED_TIP_AT: &str = "zaino.sync.reached_tip_at";
 
-    // Emitted by no crate yet, and described by `zainod`. They name the
-    // mempool's intended surface and are kept here, with the subsystem that
-    // would emit them, rather than in the storage backend that never will.
-    pub const MEMPOOL_TRANSACTIONS: &str = "zaino.mempool.transactions";
-    pub const MEMPOOL_TIP_CHANGES_TOTAL: &str = "zaino.mempool.tip_changes_total";
     pub const MEMPOOL_COHERENCE_FROZEN_SECONDS: &str = "zaino.mempool.coherence_frozen_seconds";
 }
 

--- a/packages/zainod/src/metrics.rs
+++ b/packages/zainod/src/metrics.rs
@@ -120,15 +120,14 @@ fn describe_metrics() {
 
     // DB reads. The write path has been described since before the finalised
     // state moved into its own crate; these are its reads, which a wallet
-    // syncing against this node spends almost all of its time in.
+    // syncing against this node spends almost all of its time in. One histogram
+    // covers the whole read surface, split by an `op` label naming the read
+    // (`compact_chunk`, `block_hash`, `txout_set`, ...); the wallet-sync hot
+    // path is `op="compact_chunk"`, which a client's sync rate is bounded by.
     metrics::describe_histogram!(
-        DB_COMPACT_READ_SECONDS,
-        "Time to read one chunk of compact blocks from the finalized database. The wallet-sync \
-         read path: a client's sync rate is bounded by this"
-    );
-    metrics::describe_histogram!(
-        DB_BLOCK_READ_SECONDS,
-        "Time to read one chunk of stored blocks from the finalized database"
+        DB_READ_SECONDS,
+        "Time to serve one finalized-database read, labelled by `op` (the read operation). The \
+         wallet-sync read path is `op=\"compact_chunk\"`: a client's sync rate is bounded by it"
     );
     metrics::describe_counter!(
         DB_CORRUPT_ROWS_TOTAL,

--- a/packages/zainod/src/metrics.rs
+++ b/packages/zainod/src/metrics.rs
@@ -195,14 +195,6 @@ fn describe_metrics() {
 
     // Mempool
     metrics::describe_gauge!(
-        MEMPOOL_TRANSACTIONS,
-        "Current number of transactions in the mempool"
-    );
-    metrics::describe_counter!(
-        MEMPOOL_TIP_CHANGES_TOTAL,
-        "Total mempool resets due to chain tip changes"
-    );
-    metrics::describe_gauge!(
         MEMPOOL_COHERENCE_FROZEN_SECONDS,
         "How long tip-coherent mempool reads have been frozen; 0 when live. \
          Brief spikes are normal tip transitions — a sustained non-zero value \


### PR DESCRIPTION
My takes on the review caveats from #1483, stacked on its head (`b17bc5d7`) so they can land into that branch before it merges. One commit per caveat; each is `cargo check` / `clippy` / `fmt` clean, including the `prometheus` and `transparent_address_history_experimental` features. In each case the fix already on #1483 closed the defect but left a residual — these go to the root.

### Caveat 1 — capability vs backend-state errors · `e1c136cc`
**Applied on #1483:** the consumer matcher now borrows the router's `CapabilityRequest::name()` constant, so its uppercase names finally match.
**Problem left:** the error is still a `&'static str`, and a *second* producer (`finalised_source`) keeps its own lowercase vocabulary — two string vocabularies still coexist. And `FeatureUnavailable` conflates two different conditions: a capability refusal ("this store doesn't build index X") and a mid-migration "the v1 backend isn't available yet" state, both as free-form strings.
**My take:** drop the string. `FeatureUnavailable(CapabilityRequest)` is typed, so the consumer match is **total — no `_` arm**. That total match is the real guarantee: a catch-all `_` fails open, silently absorbing any capability added later or any producer that mismaps — exactly the shape of the original collapse-to-`Core` bug. The `_` only existed because a stringified value has to catch every possible string; once the value is a typed enum the compiler forces every future variant to be handled. The mid-migration backend-state condition also splits into its own `V1BackendUnavailable` variant, mapped to `NotReady` — a transient signal the runtime can route on.

### Caveat 2 — sealed capabilities · `dbde539a`
**Applied on #1483:** each port gained `const CAPABILITY`, and `store_capabilities` reads it off the port, so a store can't advertise a capability for a port it doesn't implement.
**Problem left:** the const is *defaulted*, so any implementor can override it with a wrong value and still compile; only a per-backend test catches it. A second backend is the whole point of the port.
**My take:** seal it. A per-port carrier trait with a single blanket impl fixes the value for every implementor — an override now fails to compile (E0119). The overridable const is removed; one source of truth.

### Caveat 3 — unemitted mempool metrics · `3a01d53c`
**Applied on #1483:** metric names were consolidated to one source (re-export) so the live and pinned strings can't drift.
**Problem left:** `MEMPOOL_TRANSACTIONS` and `MEMPOOL_TIP_CHANGES_TOTAL` are described in `zainod` but emitted by no crate — a dashboard on them shows "no data" forever, and an operator can't tell "no activity" from "never wired".
**My take:** remove both. A described metric should have an emitter; re-add them with their emit call when the mempool surface lands.

### Caveat 4 — read-path instrumentation · `64beeb68`
**Applied on #1483:** spans + latency histograms on the two chunked reads (the wallet-sync hot path), plus universal corrupt-row reporting.
**Problem left:** the latency metrics assume one serving profile. The explorer/full-RPC profile leans on the point lookups, spend reads and `txout_set`, which had no latency visibility.
**My take:** instrument the whole read surface via one labelled `DB_READ_SECONDS{op=…}` histogram + per-method spans, folding the two just-added chunk metrics into it (safe — unshipped). Matches the existing `SYNC_ERRORS_TOTAL{severity}` label pattern.

### Not here
The `StoreError::Custom` / `StatusError` cleanup and the `write_core` `txn.commit()` propagation are deferred — verbatim-moved pre-existing code, tracked in #1500 and #1501. The capability↔lifecycle-error split (caveat 1) and the per-index vs global-schema-version direction belong in a wider chain-store/runtime reconciliation ADR, not this PR.
