### PR TITLE
zaino-primitives: AddressBalance.received is a flow sum; balance folding is a closed checked operation

### DIFF
--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -25,9 +25,11 @@ The correction is a doctrine about primitive quantity types, illustrated here on
 `Zatoshis` and meant to generalise:
 
 1. **A quantity is not always closed under its own operation.** Two supply-sized
-   amounts can sum past the supply, so no honest operation returns the same
-   type; the result of summing `Zatoshis` is a *different* type. We do not give
-   `Zatoshis` an addition that pretends otherwise.
+   amounts can sum past the supply, so summing amounts as flow cannot honestly
+   return the same type; that result is a *different* type. We do not give
+   `Zatoshis` an unconditional addition that pretends otherwise. Whether a sum
+   is closed is decided by the meaning of the total, not by the `+` sign — the
+   type family below has one sum that is.
 
 2. **The invariant belongs to the result type, chosen by provenance — not to the
    operator or the element.** The same `Zatoshis` values summed as flow yield an
@@ -84,10 +86,15 @@ The correction is a doctrine about primitive quantity types, illustrated here on
   of two totals. `-supply ..= supply`.
 
 `ZatoshisFlowSum` earns a distinct type by carrying a new invariant.
-`SignedZatoshis` earns one by being a different quantity. A fourth member — a
-supply-bounded sum of coexisting balances — is a real part of the algebra but
-has no consumer today; it is named here and left unbuilt until one exists,
-rather than added speculatively.
+`SignedZatoshis` earns one by being a different quantity. A sum of coexisting
+balances earns neither: balances that coexist at one moment cannot total more
+than the coins that exist, so the total is itself in `[0, supply]` and
+`Zatoshis` is closed under that sum. A distinct type is warranted only when a
+result escapes the element's invariant; this one does not. What the algebra
+gains is its second accumulate as an *operation* — `Zatoshis::sum_balances`, a
+supply-capped checked fold landing back in `Zatoshis`. Under its coexistence
+contract a total past the supply is not a large number but evidence that the
+operands overlap or double-count, so the fold refuses it.
 
 ## Considered options
 

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -11,9 +11,10 @@ than one place, and the sums do not share the same invariants.
 
   - **The Balance Sum Maximum.** A sum of balances that exist at one moment
     cannot exceed the supply.
-  - **The Movement Sum Maximum.** A sum of movements — outputs paid to an
-    address, inputs it spent — counts the same coins each time they move and is
-    not bounded by the supply at all.
+  - **The Movement Sum Maximum.** A sum of value movements over time is a
+    flow, not a holding: one coin moving many times is counted at each move, so
+    the total can exceed the supply and is bounded only by the `u128` that
+    accumulates it.
 
 The type of each value being summed—Zatoshis—and the addition operation are
 identical in both cases; only the meaning of the total differs.

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -107,7 +107,7 @@ The correction is a doctrine about primitive quantity types, illustrated here on
 
 `zaino-primitives::types::zatoshis`:
 
-- `Zatoshis` — an amount held. `0 ..= supply`.
+- `Zatoshis` — an amount of ZEC counted in zatoshis. `0 ..= supply`.
 - `ZatoshisFlowSum` — an accumulation of movements. Bounded only by machine
   representability; deliberately not by the supply.
 - `SignedZatoshis` — a signed value: a directional movement, or the difference

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -35,12 +35,13 @@ constructor validated nothing. Two faults followed:
 The correction is a doctrine about primitive quantity types, illustrated here on
 `Zatoshis` and meant to generalise:
 
-1. **A quantity is not always closed under its own operation.** Two supply-sized
-   amounts can sum past the supply, so summing amounts as flow cannot honestly
-   return the same type; that result is a *different* type. We do not give
-   `Zatoshis` an unconditional addition that pretends otherwise. Whether a sum
-   is closed is decided by the meaning of the total, not by the `+` sign — the
-   type family below has one sum that is.
+1. **The set of `Zatoshis` is not closed under addition.** Two supply-sized
+   amounts sum past the supply, so the sum of two `Zatoshis` is not always a
+   `Zatoshis`. The result of summing `Zatoshis` as movements is therefore a
+   different type. We do not define an unconditional addition on `Zatoshis`
+   that pretends otherwise; the one fold that lands back in `Zatoshis`,
+   `sum_balances` in the type family below, does so under a precondition and
+   refuses inputs that break it.
 
 2. **The invariant belongs to the result type, chosen by provenance — not to the
    operator or the element.** The same `Zatoshis` values summed as flow yield an

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -19,13 +19,13 @@ than one place, and the sums do not share the same invariants.
 The type of each value being summed—Zatoshis—and the addition operation are
 identical in both cases; only the meaning of the total differs.
 
-The earlier code expressed this with a single amount type, a supply cap applied
-to every sum, and a bare signed type whose constructor validated nothing. Two
-faults followed from putting the bound in the wrong place. A legitimate movement
-total past the supply was rejected as if corrupt, because the cap sat on the
-operator rather than on the result. And a signed value off the wire could be any
-integer, because the type's "a balance change" claim was made in prose while its
-only constructor enforced nothing.
+The earlier code attempted to express these conflicting invariants with a single
+amount type, a supply cap applied to every sum, and a bare signed type whose
+constructor validated nothing. Two faults followed from putting the bound in the
+wrong place. A legitimate movement total past the supply was rejected as if
+corrupt, because the cap sat on the operator rather than on the result. And a
+signed value off the wire could be any integer, because the type's "a balance
+change" claim was made in prose while its only constructor enforced nothing.
 
 The correction is a doctrine about primitive quantity types, illustrated here on
 `Zatoshis` and meant to generalise:

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -9,9 +9,11 @@ proposed
 `Zatoshis` is a validated amount: at most the money supply. It is summed in more
 than one place, and the sums do not share the same invariants.
 
-  - A sum of balances that exist at one moment cannot exceed the supply.
-  - A sum of movements — outputs paid to an address, inputs it spent — counts
-    the same coins each time they move and is not bounded by the supply at all.
+  - **The Balance Sum Maximum.** A sum of balances that exist at one moment
+    cannot exceed the supply.
+  - **The Movement Sum Maximum.** A sum of movements — outputs paid to an
+    address, inputs it spent — counts the same coins each time they move and is
+    not bounded by the supply at all.
 
 The type of each value being summed—Zatoshis—and the addition operation are
 identical in both cases; only the meaning of the total differs.

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -4,7 +4,7 @@
 
 proposed
 
-## Context and decision
+## Context
 
 `Zatoshis` is a validated amount: at most the money supply. It is summed in more
 than one place, and the sums do not share the same invariants.
@@ -23,12 +23,14 @@ The earlier code attempted to express these conflicting invariants with a single
 amount type, a supply cap applied to every sum, and a bare signed type whose
 constructor validated nothing. Two faults followed:
 
-  (1) A legitimate movement total past the supply was rejected as if corrupt,
-      because the cap sat on the operator rather than on the result.
+  1. A legitimate movement total past the supply was rejected as if corrupt,
+     because the cap sat on the operator rather than on the result.
 
-  (2) A signed value could be any integer, because the type's "a balance
-      change" claim was made in prose while its only constructor enforced
-      nothing.
+  2. A signed value could be any integer, because the type's "a balance
+     change" claim was made in prose while its only constructor enforced
+     nothing.
+
+## Doctrine
 
 The correction is a doctrine about primitive quantity types, illustrated here on
 `Zatoshis` and meant to generalise:

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -21,11 +21,14 @@ identical in both cases; only the meaning of the total differs.
 
 The earlier code attempted to express these conflicting invariants with a single
 amount type, a supply cap applied to every sum, and a bare signed type whose
-constructor validated nothing. Two faults followed from putting the bound in the
-wrong place. A legitimate movement total past the supply was rejected as if
-corrupt, because the cap sat on the operator rather than on the result. And a
-signed value off the wire could be any integer, because the type's "a balance
-change" claim was made in prose while its only constructor enforced nothing.
+constructor validated nothing. Two faults followed:
+
+  (1) A legitimate movement total past the supply was rejected as if corrupt,
+      because the cap sat on the operator rather than on the result.
+
+  (2) A signed value could be any integer, because the type's "a balance
+      change" claim was made in prose while its only constructor enforced
+      nothing.
 
 The correction is a doctrine about primitive quantity types, illustrated here on
 `Zatoshis` and meant to generalise:

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -32,6 +32,22 @@ constructor validated nothing. Two faults followed:
 
 ## Doctrine
 
+### Terminology
+
+  - **Zatoshi.** The unit of one hundred-millionth of a ZEC, in which every
+    amount below is counted.
+  - **`Zatoshis`.** The set of integers from zero to the money supply
+    inclusive, each an amount of ZEC counted in zatoshis; the Rust type of the
+    same name represents this set.
+  - **Element.** One member of `Zatoshis`, such as the value of a single
+    transaction output or input, or a balance.
+  - **Balance.** An element read as the amount held by one owner at one
+    moment.
+  - **Movement.** An element read as the amount one transaction transfers into
+    or out of an ownership.
+  - **Sum.** The result of adding elements, whose type is chosen by which
+    reading, balance or movement, the elements carry.
+
 The correction is a doctrine about primitive quantity types, illustrated here on
 `Zatoshis` and meant to generalise:
 

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -61,11 +61,12 @@ The correction is a doctrine about primitive quantity types, illustrated here on
 
 2. **The invariant belongs to the result type, chosen by the reading of the
    elements — not to the operator or the element.** The same `Zatoshis` values
-   summed as movements yield an unbounded accumulator; summed as coexisting
-   balances they yield a supply-bounded total. The caller, who knows which
-   reading the values carry, picks the landing type, and that choice is where
-   the bound is declared and enforced — once, in the type, not re-derived at
-   each call site.
+   summed as movements land in `ZatoshisFlowSum`, bounded only by the machine;
+   summed as coexisting balances they land back in `Zatoshis` through
+   `sum_balances`, bounded by the supply. The caller, who knows which reading
+   the values carry, picks the landing type, and that choice is where the bound
+   is declared and enforced — once, in the type, not re-derived at each call
+   site.
 
 3. **A signed zatoshi value is its own type, bounded by ±supply.** A single
    movement is one amount; a change in a balance is a difference of two. A
@@ -117,13 +118,15 @@ The correction is a doctrine about primitive quantity types, illustrated here on
 `ZatoshisFlowSum` earns a distinct type by carrying a new invariant.
 `SignedZatoshis` earns one by being a different quantity. A sum of coexisting
 balances earns neither: balances that coexist at one moment cannot total more
-than the coins that exist, so the total is itself in `[0, supply]` and
-`Zatoshis` is closed under that sum. A distinct type is warranted only when a
-result escapes the element's invariant; this one does not. What the algebra
-gains is its second accumulate as an *operation* — `Zatoshis::sum_balances`, a
-supply-capped checked fold landing back in `Zatoshis`. Under its coexistence
-contract a total past the supply is not a large number but evidence that the
-operands overlap or double-count, so the fold refuses it.
+than the coins that exist, so under that precondition the total is itself in
+`[0, supply]`. The set of `Zatoshis` is still not closed under addition; what
+holds is narrower, that the precondition keeps this particular result inside
+the set. A distinct type is warranted only when a result escapes the element's
+invariant, and this one does not, so the algebra gains its second accumulate
+as an *operation* — `Zatoshis::sum_balances`, a supply-capped checked fold that
+lands back in `Zatoshis`. A total past the supply is not a large number but
+evidence that the operands overlap or double-count, so the fold refuses it
+rather than pretend the precondition held.
 
 ## Considered options
 

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -7,12 +7,14 @@ proposed
 ## Context and decision
 
 `Zatoshis` is a validated amount: at most the money supply. It is summed in more
-than one place, and the sums do not share the same invariants. A sum of balances
-that exist at one moment cannot exceed the supply; a sum of movements — outputs
-paid to an address, inputs it spent — counts the same coins each time they move
-and is not bounded by the supply at all. The type of each value being
-summed—Zatoshis—and the addition operation are identical in both cases; only the
-meaning of the total differs.
+than one place, and the sums do not share the same invariants.
+
+  - A sum of balances that exist at one moment cannot exceed the supply.
+  - A sum of movements — outputs paid to an address, inputs it spent — counts
+    the same coins each time they move and is not bounded by the supply at all.
+
+The type of each value being summed—Zatoshis—and the addition operation are
+identical in both cases; only the meaning of the total differs.
 
 The earlier code expressed this with a single amount type, a supply cap applied
 to every sum, and a bare signed type whose constructor validated nothing. Two

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -6,12 +6,13 @@ proposed
 
 ## Context and decision
 
-`Zatoshis` is a validated amount: at most the money supply. It is summed in
-more than one place, and the sums do not share an invariant. A sum of balances
+`Zatoshis` is a validated amount: at most the money supply. It is summed in more
+than one place, and the sums do not share the same invariants. A sum of balances
 that exist at one moment cannot exceed the supply; a sum of movements — outputs
 paid to an address, inputs it spent — counts the same coins each time they move
-and is not bounded by the supply at all. The element type and the `+` sign are
-identical in both cases; only the *meaning of the total* differs.
+and is not bounded by the supply at all. The type of each value being
+summed—Zatoshis—and the addition operation are identical in both cases; only the
+meaning of the total differs.
 
 The earlier code expressed this with a single amount type, a supply cap applied
 to every sum, and a bare signed type whose constructor validated nothing. Two

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -59,12 +59,13 @@ The correction is a doctrine about primitive quantity types, illustrated here on
    `sum_balances` in the type family below, does so under a precondition and
    refuses inputs that break it.
 
-2. **The invariant belongs to the result type, chosen by provenance — not to the
-   operator or the element.** The same `Zatoshis` values summed as flow yield an
-   unbounded accumulator; summed as coexisting balances they yield a
-   supply-bounded total. The caller, who knows which the values are, picks the
-   landing type, and that choice is where the bound is declared and enforced —
-   once, in the type, not re-derived at each call site.
+2. **The invariant belongs to the result type, chosen by the reading of the
+   elements — not to the operator or the element.** The same `Zatoshis` values
+   summed as movements yield an unbounded accumulator; summed as coexisting
+   balances they yield a supply-bounded total. The caller, who knows which
+   reading the values carry, picks the landing type, and that choice is where
+   the bound is declared and enforced — once, in the type, not re-derived at
+   each call site.
 
 3. **A signed zatoshi value is its own type, bounded by ±supply.** A single
    movement is one amount; a change in a balance is a difference of two. A

--- a/packages/zaino-primitives/src/types/address_balance.rs
+++ b/packages/zaino-primitives/src/types/address_balance.rs
@@ -1,12 +1,37 @@
 //! Transparent address balance.
 
-use super::Zatoshis;
+use super::{Zatoshis, ZatoshisFlowSum};
 
 /// Balance information for a set of transparent addresses.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AddressBalance {
-    /// Total current balance in zatoshis.
+    /// Total value currently held, in zatoshis.
+    ///
+    /// A sum of balances that coexist at one moment, so it is supply-bounded
+    /// and lands in [`Zatoshis`].
     pub balance: Zatoshis,
-    /// Total received in zatoshis (lifetime).
-    pub received: Zatoshis,
+    /// Lifetime gross receipts, in zatoshis.
+    ///
+    /// A flow total: every output ever paid to the addresses counts, so coins
+    /// that cycle through are counted each time they arrive and the total is
+    /// **not** supply-bounded. It lands in [`ZatoshisFlowSum`], not
+    /// [`Zatoshis`].
+    pub received: ZatoshisFlowSum,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `received` is a flow, not a balance: a lifetime total past the money
+    /// supply is legitimate data, and the type admits it.
+    #[test]
+    fn received_past_the_supply_is_representable() {
+        let balance = AddressBalance {
+            balance: Zatoshis::ZERO,
+            received: ZatoshisFlowSum::from_summed(u64::MAX),
+        };
+
+        assert_eq!(u128::from(balance.received), u128::from(u64::MAX));
+    }
 }

--- a/packages/zaino-primitives/src/types/zatoshis.rs
+++ b/packages/zaino-primitives/src/types/zatoshis.rs
@@ -9,7 +9,7 @@
 //! `+`. So each quantity is its own type, and each summation lands in the type
 //! whose invariant it satisfies:
 //!
-//! - [`Zatoshis`] — an amount held, in `0 ..= supply`.
+//! - [`Zatoshis`] — an amount of ZEC counted in zatoshis, in `0 ..= supply`.
 //! - [`ZatoshisFlowSum`] — an accumulation of movements, bounded only by machine
 //!   representability and deliberately not by the supply.
 //! - [`SignedZatoshis`] — a signed value (a movement or a difference), in

--- a/packages/zaino-primitives/src/types/zatoshis/arithmetic.rs
+++ b/packages/zaino-primitives/src/types/zatoshis/arithmetic.rs
@@ -16,37 +16,54 @@
 //! D ∈ [−S, S]         a signed value (a movement or a difference)
 //! ```
 //!
-//! Two relations are defined, and only these two:
+//! Three relations are defined, and only these three:
 //!
 //! ```text
-//! accumulate : [A] → F            Σ aᵢ, counting each movement
-//! net        : F × F → D          received − spent, landing in [−S, S] or refused
+//! accumulate          : [A] → F   Σ aᵢ, counting each movement
+//! accumulate_balances : [A] → A?  Σ aᵢ, of balances that coexist
+//!                                 (supply-capped; closed — lands back in A)
+//! net                 : F × F → D received − spent, landing in [−S, S] or refused
 //! ```
 //!
 //! `accumulate` carries amounts into the unbounded flow sum: a total of
 //! movements is not a balance, so the supply cap does not apply to it, and it
-//! fails only if the machine integer overflows. `net` subtracts a spent flow
-//! from a received one and admits the result only as a signed value: a balance
-//! change lives in `[−S, S]`, so a result outside it is refused. That bound is a
-//! property of a balance change, which the two sums are only when they are the
-//! received and spent flow of one balance — `net`'s contract. A difference of
-//! unrelated flow sums is not a balance change and is deliberately not offered.
-//!
-//! # A member left unbuilt
-//!
-//! A fourth quantity belongs to this algebra: a **supply-bounded sum of
-//! coexisting balances**, `ZatoshisBalanceSum ∈ [0, S]`, with its own relation
-//!
-//! ```text
-//! accumulate_balances : [A] → B   Σ aᵢ, of balances that exist at one moment
-//! ```
-//!
-//! It differs from a flow sum precisely in its bound: balances that coexist
-//! cannot sum past the supply, whereas movements can. It is a real member of
-//! the algebra, but no consumer needs it today, so it is named here and left
-//! unbuilt rather than added speculatively. See ADR-0013.
+//! fails only if the machine integer overflows. `accumulate_balances` is the
+//! second accumulate — the same fold shape with a different landing: balances
+//! that coexist at one moment cannot total more than the coins that exist, so
+//! the sum is itself in `[0, S]` and `A` is closed under it; the fold lands
+//! back in [`Zatoshis`] rather than a new type, refusing a total past the
+//! supply. `net` subtracts a spent flow from a received one and admits the
+//! result only as a signed value: a balance change lives in `[−S, S]`, so a
+//! result outside it is refused. That bound is a property of a balance change,
+//! which the two sums are only when they are the received and spent flow of
+//! one balance — `net`'s contract. A difference of unrelated flow sums is not
+//! a balance change and is deliberately not offered. See ADR-0013.
 
 use super::{SignedZatoshis, Zatoshis, ZatoshisFlowSum};
+
+impl Zatoshis {
+    /// Sum a set of coexisting balances.
+    ///
+    /// The `accumulate_balances` relation: `[A] → A?`. Folds the balances with
+    /// the supply-capped [`checked_add`](Self::checked_add), returning `None`
+    /// if the running total passes the supply; an empty sequence sums to
+    /// [`ZERO`](Self::ZERO).
+    ///
+    /// Contract: the operands are balances that coexist at one moment. Coins
+    /// that coexist cannot total more than the coins that exist, so under that
+    /// contract a total past the supply is not a large number — it is evidence
+    /// the inputs overlap or double-count (corruption), hence `None`, failing
+    /// loud rather than wrapping.
+    ///
+    /// This is the second accumulate of the algebra: the same fold shape as
+    /// [`ZatoshisFlowSum::try_accumulate`], with a different landing and
+    /// bound. Because a sum of coexisting balances stays within `[0, supply]`,
+    /// [`Zatoshis`] is closed under it — so this is deliberately an operation
+    /// returning [`Zatoshis`], not a new quantity type.
+    pub fn sum_balances(mut values: impl Iterator<Item = Zatoshis>) -> Option<Zatoshis> {
+        values.try_fold(Zatoshis::ZERO, Zatoshis::checked_add)
+    }
+}
 
 impl ZatoshisFlowSum {
     /// Sum a sequence of amounts as flow.
@@ -171,6 +188,43 @@ mod tests {
 
         assert_eq!(two_supplies.net(ZatoshisFlowSum::ZERO), None);
         assert_eq!(ZatoshisFlowSum::ZERO.net(two_supplies), None);
+    }
+
+    /// `accumulate_balances` of nothing is zero held.
+    #[test]
+    fn sum_balances_of_nothing_is_zero() {
+        assert_eq!(
+            Zatoshis::sum_balances(core::iter::empty()),
+            Some(Zatoshis::ZERO)
+        );
+    }
+
+    /// `accumulate_balances` sums balances within the supply.
+    #[test]
+    fn sum_balances_within_the_supply_sums() {
+        let total = Zatoshis::sum_balances([100, 50, 30].map(zatoshis).into_iter());
+
+        assert_eq!(total.map(u64::from), Some(180));
+    }
+
+    /// A set of balances totalling exactly the supply is the extreme legitimate
+    /// case — all coins in the summed set — and is admitted.
+    #[test]
+    fn sum_balances_at_the_supply_is_allowed() {
+        let half = MAX_ZATOSHIS / 2;
+        let total = Zatoshis::sum_balances([half, MAX_ZATOSHIS - half].map(zatoshis).into_iter());
+
+        assert_eq!(total.map(u64::from), Some(MAX_ZATOSHIS));
+    }
+
+    /// Coexisting balances cannot total past the supply, so such a total is
+    /// evidence of overlapping or double-counted inputs and is refused.
+    #[test]
+    fn sum_balances_past_the_supply_is_refused() {
+        assert_eq!(
+            Zatoshis::sum_balances([MAX_ZATOSHIS, 1].map(zatoshis).into_iter()),
+            None
+        );
     }
 
     /// A difference at exactly the supply is still a representable signed value.

--- a/packages/zaino-primitives/src/types/zatoshis/arithmetic.rs
+++ b/packages/zaino-primitives/src/types/zatoshis/arithmetic.rs
@@ -21,7 +21,7 @@
 //! ```text
 //! accumulate          : [A] → F   Σ aᵢ, counting each movement
 //! accumulate_balances : [A] → A?  Σ aᵢ, of balances that coexist
-//!                                 (supply-capped; closed — lands back in A)
+//!                                 (supply-capped; lands back in A or refused)
 //! net                 : F × F → D received − spent, landing in [−S, S] or refused
 //! ```
 //!
@@ -30,9 +30,10 @@
 //! fails only if the machine integer overflows. `accumulate_balances` is the
 //! second accumulate — the same fold shape with a different landing: balances
 //! that coexist at one moment cannot total more than the coins that exist, so
-//! the sum is itself in `[0, S]` and `A` is closed under it; the fold lands
-//! back in [`Zatoshis`] rather than a new type, refusing a total past the
-//! supply. `net` subtracts a spent flow from a received one and admits the
+//! under that precondition the sum is itself in `[0, S]`; the fold lands back
+//! in [`Zatoshis`] rather than a new type, refusing a total past the supply.
+//! `A` is still not closed under addition — the precondition, not the set,
+//! keeps this result inside it. `net` subtracts a spent flow from a received one and admits the
 //! result only as a signed value: a balance change lives in `[−S, S]`, so a
 //! result outside it is refused. That bound is a property of a balance change,
 //! which the two sums are only when they are the received and spent flow of
@@ -57,9 +58,10 @@ impl Zatoshis {
     ///
     /// This is the second accumulate of the algebra: the same fold shape as
     /// [`ZatoshisFlowSum::try_accumulate`], with a different landing and
-    /// bound. Because a sum of coexisting balances stays within `[0, supply]`,
-    /// [`Zatoshis`] is closed under it — so this is deliberately an operation
-    /// returning [`Zatoshis`], not a new quantity type.
+    /// bound. Because a sum of coexisting balances stays within `[0, supply]`
+    /// under its precondition, this is deliberately an operation returning
+    /// [`Zatoshis`], not a new quantity type; the set is not closed under
+    /// addition, so the fold is checked and refuses a total past the supply.
     pub fn sum_balances(mut values: impl Iterator<Item = Zatoshis>) -> Option<Zatoshis> {
         values.try_fold(Zatoshis::ZERO, Zatoshis::checked_add)
     }

--- a/packages/zaino-primitives/src/types/zatoshis/arithmetic.rs
+++ b/packages/zaino-primitives/src/types/zatoshis/arithmetic.rs
@@ -11,7 +11,7 @@
 //! and `S` for the money supply. The quantities occupy nested ranges:
 //!
 //! ```text
-//! A ∈ [0, S]          an amount held
+//! A ∈ [0, S]          an amount of ZEC counted in zatoshis
 //! F ∈ [0, ∞)          a sum of movements  (machine-bounded, not supply-bounded)
 //! D ∈ [−S, S]         a signed value (a movement or a difference)
 //! ```

--- a/packages/zaino-primitives/src/types/zatoshis/flow_sum.rs
+++ b/packages/zaino-primitives/src/types/zatoshis/flow_sum.rs
@@ -9,19 +9,35 @@
 /// bounded only by machine representability, which is why it is a `u128` and not
 /// a [`Zatoshis`](super::Zatoshis).
 ///
-/// The only way to obtain one is
-/// [`try_accumulate`](ZatoshisFlowSum::try_accumulate): the inner value is
-/// private, so a flow sum can only be the sum of some amounts, never an
-/// arbitrary integer. Differencing two flow sums lands the result in a
+/// Two validated provenances lead in, and no unchecked one: a total *derived*
+/// in the domain arrives through
+/// [`try_accumulate`](ZatoshisFlowSum::try_accumulate), a checked fold of
+/// amounts, and a total a source *delivers already summed* arrives through
+/// [`from_summed`](ZatoshisFlowSum::from_summed), the boundary door. The inner
+/// value is private, so a flow sum is always the sum of some movements, never
+/// an arbitrary integer. Differencing two flow sums lands the result in a
 /// [`SignedZatoshis`](super::SignedZatoshis) via
-/// [`net`](ZatoshisFlowSum::net). Both operations, and the algebra that
-/// relates the quantities, live in the `arithmetic` module.
+/// [`net`](ZatoshisFlowSum::net). The fold, the difference, and the algebra
+/// that relates the quantities live in the `arithmetic` module.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ZatoshisFlowSum(u128);
 
 impl ZatoshisFlowSum {
     /// A flow sum of nothing.
     pub(super) const ZERO: Self = Self(0);
+
+    /// Adopt a flow total delivered already summed by a source.
+    ///
+    /// This is the boundary door: a backend reports a lifetime flow total —
+    /// such as an address's gross receipts — as a single `u64`, summed on its
+    /// side. The flow sum's only invariant is machine representability, and a
+    /// `u64` always fits the `u128` accumulator, so there is genuinely nothing
+    /// to check and the door is honestly infallible. A total *derived* in the
+    /// domain reaches the type through
+    /// [`try_accumulate`](Self::try_accumulate) instead.
+    pub fn from_summed(total: u64) -> Self {
+        Self(u128::from(total))
+    }
 
     /// Wrap a raw accumulator value.
     ///
@@ -34,6 +50,12 @@ impl ZatoshisFlowSum {
     /// The raw accumulated value, for the arithmetic relations to difference.
     pub(super) const fn into_raw(self) -> u128 {
         self.0
+    }
+}
+
+impl From<ZatoshisFlowSum> for u128 {
+    fn from(sum: ZatoshisFlowSum) -> Self {
+        sum.0
     }
 }
 
@@ -56,5 +78,28 @@ mod tests {
 
         assert_eq!(unrepresentable.net(ZatoshisFlowSum::ZERO), None);
         assert_eq!(ZatoshisFlowSum::ZERO.net(unrepresentable), None);
+    }
+
+    /// The boundary door round-trips: a pre-summed total goes in as a `u64`
+    /// and comes back out unchanged through the `u128` reader.
+    #[test]
+    fn from_summed_round_trips() {
+        let total = 123_456_789_u64;
+
+        assert_eq!(
+            u128::from(ZatoshisFlowSum::from_summed(total)),
+            u128::from(total)
+        );
+    }
+
+    /// The boundary door admits any `u64`, including totals past the money
+    /// supply — a flow counts the same coins each time they move, so a
+    /// lifetime total past the supply is legitimate data, not corruption.
+    #[test]
+    fn from_summed_admits_totals_past_the_supply() {
+        assert_eq!(
+            u128::from(ZatoshisFlowSum::from_summed(u64::MAX)),
+            u128::from(u64::MAX)
+        );
     }
 }

--- a/packages/zaino-primitives/usage.md
+++ b/packages/zaino-primitives/usage.md
@@ -78,9 +78,9 @@ ADR-0013 for the doctrine.
 A sum of *movements* — every output paying an address, every input it spent —
 counts the same coins each time they move, so it is not bounded by the supply;
 that is why it is its own type and not another `Zatoshis`. A sum of *coexisting*
-balances would be supply-bounded, and is a real fourth member of this family,
-but has no consumer yet and is not built (it is named in the arithmetic
-module's docs).
+balances stays supply-bounded — coins that coexist cannot total more than
+exist — so `Zatoshis` is closed under it and there is no fourth type: that sum
+is the operation `Zatoshis::sum_balances`, landing back in `Zatoshis`.
 
 The operations relate the types and live beside them:
 
@@ -92,19 +92,31 @@ use zaino_primitives::types::{Zatoshis, ZatoshisFlowSum, SignedZatoshis};
 let received = ZatoshisFlowSum::try_accumulate(outputs.iter().copied())?;
 let spent = ZatoshisFlowSum::try_accumulate(spends.iter().copied())?;
 
+// Adopt a flow total a backend delivered already summed as a u64.
+// Infallible: a u64 always fits the u128 accumulator, and machine
+// representability is the flow sum's only invariant.
+let lifetime = ZatoshisFlowSum::from_summed(received_total);
+
 // Net of a received flow minus a spent flow for one balance, as a signed
 // value. `None` if the two flows don't describe a coherent balance.
 let net: Option<SignedZatoshis> = received.net(spent);
+
+// Sum balances that coexist at one moment. Supply-capped and closed: the
+// total lands back in `Zatoshis`. `None` means the total passed the supply,
+// which under the coexistence contract is overlapping or double-counted
+// input, not a large number.
+let held: Option<Zatoshis> = Zatoshis::sum_balances(balances.iter().copied());
 ```
 
-`ZatoshisFlowSum` has no other constructor: a flow sum is only ever the checked
-sum of some amounts. `SignedZatoshis` has two validated doors and no unchecked
-one — `ZatoshisFlowSum::net` for a value *derived* in the domain, and
-`SignedZatoshis::try_new` for one *parsed at a boundary* (a movement read off the
-wire or disk). `try_new` is the external-input validation step for a signed
-value, the
-same discipline the crate applies at every wire and persistence boundary,
-pushed down to the primitive.
+`ZatoshisFlowSum` has two validated doors and no unchecked one:
+`try_accumulate` for a total *derived* in the domain as the checked sum of
+some amounts, and `from_summed` for a total a source *delivers already
+summed*. `SignedZatoshis` likewise — `ZatoshisFlowSum::net` for a value
+*derived* in the domain, and `SignedZatoshis::try_new` for one *parsed at a
+boundary* (a movement read off the wire or disk). `try_new` is the
+external-input validation step for a signed value, the same discipline the
+crate applies at every wire and persistence boundary, pushed down to the
+primitive.
 
 ## Byte order
 

--- a/packages/zaino-primitives/usage.md
+++ b/packages/zaino-primitives/usage.md
@@ -79,8 +79,11 @@ A sum of *movements* — every output paying an address, every input it spent �
 counts the same coins each time they move, so it is not bounded by the supply;
 that is why it is its own type and not another `Zatoshis`. A sum of *coexisting*
 balances stays supply-bounded — coins that coexist cannot total more than
-exist — so `Zatoshis` is closed under it and there is no fourth type: that sum
-is the operation `Zatoshis::sum_balances`, landing back in `Zatoshis`.
+exist — so that precondition keeps the total inside `Zatoshis` and there is no
+fourth type: that sum is the operation `Zatoshis::sum_balances`, a checked fold
+landing back in `Zatoshis`. The set of `Zatoshis` is still not closed under
+addition; the fold refuses a total past the supply rather than pretend the
+precondition held.
 
 The operations relate the types and live beside them:
 
@@ -101,10 +104,10 @@ let lifetime = ZatoshisFlowSum::from_summed(received_total);
 // value. `None` if the two flows don't describe a coherent balance.
 let net: Option<SignedZatoshis> = received.net(spent);
 
-// Sum balances that coexist at one moment. Supply-capped and closed: the
-// total lands back in `Zatoshis`. `None` means the total passed the supply,
-// which under the coexistence contract is overlapping or double-counted
-// input, not a large number.
+// Sum balances that coexist at one moment. Supply-capped, and under that
+// precondition the total lands back in `Zatoshis`. `None` means the total
+// passed the supply, which under the coexistence contract is overlapping or
+// double-counted input, not a large number.
 let held: Option<Zatoshis> = Zatoshis::sum_balances(balances.iter().copied());
 ```
 

--- a/packages/zaino-primitives/usage.md
+++ b/packages/zaino-primitives/usage.md
@@ -71,7 +71,7 @@ ADR-0013 for the doctrine.
 
 | type | range | is |
 |---|---|---|
-| `Zatoshis` | `0 ..= supply` | an amount held — a balance, a UTXO value |
+| `Zatoshis` | `0 ..= supply` | an amount of ZEC counted in zatoshis — a balance, a UTXO value, a single movement |
 | `ZatoshisFlowSum` | `0 ..= u128::MAX` | an accumulation of movements, **not** supply-bounded |
 | `SignedZatoshis` | `-supply ..= supply` | a signed value: a movement or a difference |
 

--- a/packages/zaino-serve/src/rpc/jsonrpc/service.rs
+++ b/packages/zaino-serve/src/rpc/jsonrpc/service.rs
@@ -737,8 +737,11 @@ impl<Indexer: ZcashIndexer + LightWalletIndexer> ZcashIndexerRpcServer for JsonR
             .inner_ref()
             .z_get_address_balance(address_strings)
             .await
-            .map(crate::rpc::jsonrpc::wire::address_queries::address_balance_from_domain)
             .map_err(invalid_params_error_object)
+            .and_then(|balance| {
+                crate::rpc::jsonrpc::wire::address_queries::address_balance_from_domain(balance)
+                    .map_err(invalid_params_error_object)
+            })
     }
 
     async fn send_raw_transaction(

--- a/packages/zaino-serve/src/rpc/jsonrpc/wire/address_queries.rs
+++ b/packages/zaino-serve/src/rpc/jsonrpc/wire/address_queries.rs
@@ -22,9 +22,24 @@ use zebra_rpc::methods::{AddressBalance, GetAddressUtxos};
 #[error("utxo address is not a valid transparent address: {0}")]
 pub struct UnrenderableUtxoAddress(String);
 
+/// A received total the wire type cannot represent.
+///
+/// The domain carries lifetime receipts as a flow sum over a `u128`; the
+/// `getaddressbalance` response carries `received` as a `u64`. Every backend
+/// delivers the total already summed into a `u64`, so a value past that width
+/// cannot arise in practice. It is reported rather than asserted because the
+/// alternative is a panic on a value that came from outside this process.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("received total {0} exceeds the wire field's u64 range")]
+pub struct UnrenderableReceivedTotal(u128);
+
 /// Renders the domain type as the `getaddressbalance` response.
-pub fn address_balance_from_domain(balance: DomainAddressBalance) -> AddressBalance {
-    AddressBalance::new(u64::from(balance.balance), u64::from(balance.received))
+pub fn address_balance_from_domain(
+    balance: DomainAddressBalance,
+) -> Result<AddressBalance, UnrenderableReceivedTotal> {
+    let received = u128::from(balance.received);
+    let received = u64::try_from(received).map_err(|_| UnrenderableReceivedTotal(received))?;
+    Ok(AddressBalance::new(u64::from(balance.balance), received))
 }
 
 /// Renders the domain UTXOs as the `getaddressutxos` response.
@@ -54,7 +69,9 @@ pub fn address_utxos_from_domain(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use zaino_primitives::types::{Height, Script, TransactionId, TransparentAddress, Zatoshis};
+    use zaino_primitives::types::{
+        Height, Script, TransactionId, TransparentAddress, Zatoshis, ZatoshisFlowSum,
+    };
 
     /// Asymmetric under reversal, so a missing or doubled byte-reversal shows up.
     const ASYMMETRIC: [u8; 32] = [
@@ -82,14 +99,33 @@ mod tests {
     /// per-method, so it is pinned per method.
     #[test]
     fn balance_is_reported_in_zatoshis() {
-        let json = serde_json::to_value(address_balance_from_domain(DomainAddressBalance {
-            balance: Zatoshis::new(150_000_000).unwrap(),
-            received: Zatoshis::new(200_000_000).unwrap(),
-        }))
+        let json = serde_json::to_value(
+            address_balance_from_domain(DomainAddressBalance {
+                balance: Zatoshis::new(150_000_000).unwrap(),
+                received: ZatoshisFlowSum::from_summed(200_000_000),
+            })
+            .expect("a u64-summed received total renders"),
+        )
         .unwrap();
 
         assert_eq!(json["balance"], 150_000_000u64);
         assert_eq!(json["received"], 200_000_000u64);
+    }
+
+    /// `received` is a flow: a lifetime total past the money supply is
+    /// legitimate data and round-trips to the wire unchanged.
+    #[test]
+    fn a_received_total_past_the_supply_renders() {
+        let json = serde_json::to_value(
+            address_balance_from_domain(DomainAddressBalance {
+                balance: Zatoshis::ZERO,
+                received: ZatoshisFlowSum::from_summed(u64::MAX),
+            })
+            .expect("any u64-summed received total renders"),
+        )
+        .unwrap();
+
+        assert_eq!(json["received"], u64::MAX);
     }
 
     #[test]

--- a/packages/zaino-source-zebra-readstate/src/adapter.rs
+++ b/packages/zaino-source-zebra-readstate/src/adapter.rs
@@ -370,8 +370,11 @@ impl zaino_source::OneShotGetAddressBalance for ZebraReadStateAdapter {
                 Ok(zaino_primitives::types::AddressBalance {
                     balance: zaino_primitives::types::Zatoshis::new(balance.into())
                         .map_err(|e| FetchError::new(FailureMode::Parse, e.to_string()))?,
-                    received: zaino_primitives::types::Zatoshis::new(received)
-                        .map_err(|e| FetchError::new(FailureMode::Parse, e.to_string()))?,
+                    // A lifetime receipts flow, delivered pre-summed by the
+                    // state service; not supply-bounded, so it lands in the
+                    // flow-sum type through its boundary door rather than
+                    // being rejected by the amount bound.
+                    received: zaino_primitives::types::ZatoshisFlowSum::from_summed(received),
                 })
             }
             _ => Err(unexpected_response("AddressBalance").into()),

--- a/packages/zaino-source-zebra-rpc/src/parse.rs
+++ b/packages/zaino-source-zebra-rpc/src/parse.rs
@@ -35,7 +35,7 @@ use zaino_primitives::types::{
     BlockchainInfo, ChainWork, ConsensusBranchId, ConsensusBranchIds, Height, MerkleRoot,
     NetworkUpgradeInfo, NetworkUpgradeStatus, Script, SignedZatoshis, SubtreeRoot, TransactionId,
     TransactionLocation, TransparentAddress, TreeRoot, TreeRootInfo, TreeRoots, Treestate, Utxo,
-    ValuePoolBalance, Zatoshis,
+    ValuePoolBalance, Zatoshis, ZatoshisFlowSum,
 };
 use zaino_source::{MempoolTxMeta, TransactionResponse};
 
@@ -614,9 +614,12 @@ pub(crate) fn parse_address_balance(
     Ok(AddressBalance {
         balance: Zatoshis::new(as_u64(field(value, "balance")?)?)
             .map_err(|e| ParseError::Amount(e.to_string()))?,
+        // A lifetime receipts flow, delivered pre-summed by the validator; not
+        // supply-bounded, so it lands in the flow-sum type through its
+        // boundary door rather than being rejected by the amount bound.
         received: match opt_field(value, "received") {
-            Some(v) => Zatoshis::new(as_u64(v)?).map_err(|e| ParseError::Amount(e.to_string()))?,
-            None => Zatoshis::ZERO,
+            Some(v) => ZatoshisFlowSum::from_summed(as_u64(v)?),
+            None => ZatoshisFlowSum::from_summed(0),
         },
     })
 }

--- a/packages/zaino-state/src/chain_index/source/mockchain_source.rs
+++ b/packages/zaino-state/src/chain_index/source/mockchain_source.rs
@@ -1043,17 +1043,14 @@ impl zaino_source::OneShotGetAddressBalance for MockchainSource {
         let matching = self.matching_transparent_outputs(&valid, &network);
         let spent = self.spent_transparent_outpoints();
 
+        let mut received_values = Vec::new();
         let mut balance = 0_u64;
-        let mut received = 0_u64;
         for (outpoint, output) in matching {
-            let value = u64::from(output.output.value());
-            received = received.checked_add(value).ok_or_else(|| {
-                port_fault::<zaino_source::GetAddressBalanceError>(
-                    "address received amount overflowed u64",
-                )
-            })?;
+            let value = domain::Zatoshis::new(u64::from(output.output.value()))
+                .map_err(|e| port_fault::<zaino_source::GetAddressBalanceError>(e.to_string()))?;
+            received_values.push(value);
             if !spent.contains(&outpoint) {
-                balance = balance.checked_add(value).ok_or_else(|| {
+                balance = balance.checked_add(u64::from(value)).ok_or_else(|| {
                     port_fault::<zaino_source::GetAddressBalanceError>(
                         "address balance amount overflowed u64",
                     )
@@ -1061,11 +1058,20 @@ impl zaino_source::OneShotGetAddressBalance for MockchainSource {
             }
         }
 
+        // Every matching output is a receipt, so the lifetime received total
+        // is a flow: it is derived here by the flow accumulate, not bounded by
+        // the supply.
+        let received = domain::ZatoshisFlowSum::try_accumulate(received_values.into_iter())
+            .ok_or_else(|| {
+                port_fault::<zaino_source::GetAddressBalanceError>(
+                    "address received flow overflowed its accumulator",
+                )
+            })?;
+
         Ok(domain::AddressBalance {
             balance: domain::Zatoshis::new(balance)
                 .map_err(|e| port_fault::<zaino_source::GetAddressBalanceError>(e.to_string()))?,
-            received: domain::Zatoshis::new(received)
-                .map_err(|e| port_fault::<zaino_source::GetAddressBalanceError>(e.to_string()))?,
+            received,
         })
     }
 }

--- a/packages/zaino-state/src/chain_index/source/mockchain_source.rs
+++ b/packages/zaino-state/src/chain_index/source/mockchain_source.rs
@@ -1044,17 +1044,13 @@ impl zaino_source::OneShotGetAddressBalance for MockchainSource {
         let spent = self.spent_transparent_outpoints();
 
         let mut received_values = Vec::new();
-        let mut balance = 0_u64;
+        let mut balance_values = Vec::new();
         for (outpoint, output) in matching {
             let value = domain::Zatoshis::new(u64::from(output.output.value()))
                 .map_err(|e| port_fault::<zaino_source::GetAddressBalanceError>(e.to_string()))?;
             received_values.push(value);
             if !spent.contains(&outpoint) {
-                balance = balance.checked_add(u64::from(value)).ok_or_else(|| {
-                    port_fault::<zaino_source::GetAddressBalanceError>(
-                        "address balance amount overflowed u64",
-                    )
-                })?;
+                balance_values.push(value);
             }
         }
 
@@ -1068,11 +1064,18 @@ impl zaino_source::OneShotGetAddressBalance for MockchainSource {
                 )
             })?;
 
-        Ok(domain::AddressBalance {
-            balance: domain::Zatoshis::new(balance)
-                .map_err(|e| port_fault::<zaino_source::GetAddressBalanceError>(e.to_string()))?,
-            received,
-        })
+        // The unspent outputs coexist on the chain, so their total is a
+        // supply-bounded balance; a total past the supply means the UTXO set
+        // overlaps or double-counts, and is refused rather than wrapped.
+        let balance =
+            domain::Zatoshis::sum_balances(balance_values.into_iter()).ok_or_else(|| {
+                port_fault::<zaino_source::GetAddressBalanceError>(
+                    "unspent output values total past the money supply: \
+                     overlapping or corrupt UTXO set",
+                )
+            })?;
+
+        Ok(domain::AddressBalance { balance, received })
     }
 }
 

--- a/packages/zaino-state/src/indexer/node_backed_indexer.rs
+++ b/packages/zaino-state/src/indexer/node_backed_indexer.rs
@@ -1596,16 +1596,30 @@ impl<Source: BlockchainSource + WithChainHeadSource + WithChainStoreSource> Ligh
             let fetcher_timeout = timeout(
                 time::Duration::from_secs((service_timeout * 4) as u64),
                 async {
-                    let mut total_balance: u64 = 0;
+                    // Per-address balances coexist at one moment, so their
+                    // running total is itself a supply-bounded balance: the
+                    // incremental form of `Zatoshis::sum_balances`, demanded
+                    // by the streaming shape. A total past the supply means
+                    // the request's addresses overlap or the source
+                    // double-counts, and is refused rather than wrapped.
+                    let mut total_balance = zaino_primitives::types::Zatoshis::ZERO;
                     loop {
                         match channel_rx.recv().await {
                             Some(taddr) => {
                                 let taddrs = GetAddressBalanceRequest::new(vec![taddr]);
                                 let balance = service_clone.z_get_address_balance(taddrs).await?;
-                                total_balance += u64::from(balance.balance);
+                                total_balance = total_balance
+                                    .checked_add(balance.balance)
+                                    .ok_or_else(|| {
+                                        tonic::Status::data_loss(
+                                            "Error: address balances total past the money \
+                                                 supply; the requested addresses overlap or the \
+                                                 source data is corrupt.",
+                                        )
+                                    })?;
                             }
                             None => {
-                                return Ok(total_balance);
+                                return Ok(u64::from(total_balance));
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

Stacked on #1508 (the zatoshi quantity family). First item of the primitives
invariance audit: `AddressBalance` carried a flow total in a supply-bounded
type, and the balance-side aggregation ran on an unchecked bare integer.

- `AddressBalance.received` is lifetime gross receipts — cumulative flow.
  Coins that cycle through an address are counted on every arrival, so across
  a set of addresses the total legitimately exceeds the money supply. It was
  typed `Zatoshis` (rejects > supply), so both real backends turned legitimate
  high-throughput data into a parse error. It is now a `ZatoshisFlowSum`.
- The backends deliver `received` already summed as a `u64`, which always fits
  the flow sum's `u128` — so the new boundary door,
  `ZatoshisFlowSum::from_summed(u64)`, is honestly infallible: machine
  representability is the type's only invariant and a `u64` cannot violate it.
- A sum of *coexisting* balances is bounded by the supply, so `Zatoshis` is
  closed under it — the previously deferred `ZatoshisBalanceSum` type is a
  phantom. The algebra instead gains a second accumulate *operation*,
  `Zatoshis::sum_balances(iter) -> Option<Zatoshis>`: the supply-capped checked
  fold, where `None` means the inputs overlap or are corrupt (a coexisting set
  cannot total past the supply). ADR-0013 is corrected accordingly.
- `get_taddress_balance_stream` aggregated balances with an unchecked
  `total_balance += u64`, which could wrap silently. It now folds through the
  checked balance sum and reports an impossible total as a loud typed error.
- The wire render converts the `u128` flow total back to the response's `u64`
  through a checked conversion with a typed error, mirroring the file's
  existing unrenderable-value pattern.

## Test plan

- `cargo fmt --check`, `cargo check --workspace`,
  `cargo clippy --workspace -- -D warnings` (with and without
  `zaino-chain-store/transparent_address_history_experimental`) — clean.
- `cargo nextest run` on zaino-primitives, zaino-serve, zaino-state,
  zaino-source-zebra-rpc, zaino-source-zebra-readstate — 329 passed.
- Regression test pinning the bug: an `AddressBalance` whose `received`
  exceeds the supply is now representable (`received_past_the_supply_is_representable`).
- `sum_balances`: within/at supply accepted, past supply refused, empty is zero.
