### PR TITLE
ci: run live suite (ztest) via tailnet-federated runner

### DIFF
--- a/.github/workflows/ztest-live.yml
+++ b/.github/workflows/ztest-live.yml
@@ -1,0 +1,124 @@
+name: Live suite (ztest)
+
+# Runs the wallet-driven chain-sync live suite (live-tests/sync) against the
+# real cluster, with ztest as the orchestrator: given cluster API access it
+# compiles + builds the runner image on-cluster, deploys the system under test
+# as sibling pods, drives the sync profile, and tears everything down.
+#
+# The runner reaches the cluster over Tailscale, joining the tailnet as an
+# ephemeral tag:ztest-runner node via GitHub OIDC workload-identity federation
+# (NO stored secret — GitHub mints a short-lived token per run, mirroring how
+# zingolabs/machines' deploy-node.yaml joins as tag:ci). It then talks to the
+# Kubernetes API through the Tailscale operator's API-server proxy, which
+# impersonates the k8s group `ztest-ci` (bound to the `ztest-remote`
+# ClusterRole). RBAC is self-checked by `ztest cluster check` before any work.
+#
+# Prerequisites that live OUTSIDE this PR (see the PR description):
+#   - zingolabs/machines: the tag:ztest-runner ACL + a Tailscale OAuth client
+#     federated to repo:zingolabs/zaino with the auth_keys scope.
+#   - Repo variables: TS_OIDC_CLIENT_ID, TS_OIDC_AUDIENCE (non-secret),
+#     ZTEST_CLUSTER_CONFIG_URL (https:// TOML of non-secret cluster facts:
+#     registry + storage classes).
+#   - On the cluster: `ztest cluster setup` has created the ztest-remote
+#     ClusterRole, and the ztest-ci ClusterRoleBinding (devops PR #9) binds it
+#     to the impersonated group.
+#   - The suite itself: zaino PR #1458 (feat/add_sync_tests) introduces
+#     live-tests/sync and the `zaino_index_construction` profile. This workflow
+#     is inert until #1458 lands on dev.
+
+on:
+  pull_request:
+    # `labeled` fires the run when a maintainer applies the trigger label;
+    # `synchronize` re-runs it on every push to an already-labeled PR;
+    # `reopened` covers a PR reopened while still labeled.
+    types: [labeled, synchronize, reopened]
+
+concurrency:
+  group: ztest-live-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # checkout
+  id-token: write # mint the GitHub OIDC token for the tailnet join
+  checks: write # the job status is reported as a native check run
+  pull-requests: write # post the result summary as a PR comment
+
+jobs:
+  live-sync:
+    name: Live sync suite (ztest)
+    # Gate on the dedicated label. `labeled` carries the just-added label in the
+    # event payload; on `synchronize`/`reopened` this re-reads the current set,
+    # so removing the label stops future pushes from running the suite.
+    if: contains(github.event.pull_request.labels.*.name, 'ztest-live')
+    runs-on: ubuntu-latest
+    # A full-history mainnet index build is long-running; cap it so a stuck run
+    # cannot hold the cluster's sync tier indefinitely.
+    timeout-minutes: 120
+    # Protected environment = the fork-PR trust boundary. A fork PR cannot
+    # self-authorize a cluster run: GitHub requires a maintainer to approve the
+    # deployment before this job starts, and the label alone grants nothing.
+    # Configure `ztest-cluster` with required reviewers in repo settings.
+    environment: ztest-cluster
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Join tailnet (tag:ztest-runner, OIDC — no stored secret)
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ vars.TS_OIDC_CLIENT_ID }}
+          audience: ${{ vars.TS_OIDC_AUDIENCE }}
+          tags: tag:ztest-runner
+
+      - name: Point kubeconfig at the Tailscale API-server proxy
+        run: tailscale configure kubeconfig tailscale-operator
+
+      - name: Install ztest CLI
+        # The `ztest` binary ships from the `ztest_cli` crate on crates.io.
+        # Pinned for reproducibility; keep in lockstep with the harness pinned by
+        # live-tests/sync/Cargo.toml (`ztest = "0.1"`, currently resolving 0.1.x).
+        run: cargo install ztest_cli --version 0.1.10 --locked
+
+      - name: Register the remote cluster profile
+        # Remote class → on-cluster BuildKit compile + build. Identity is the
+        # kube-context the Tailscale proxy just wrote (`tailscale-operator`); the
+        # cluster facts (registry, storage classes) come from a non-secret TOML
+        # in the devops repo. `--yes` accepts the fetched config non-interactively.
+        run: >
+          ztest cluster add zingo-infra
+          --kube-context tailscale-operator
+          --extra-config "${{ vars.ZTEST_CLUSTER_CONFIG_URL }}"
+          --set-default
+          --yes
+
+      - name: Check cluster access (RBAC self-check)
+        # SelfSubjectAccessReview over the whole ztest-remote role — fails fast
+        # and by name if the ztest-ci ClusterRoleBinding is missing or the proxy
+        # is impersonating the wrong group.
+        run: ztest cluster check
+
+      - name: Run live sync suite
+        working-directory: live-tests/sync
+        # Launches the detached `zaino_index_construction` profile and tails it to
+        # its terminal verdict. Profiling is left off for a gating run (eBPF is a
+        # manual investigation tool via `ztest sync perf`).
+        #
+        # Depends on zaino PR #1458 (feat/add_sync_tests) for the suite to exist.
+        #
+        # TODO(ztest-cli-provisional): the `sync` CLI is documented as provisional
+        # (ztest docs/design-sync.md). This gates on the exit status of
+        # `sync start --watch`. If that proves to be a pure read-only tail that
+        # does not propagate the profile verdict as its exit code, capture the
+        # sync id from the start output and gate on `ztest sync status <id> --json`.
+        run: ztest sync start zaino_index_construction --watch --profile false
+
+      - name: Report result to the PR
+        if: always() && github.event.pull_request.number
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESULT: ${{ job.status }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh pr comment "${PR_NUMBER}" \
+            --body "Live sync suite (ztest): **${RESULT}** — [run log](${RUN_URL})"


### PR DESCRIPTION
## What this adds

A GitHub Actions workflow (`.github/workflows/ztest-live.yml`) that runs zaino's
wallet-driven chain-sync live suite (`live-tests/sync`) against the real cluster,
with `ztest` as the orchestrator. On an opted-in pull request, the workflow joins
the tailnet, hands cluster API access to `ztest`, and `ztest` compiles + builds
the runner image on-cluster, deploys the system under test, drives the
`zaino_index_construction` sync profile, and tears everything down. The job
status is the native check; the result is also posted as a PR comment.

## Design

- **Federated OIDC, no stored secret.** The runner joins the tailnet with
  `tailscale/github-action@v4` using workload-identity federation:
  `oauth-client-id: ${{ vars.TS_OIDC_CLIENT_ID }}`,
  `audience: ${{ vars.TS_OIDC_AUDIENCE }}`, `tags: tag:ztest-runner`. GitHub mints
  a short-lived OIDC token per run (`permissions: id-token: write`); no Tailscale
  auth key is stored in the repo. This mirrors how `zingolabs/machines`
  `deploy-node.yaml` joins as `tag:ci`.
- **Reaching the cluster.** `tailscale configure kubeconfig tailscale-operator`
  points kubeconfig at the Tailscale operator's Kubernetes API-server proxy. The
  proxy impersonates the k8s group `ztest-ci`, which is bound to the
  `ztest-remote` ClusterRole. `ztest cluster check` runs a `SelfSubjectAccessReview`
  over that role and fails fast, by name, if the binding is missing.
- **Trust boundary for fork PRs.** The cluster-touching job is gated behind the
  protected `environment: ztest-cluster`. A fork PR cannot self-authorize a
  cluster run — GitHub requires a maintainer to approve the deployment before the
  job starts. The trigger label alone grants nothing.

## Triggering

The workflow runs on `pull_request` `labeled` / `synchronize` / `reopened` and is
gated on the `ztest-live` label being present. Applying the label starts a run;
pushing to a labeled PR re-runs it; removing the label stops future pushes from
running the suite.

## How `ztest` is obtained and invoked

- Install: `cargo install ztest_cli --version 0.1.10 --locked` — the `ztest`
  binary ships from the `ztest_cli` crate on crates.io. The version is pinned for
  reproducibility and tracks the harness pinned by `live-tests/sync/Cargo.toml`
  (`ztest = "0.1"`).
- Register cluster: `ztest cluster add zingo-infra --kube-context tailscale-operator
  --extra-config <ZTEST_CLUSTER_CONFIG_URL> --set-default --yes`. The remote class
  drives on-cluster BuildKit compile + build; the cluster facts (registry, storage
  classes) arrive as a non-secret TOML.
- Self-check: `ztest cluster check`.
- Run: `ztest sync start zaino_index_construction --watch --profile false`
  (profiling left off for a gating run).

## Prerequisites NOT in this PR

- **`zingolabs/machines`**: the `tag:ztest-runner` ACL, and a second Tailscale
  OAuth client federated to `repo:zingolabs/zaino` with the `auth_keys` scope.
- **Repo variables** (non-secret): `TS_OIDC_CLIENT_ID`, `TS_OIDC_AUDIENCE`, and
  `ZTEST_CLUSTER_CONFIG_URL` (the `https://` TOML of cluster facts).
- **On the cluster**: `ztest cluster setup` has created the `ztest-remote`
  ClusterRole, and the `ztest-ci` ClusterRoleBinding (devops PR #9) binds it to
  the impersonated group.
- **The suite**: depends on zaino PR #1458 (`feat/add_sync_tests`), which
  introduces `live-tests/sync` and the `zaino_index_construction` profile. This
  workflow is inert until #1458 lands on `dev`.

## Why draft

Draft until the prerequisites above are in place — the tailnet ACL and the second
federated OAuth client, the repo variables, the cluster-side RBAC, and #1458.
`ztest`'s `sync` CLI is also documented as provisional; a `TODO` in the workflow
marks the assumed `sync start --watch` verdict/exit-code contract and the fallback
(`ztest sync status <id> --json`) if it turns out to be a pure read-only tail.
