### PR TITLE
zaino-primitives: validate TransparentAddress at construction via zcash_address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6033,6 +6033,8 @@ name = "zaino-primitives"
 version = "0.1.0"
 dependencies = [
  "thiserror 2.0.18",
+ "zcash_address",
+ "zcash_protocol",
 ]
 
 [[package]]

--- a/packages/zaino-primitives/Cargo.toml
+++ b/packages/zaino-primitives/Cargo.toml
@@ -10,6 +10,8 @@ license.workspace = true
 
 [dependencies]
 thiserror = { workspace = true }
+zcash_address.workspace = true
+zcash_protocol.workspace = true
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/packages/zaino-primitives/src/types.rs
+++ b/packages/zaino-primitives/src/types.rs
@@ -2,6 +2,7 @@
 
 mod address_balance;
 mod address_delta;
+mod address_network;
 mod aliases;
 mod block;
 mod block_commitments;
@@ -41,6 +42,7 @@ mod zatoshis;
 
 pub use address_balance::AddressBalance;
 pub use address_delta::AddressDelta;
+pub use address_network::AddressNetwork;
 pub use aliases::{
     BlockTime, CompactDifficulty, Confirmations, Difficulty, EquihashNonce, OutputIndex,
     SubtreeIndex, TreeSize, TxIndex,
@@ -77,7 +79,7 @@ pub use transaction::{
 };
 pub use transaction_hash::TransactionId;
 pub use transaction_location::TransactionLocation;
-pub use transparent_address::TransparentAddress;
+pub use transparent_address::{TransparentAddress, TransparentAddressError};
 pub use tree_root::TreeRoot;
 pub use tree_roots::{TreeRootInfo, TreeRoots};
 pub use treestate::{PoolTreestate, TreeBytes, Treestate};

--- a/packages/zaino-primitives/src/types/address_network.rs
+++ b/packages/zaino-primitives/src/types/address_network.rs
@@ -1,0 +1,30 @@
+//! The Zcash network an address encodes for.
+
+/// The network an encoded Zcash address belongs to.
+///
+/// An address string commits to a network in its encoding — the same key
+/// material produces a different string on mainnet than on testnet — so the
+/// network is a fact *about the address*, read off it at parse time, not a
+/// separate configuration a consumer supplies.
+///
+/// This is Zaino's own vocabulary: the address parser inside
+/// [`TransparentAddress`](crate::types::TransparentAddress) maps the underlying
+/// protocol library's network tag onto this enum so that nothing from that
+/// library reaches Zaino's API surface.
+///
+/// Transparent testnet and regtest addresses share one base58 encoding, so a
+/// transparent address parsed from a string is only ever [`Mainnet`] or
+/// [`Testnet`]; [`Regtest`] is carried for completeness of the mapping.
+///
+/// [`Mainnet`]: AddressNetwork::Mainnet
+/// [`Testnet`]: AddressNetwork::Testnet
+/// [`Regtest`]: AddressNetwork::Regtest
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AddressNetwork {
+    /// Zcash mainnet.
+    Mainnet,
+    /// Zcash testnet.
+    Testnet,
+    /// A private regression-testing network.
+    Regtest,
+}

--- a/packages/zaino-primitives/src/types/transparent_address.rs
+++ b/packages/zaino-primitives/src/types/transparent_address.rs
@@ -1,32 +1,277 @@
 //! Transparent Zcash address.
 
-/// A transparent Zcash address (t-addr string).
+use zcash_address::{ConversionError, TryFromAddress, ZcashAddress};
+use zcash_protocol::consensus::NetworkType;
+
+use crate::types::{AddressNetwork, ScriptType};
+
+/// A transparent Zcash address.
 ///
-/// Wraps the string representation. Validation of address format
-/// is the adapter's responsibility at construction time.
+/// Holds the canonical encoded string, and only ever a string that is a
+/// well-formed transparent (P2PKH or P2SH) address. The constructor
+/// [`try_new`](TransparentAddress::try_new) is the one place the format is
+/// checked, so every consumer inherits a validated address for free: there is
+/// no unchecked door.
+///
+/// # What validates
+///
+/// Construction parses the string with the `zcash_address` protocol library and
+/// accepts *only* the two transparent kinds. Shielded (Sapling), unified,
+/// Sprout, and TEX addresses decode successfully but are rejected as
+/// [`TransparentAddressError::NotTransparent`]; anything that does not decode as
+/// a Zcash address at all is rejected as
+/// [`TransparentAddressError::Undecodable`] with the parser's reason preserved.
+///
+/// The address library is an implementation detail: none of its types appear in
+/// this type's API. What the address *is* — its network and script form — is
+/// re-expressed in Zaino's own vocabulary ([`AddressNetwork`], [`ScriptType`]).
+///
+/// # Network-blindness
+///
+/// A transparent address is accepted regardless of which network it encodes
+/// for; the network is then reported by [`network`](TransparentAddress::network).
+/// The primitive states what the address *is*; deciding whether that network is
+/// the one a given query should act on is the consumer's policy, not the
+/// address's invariant.
+///
+/// # Stored metadata
+///
+/// The network and script form are parsed once at construction and stored
+/// alongside the string, so [`network`](TransparentAddress::network) and
+/// [`script_type`](TransparentAddress::script_type) are field reads rather than
+/// a re-parse on every call. The two extra machine words are cheaper than
+/// re-running base58 decoding at each accessor, and both are `Copy` so the
+/// struct stays cheap to clone.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct TransparentAddress(String);
+pub struct TransparentAddress {
+    encoded: String,
+    network: AddressNetwork,
+    script_type: ScriptType,
+}
 
 impl TransparentAddress {
-    /// Wrap a validated address string.
-    pub fn new(address: String) -> Self {
-        Self(address)
+    /// Parses and validates a transparent address string.
+    ///
+    /// # Errors
+    ///
+    /// - [`TransparentAddressError::Undecodable`] if the string is not a
+    ///   decodable Zcash address.
+    /// - [`TransparentAddressError::NotTransparent`] if it decodes as a Zcash
+    ///   address of a non-transparent kind (shielded, unified, Sprout, TEX).
+    pub fn try_new(address: impl Into<String>) -> Result<Self, TransparentAddressError> {
+        let encoded = address.into();
+        let parsed = ZcashAddress::try_from_encoded(&encoded)
+            .map_err(|e| TransparentAddressError::Undecodable(e.to_string()))?;
+
+        // `convert` dispatches on the parsed address kind without checking the
+        // network, so acceptance is network-blind. The only failure it can
+        // produce for a successfully decoded address is `Unsupported`, raised by
+        // the defaulted non-transparent arms of `TransparentKind` below — hence
+        // any error here means "decoded, but not transparent".
+        let kind = parsed
+            .convert::<TransparentKind>()
+            .map_err(|e| TransparentAddressError::NotTransparent(e.to_string()))?;
+
+        Ok(Self {
+            encoded,
+            network: kind.network,
+            script_type: kind.script_type,
+        })
     }
 
-    /// The address string.
+    /// The network this address encodes for.
+    pub fn network(&self) -> AddressNetwork {
+        self.network
+    }
+
+    /// The transparent script form this address pays to — [`ScriptType::P2PKH`]
+    /// or [`ScriptType::P2SH`].
+    pub fn script_type(&self) -> ScriptType {
+        self.script_type
+    }
+
+    /// The canonical encoded address string.
     pub fn as_str(&self) -> &str {
-        &self.0
+        &self.encoded
     }
 }
 
 impl core::fmt::Display for TransparentAddress {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.encoded)
     }
 }
 
 impl From<TransparentAddress> for String {
     fn from(a: TransparentAddress) -> Self {
-        a.0
+        a.encoded
+    }
+}
+
+/// The transparent metadata extracted while parsing an address.
+///
+/// A private carrier for the `zcash_address` conversion: implementing
+/// [`TryFromAddress`] lets `convert` hand back exactly the two facts Zaino
+/// keeps — network and script form — for the transparent kinds, while the
+/// defaulted arms reject every other kind. It never crosses this module's
+/// boundary, so the address library stays contained here.
+struct TransparentKind {
+    network: AddressNetwork,
+    script_type: ScriptType,
+}
+
+impl TryFromAddress for TransparentKind {
+    // No transparent arm produces a user error, so the user-error channel is
+    // uninhabited.
+    type Error = core::convert::Infallible;
+
+    fn try_from_transparent_p2pkh(
+        net: NetworkType,
+        _data: [u8; 20],
+    ) -> Result<Self, ConversionError<Self::Error>> {
+        Ok(Self {
+            network: network_from(net),
+            script_type: ScriptType::P2PKH,
+        })
+    }
+
+    fn try_from_transparent_p2sh(
+        net: NetworkType,
+        _data: [u8; 20],
+    ) -> Result<Self, ConversionError<Self::Error>> {
+        Ok(Self {
+            network: network_from(net),
+            script_type: ScriptType::P2SH,
+        })
+    }
+}
+
+/// Maps the protocol library's network tag onto Zaino's [`AddressNetwork`].
+///
+/// The match is exhaustive over `NetworkType`'s three variants, so a new kind
+/// of network in the library would surface here as a compile error rather than
+/// a silent mis-mapping.
+fn network_from(net: NetworkType) -> AddressNetwork {
+    match net {
+        NetworkType::Main => AddressNetwork::Mainnet,
+        NetworkType::Test => AddressNetwork::Testnet,
+        NetworkType::Regtest => AddressNetwork::Regtest,
+    }
+}
+
+/// Why a string was rejected as a transparent address.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TransparentAddressError {
+    /// The string is not a decodable Zcash address. Carries the parser's reason.
+    #[error("not a decodable Zcash address: {0}")]
+    Undecodable(String),
+    /// The string decodes as a Zcash address, but not a transparent one
+    /// (shielded, unified, Sprout, or TEX).
+    #[error("not a transparent address: {0}")]
+    NotTransparent(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Real vectors. The mainnet pair is from `zcash_address`'s own encoding
+    // tests; the testnet pair and the shielded / unified / Sprout rejections
+    // are the vectors pinned in `zaino-address`'s classifier tests.
+    const MAINNET_P2PKH: &str = "t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs";
+    const MAINNET_P2SH: &str = "t3JZcvsuaXE6ygokL4XUiZSTrQBUoPYFnXJ";
+    const TESTNET_P2PKH: &str = "tmVqEASZxBNKFTbmASZikGa5fPLkd68iJyx";
+    const TESTNET_P2SH: &str = "t2MjoXQ2iDrjG9QXNZNCY9io8ecN4FJYK1u";
+    const SAPLING: &str = "zregtestsapling1jalqhycwumq3unfxlzyzcktq3n478n82k2wacvl8gwfxk6ahshkxmtp2034qj28n7gl92ka5wca";
+    const UNIFIED: &str = "uregtest1njwg60x0jarhyuuxrcdvw854p68cgdfe85822lmclc7z9vy9xqr7t49n3d97k2dwlee82skwwe0ens0rc06p4vr04tvd3j9ckl3qry83ckay4l4ngdq9atg7vuj9z58tfjs0mnsgyrnprtqfv8almu564z498zy6tp2aa569tk8fyhdazyhytel2m32awe4kuy6qq996um3ljaajj36";
+    const SPROUT: &str = "ztfhKyLouqi8sSwjRm4YMQdWPjTmrJ4QgtziVQ1Kd1e9EsRHYKofjoJdF438FwcUQnix8yrbSrzPpJJNABewgNffs5d4YZJ";
+    const TEX: &str = "textest1qyqszqgpqyqszqgpqyqszqgpqyqszqgpfcjgfy";
+
+    #[test]
+    fn mainnet_p2pkh_accepted() {
+        let a = TransparentAddress::try_new(MAINNET_P2PKH).expect("valid mainnet t1");
+        assert_eq!(a.network(), AddressNetwork::Mainnet);
+        assert_eq!(a.script_type(), ScriptType::P2PKH);
+        assert_eq!(a.as_str(), MAINNET_P2PKH);
+    }
+
+    #[test]
+    fn mainnet_p2sh_accepted() {
+        let a = TransparentAddress::try_new(MAINNET_P2SH).expect("valid mainnet t3");
+        assert_eq!(a.network(), AddressNetwork::Mainnet);
+        assert_eq!(a.script_type(), ScriptType::P2SH);
+    }
+
+    #[test]
+    fn testnet_p2pkh_accepted() {
+        let a = TransparentAddress::try_new(TESTNET_P2PKH).expect("valid testnet tm");
+        assert_eq!(a.network(), AddressNetwork::Testnet);
+        assert_eq!(a.script_type(), ScriptType::P2PKH);
+    }
+
+    #[test]
+    fn testnet_p2sh_accepted() {
+        let a = TransparentAddress::try_new(TESTNET_P2SH).expect("valid testnet t2");
+        assert_eq!(a.network(), AddressNetwork::Testnet);
+        assert_eq!(a.script_type(), ScriptType::P2SH);
+    }
+
+    #[test]
+    fn garbage_is_undecodable() {
+        assert!(matches!(
+            TransparentAddress::try_new("not an address"),
+            Err(TransparentAddressError::Undecodable(_))
+        ));
+    }
+
+    /// A valid t1 address with its final character mutated: still base58, but
+    /// the checksum no longer holds, so it does not decode.
+    #[test]
+    fn bad_checksum_is_undecodable() {
+        let mutated = "t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbt";
+        assert_ne!(mutated, MAINNET_P2PKH);
+        assert!(matches!(
+            TransparentAddress::try_new(mutated),
+            Err(TransparentAddressError::Undecodable(_))
+        ));
+    }
+
+    #[test]
+    fn shielded_is_not_transparent() {
+        assert!(matches!(
+            TransparentAddress::try_new(SAPLING),
+            Err(TransparentAddressError::NotTransparent(_))
+        ));
+    }
+
+    #[test]
+    fn unified_is_not_transparent() {
+        assert!(matches!(
+            TransparentAddress::try_new(UNIFIED),
+            Err(TransparentAddressError::NotTransparent(_))
+        ));
+    }
+
+    #[test]
+    fn sprout_is_not_transparent() {
+        assert!(matches!(
+            TransparentAddress::try_new(SPROUT),
+            Err(TransparentAddressError::NotTransparent(_))
+        ));
+    }
+
+    #[test]
+    fn tex_is_not_transparent() {
+        assert!(matches!(
+            TransparentAddress::try_new(TEX),
+            Err(TransparentAddressError::NotTransparent(_))
+        ));
+    }
+
+    #[test]
+    fn round_trips_through_string_and_display() {
+        let a = TransparentAddress::try_new(MAINNET_P2PKH).expect("valid mainnet t1");
+        assert_eq!(a.to_string(), MAINNET_P2PKH);
+        assert_eq!(String::from(a), MAINNET_P2PKH);
     }
 }

--- a/packages/zaino-primitives/usage.md
+++ b/packages/zaino-primitives/usage.md
@@ -5,16 +5,38 @@ own terms, independent of how any of it is transported or stored.
 
 ## The one rule
 
-**This crate's entire dependency list is `thiserror`.** That is not an
-accident of the current implementation — it is the property that makes every
-other crate able to depend on it. Adding a dependency here adds it to
-`zaino-source`, both adapters, `zaino-state`, `zaino-serve` and `zainod` at
-once.
+**This crate depends only on `thiserror` and the librustzcash
+protocol-specification crates (`zcash_address`, `zcash_protocol`).** Keeping the
+list this short is not an accident of the current implementation — it is the
+property that makes every other crate able to depend on it. Adding a dependency
+here adds it to `zaino-source`, both adapters, `zaino-state`, `zaino-serve` and
+`zainod` at once, so each addition has to earn its place.
 
-In particular there is **no serde**. A serde derive in this crate would let the
-wire format and the domain model start deciding each other, which is exactly
-what ADR-0009 exists to prevent. Serialization lives at the boundary that owns
-the format:
+The rule is about *what a dependency lets in*, not a fixed name list. Two things
+must never enter through it, because both would let some other layer's decisions
+leak into the domain vocabulary:
+
+- **No serialization framework.** In particular there is **no serde**. A serde
+  derive in this crate would let the wire format and the domain model start
+  deciding each other, which is exactly what ADR-0009 exists to prevent.
+- **No node, transport, or storage implementation.** A validator client, a gRPC
+  or JSON-RPC stack, a database — these belong at the boundaries that own them,
+  never in the vocabulary every boundary shares.
+
+A **protocol-specification** library is admissible, on one condition: its API is
+**fully contained** — no type of its own appears in any public signature,
+re-export, or public error of this crate. Validation happens inside; everything
+exposed is ours. `zcash_address` is the first such dependency, used by
+[`TransparentAddress`](src/types/transparent_address.rs) to decide whether a
+string is a valid transparent address. The alternative was to hand-roll
+Base58Check and SHA-256 here, which buys risk, not ownership: the address
+encoding *is* the protocol, and the spec-steward's parser is the spec artifact,
+so re-implementing it would mean maintaining a second, drift-prone copy of a
+consensus rule. We take the parser and keep its types off our surface — the
+containment condition is what makes that a domain decision expressed in our own
+vocabulary rather than a leak of theirs.
+
+Serialization, by contrast, lives at the boundary that owns the format:
 
 | direction | who owns the format |
 |---|---|
@@ -57,12 +79,19 @@ Types enforce what they claim:
 let h = Height::try_from(800_000u32)?;   // rejects above 2^31 - 1
 let z = Zatoshis::new(21_000_000)?;      // rejects out-of-range amounts
 let b = Block::try_new(header, txs, chain_metadata)?; // rejects an empty tx list
+let a = TransparentAddress::try_new(s)?; // rejects non-transparent / undecodable
 ```
 
 A transaction's position is the block's to know, not the transaction's:
 `Transaction` stores no index, and coinbase-ness is read from block order via
 `Block::coinbase()` (position 0), never from a per-transaction field that could
 disagree with the container.
+
+`TransparentAddress` is network-blind on construction: it accepts a valid
+transparent address for any network and reports which one via `network()` (an
+`AddressNetwork`) and the script form via `script_type()`. The primitive states
+what the address *is*; whether that network is the one a query should act on is
+the consumer's policy, not the address's invariant.
 
 `Height::checked_add` / `checked_sub` are checked, not wrapping. Prefer
 expressing an invariant in the type over asserting it at a call site — the

--- a/packages/zaino-serve/src/rpc/jsonrpc/wire/address_deltas.rs
+++ b/packages/zaino-serve/src/rpc/jsonrpc/wire/address_deltas.rs
@@ -44,40 +44,64 @@ impl GetAddressDeltasParams {
         GetAddressDeltasParams::Address(addr.into())
     }
 
-    /// Reads the client's request into the domain vocabulary.
+    /// Reads and validates the client's request into the domain vocabulary.
     ///
-    /// Infallible, unlike the other request conversions in this module. The two
-    /// things that could be rejected here are not rejected by this interface:
-    /// the height range is open-ended by design — the legacy full node reads `0` in either
-    /// position as "unbounded" — and is resolved against the tip by the
-    /// answering adapter, which is the only layer that knows the tip; and
-    /// [`TransparentAddress`](zaino_primitives::types::TransparentAddress) is
-    /// an opaque string, so there is nothing to parse.
+    /// The client supplies the addresses as strings, so this is the
+    /// external-input validation step for them:
+    /// [`TransparentAddress::try_new`](zaino_primitives::types::TransparentAddress::try_new)
+    /// rejects anything that is not a well-formed transparent address, and the
+    /// rejection surfaces as an invalid-params error at the endpoint rather than
+    /// letting a bogus filter string reach the index.
     ///
-    /// Validating the addresses here is now possible — `zaino-address` can
-    /// classify them — but it would start rejecting requests this method
-    /// currently answers with an empty list, which is a served-behaviour change
-    /// and does not belong in a rewire.
-    pub fn into_domain(self) -> zaino_primitives::types::rpc::AddressDeltasRequest {
+    /// The height range is not validated here: it is open-ended by design — the
+    /// legacy full node reads `0` in either position as "unbounded" — and is
+    /// resolved against the tip by the answering adapter, the only layer that
+    /// knows the tip.
+    pub fn into_domain(
+        self,
+    ) -> Result<zaino_primitives::types::rpc::AddressDeltasRequest, GetAddressDeltasError> {
         use zaino_primitives::types::{rpc::AddressDeltasRequest, TransparentAddress};
 
+        let parse = |address: String| {
+            TransparentAddress::try_new(address.clone()).map_err(|reason| {
+                GetAddressDeltasError::Address {
+                    address,
+                    reason: reason.to_string(),
+                }
+            })
+        };
+
         match self {
-            Self::Address(address) => {
-                AddressDeltasRequest::Address(TransparentAddress::new(address))
-            }
+            Self::Address(address) => Ok(AddressDeltasRequest::Address(parse(address)?)),
             Self::Filtered {
                 addresses,
                 start,
                 end,
                 chain_info,
-            } => AddressDeltasRequest::Filtered {
-                addresses: addresses.into_iter().map(TransparentAddress::new).collect(),
+            } => Ok(AddressDeltasRequest::Filtered {
+                addresses: addresses
+                    .into_iter()
+                    .map(parse)
+                    .collect::<Result<Vec<_>, _>>()?,
                 start,
                 end,
                 chain_info,
-            },
+            }),
         }
     }
+}
+
+/// Why a [`GetAddressDeltasParams`] could not be understood.
+#[derive(Debug, thiserror::Error)]
+pub enum GetAddressDeltasError {
+    /// A requested address is not a valid transparent address.
+    #[error("invalid transparent address {address:?}: {reason}")]
+    Address {
+        /// The offending string as the client sent it.
+        address: String,
+        /// Why it was rejected.
+        reason: String,
+    },
 }
 
 /// Response to a `getaddressdeltas` RPC request.
@@ -220,6 +244,12 @@ mod domain_tests {
     use super::*;
     use zaino_primitives::types::{self as domain, Height, SignedZatoshis, TransparentAddress};
 
+    // Real vectors (mainnet t1 / t3, testnet tm), so the addresses that reach
+    // the domain are the ones the validating constructor accepts.
+    const MAINNET_P2PKH: &str = "t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs";
+    const TESTNET_P2PKH: &str = "tmVqEASZxBNKFTbmASZikGa5fPLkd68iJyx";
+    const TESTNET_P2SH: &str = "t2MjoXQ2iDrjG9QXNZNCY9io8ecN4FJYK1u";
+
     /// Asymmetric under reversal, so a missing or doubled byte-reversal shows up.
     const ASYMMETRIC: [u8; 32] = [
         0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee,
@@ -233,7 +263,7 @@ mod domain_tests {
             txid: domain::TransactionId::from(ASYMMETRIC),
             index: 2,
             height: Height::try_from(99u32).unwrap(),
-            address: TransparentAddress::new("t1address".to_string()),
+            address: TransparentAddress::try_new(MAINNET_P2PKH).expect("valid mainnet t1"),
             block_index: Some(4),
         }
     }
@@ -256,7 +286,7 @@ mod domain_tests {
         assert_eq!(json[0]["satoshis"], -1_000i64);
         assert_eq!(json[0]["index"], 2);
         assert_eq!(json[0]["height"], 99);
-        assert_eq!(json[0]["address"], "t1address");
+        assert_eq!(json[0]["address"], MAINNET_P2PKH);
         assert_eq!(json[0]["blockindex"], 4);
     }
 
@@ -314,12 +344,13 @@ mod domain_tests {
     #[test]
     fn request_range_is_carried_through_unclamped() {
         let request = GetAddressDeltasParams::new_filtered(
-            vec!["t1a".to_string(), "t1b".to_string()],
+            vec![TESTNET_P2PKH.to_string(), TESTNET_P2SH.to_string()],
             0,
             0,
             true,
         )
-        .into_domain();
+        .into_domain()
+        .expect("both addresses are valid");
 
         let domain::rpc::AddressDeltasRequest::Filtered {
             addresses,
@@ -337,11 +368,35 @@ mod domain_tests {
     /// The single-address form has no range at all, and must not acquire one.
     #[test]
     fn single_address_request_stays_rangeless() {
-        let request = GetAddressDeltasParams::new_address("t1a").into_domain();
+        let request = GetAddressDeltasParams::new_address(TESTNET_P2PKH)
+            .into_domain()
+            .expect("a valid address");
 
         assert!(matches!(
             request,
             domain::rpc::AddressDeltasRequest::Address(_)
+        ));
+    }
+
+    /// A client-supplied string that is not a transparent address is rejected
+    /// at the boundary rather than reaching the index. This is the
+    /// security-relevant fix: the filter string is now validated input.
+    #[test]
+    fn a_bogus_address_is_rejected() {
+        assert!(matches!(
+            GetAddressDeltasParams::new_address("not an address").into_domain(),
+            Err(GetAddressDeltasError::Address { .. })
+        ));
+
+        assert!(matches!(
+            GetAddressDeltasParams::new_filtered(
+                vec![TESTNET_P2PKH.to_string(), "not an address".to_string()],
+                0,
+                0,
+                false,
+            )
+            .into_domain(),
+            Err(GetAddressDeltasError::Address { .. })
         ));
     }
 }

--- a/packages/zaino-serve/src/rpc/jsonrpc/wire/address_queries.rs
+++ b/packages/zaino-serve/src/rpc/jsonrpc/wire/address_queries.rs
@@ -9,15 +9,15 @@ use zebra_rpc::methods::{AddressBalance, GetAddressUtxos};
 
 /// A UTXO whose address the wire type cannot represent.
 ///
-/// [`TransparentAddress`](zaino_primitives::types::TransparentAddress) is an
-/// opaque string by design — the domain never inspects an address, it forwards
-/// it. Zebra's `GetAddressUtxos` holds a parsed `transparent::Address`, so
-/// rendering has to parse, and parsing can fail.
+/// A [`TransparentAddress`](zaino_primitives::types::TransparentAddress) is a
+/// validated transparent address, but Zebra's `GetAddressUtxos` holds a parsed
+/// `transparent::Address` of its own, so rendering re-parses with a second
+/// implementation, and that step is typed as fallible.
 ///
-/// In practice it cannot: the addresses in a response are the ones the caller
-/// asked about, echoed back by a validator that matched them. It is reported
-/// rather than asserted because the alternative is a panic on a value that came
-/// from outside this process.
+/// In practice it cannot fail: our constructor already accepted the string as a
+/// transparent address, and Zebra parses the same set. It is reported rather
+/// than asserted because the two parsers are separate implementations, and a
+/// disagreement between them is a reason to fail the query, not to panic.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[error("utxo address is not a valid transparent address: {0}")]
 pub struct UnrenderableUtxoAddress(String);
@@ -85,7 +85,7 @@ mod tests {
 
     fn utxo() -> Utxo {
         Utxo {
-            address: TransparentAddress::new(ADDRESS.to_string()),
+            address: TransparentAddress::try_new(ADDRESS).expect("valid testnet address"),
             txid: TransactionId::from(ASYMMETRIC),
             output_index: 2,
             script: Script::from(vec![0x76, 0xa9]),
@@ -143,11 +143,13 @@ mod tests {
         assert_eq!(json[0]["height"], 1_234);
     }
 
+    /// A malformed address is now rejected where it is *constructed*, not where
+    /// it is rendered: [`TransparentAddress`] cannot hold a non-address, so the
+    /// rendering path never receives one. What was once a render-time error
+    /// check is now a construction-time invariant, so the rejection is asserted
+    /// at the boundary that enforces it.
     #[test]
-    fn an_unparseable_address_is_reported_not_panicked_on() {
-        let mut utxo = utxo();
-        utxo.address = TransparentAddress::new("not an address".to_string());
-
-        assert!(address_utxos_from_domain(vec![utxo]).is_err());
+    fn a_malformed_address_is_rejected_at_construction() {
+        assert!(TransparentAddress::try_new("not an address").is_err());
     }
 }

--- a/packages/zaino-serve/src/rpc/jsonrpc/wire/block_deltas.rs
+++ b/packages/zaino-serve/src/rpc/jsonrpc/wire/block_deltas.rs
@@ -219,14 +219,16 @@ mod tests {
                 txid: domain::TransactionId::from(ASYMMETRIC),
                 index: 1,
                 inputs: vec![domain::rpc::InputDelta {
-                    address: TransparentAddress::new("t1spender".to_string()),
+                    address: TransparentAddress::try_new("t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs")
+                        .expect("valid mainnet t1"),
                     satoshis: SignedZatoshis::try_new(-5_000).expect("within the supply"),
                     index: 0,
                     prev_txid: domain::TransactionId::from([0xbb; 32]),
                     prev_output: 3,
                 }],
                 outputs: vec![domain::rpc::OutputDelta {
-                    address: TransparentAddress::new("t1payee".to_string()),
+                    address: TransparentAddress::try_new("t3JZcvsuaXE6ygokL4XUiZSTrQBUoPYFnXJ")
+                        .expect("valid mainnet t3"),
                     satoshis: Zatoshis::new(5_000).unwrap(),
                     index: 0,
                 }],

--- a/packages/zaino-serve/src/rpc/jsonrpc/wire/misc.rs
+++ b/packages/zaino-serve/src/rpc/jsonrpc/wire/misc.rs
@@ -300,7 +300,10 @@ mod tests {
                 asm: Some("OP_DUP OP_HASH160".to_string()),
                 script_type: Some("pubkeyhash".to_string()),
                 required_signatures: Some(1),
-                addresses: vec![TransparentAddress::new("t1abc".to_string())],
+                addresses: vec![
+                    TransparentAddress::try_new("t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs")
+                        .expect("valid mainnet t1"),
+                ],
             },
             coinbase: true,
         }));
@@ -316,7 +319,7 @@ mod tests {
                     "asm": "OP_DUP OP_HASH160",
                     "type": "pubkeyhash",
                     "reqSigs": 1,
-                    "addresses": ["t1abc"],
+                    "addresses": ["t1Hsc1LR8yKnbbe3twRp88p6vFfC5t7DLbs"],
                 },
                 "coinbase": true,
             })

--- a/packages/zaino-source-zebra-readstate/src/adapter.rs
+++ b/packages/zaino-source-zebra-readstate/src/adapter.rs
@@ -60,6 +60,18 @@ fn unexpected_response(request: &'static str) -> FetchError {
     )
 }
 
+/// Validate a transparent address string from the state service.
+///
+/// Zebra derives these from outputs in its own validated indexes, so the string
+/// is expected to parse; a rejection is corrupt state-service data, surfaced as
+/// a parse failure rather than swallowed.
+fn transparent_address(
+    encoded: String,
+) -> Result<zaino_primitives::types::TransparentAddress, FetchError> {
+    zaino_primitives::types::TransparentAddress::try_new(encoded)
+        .map_err(|e| FetchError::new(FailureMode::Parse, e.to_string()))
+}
+
 /// The state service returned rows out of order.
 ///
 /// Zebra's address indexes are documented as ordered, and Zaino relies on that
@@ -423,7 +435,7 @@ impl zaino_source::OneShotGetAddressUtxos for ZebraReadStateAdapter {
         addresses: Vec<String>,
     ) -> Result<Vec<zaino_primitives::types::Utxo>, QueryError<zaino_source::GetAddressUtxosError>>
     {
-        use zaino_primitives::types::{Script, TransparentAddress, Utxo, Zatoshis};
+        use zaino_primitives::types::{Script, Utxo, Zatoshis};
 
         let valid = parse_addresses(addresses)?;
 
@@ -454,7 +466,7 @@ impl zaino_source::OneShotGetAddressUtxos for ZebraReadStateAdapter {
             previous = *location;
 
             result.push(Utxo {
-                address: TransparentAddress::new(address.to_string()),
+                address: transparent_address(address.to_string())?,
                 txid: zaino_primitives::types::TransactionId::from(txid.0),
                 output_index: location.output_index().index(),
                 script: Script::new(output.lock_script.as_raw_bytes().to_vec()),
@@ -561,9 +573,7 @@ impl zaino_source::OneShotGetAddressDeltas for ZebraReadStateAdapter {
         Vec<zaino_primitives::types::AddressDelta>,
         QueryError<zaino_source::GetAddressDeltasError>,
     > {
-        use zaino_primitives::types::{
-            AddressDelta, SignedZatoshis, TransactionId, TransparentAddress,
-        };
+        use zaino_primitives::types::{AddressDelta, SignedZatoshis, TransactionId};
 
         if start > end {
             return Err(QueryError::Domain(
@@ -627,7 +637,7 @@ impl zaino_source::OneShotGetAddressDeltas for ZebraReadStateAdapter {
                     txid: delta_txid,
                     index: index as u32,
                     height,
-                    address: TransparentAddress::new(address),
+                    address: transparent_address(address)?,
                     block_index: Some(u32::from(location.index.index())),
                 });
             }
@@ -1260,7 +1270,7 @@ impl zaino_source::OneShotGetBlockDeltas for ZebraReadStateAdapter {
     > {
         use zaino_primitives::types::{
             rpc::{BlockDelta, BlockDeltas, InputDelta, OutputDelta},
-            MerkleRoot, SignedZatoshis, TransactionId, TransparentAddress, Zatoshis,
+            MerkleRoot, SignedZatoshis, TransactionId, Zatoshis,
         };
         use zebra_chain::serialization::ZcashSerialize as _;
 
@@ -1337,7 +1347,7 @@ impl zaino_source::OneShotGetBlockDeltas for ZebraReadStateAdapter {
                 };
 
                 inputs.push(InputDelta {
-                    address: TransparentAddress::new(address.to_string()),
+                    address: transparent_address(address.to_string())?,
                     // A spend debits the address, so the value leaves it.
                     satoshis: SignedZatoshis::try_new(-output.value.zatoshis())
                         .map_err(|e| parse(e.to_string()))?,
@@ -1353,7 +1363,7 @@ impl zaino_source::OneShotGetBlockDeltas for ZebraReadStateAdapter {
                     continue;
                 };
                 outputs.push(OutputDelta {
-                    address: TransparentAddress::new(address.to_string()),
+                    address: transparent_address(address.to_string())?,
                     satoshis: Zatoshis::new(u64::from(output.value))
                         .map_err(|e| parse(e.to_string()))?,
                     index: index as u32,

--- a/packages/zaino-source-zebra-rpc/src/parse.rs
+++ b/packages/zaino-source-zebra-rpc/src/parse.rs
@@ -104,6 +104,14 @@ pub(crate) fn as_height(value: &serde_json::Value) -> Result<Height, ParseError>
     Height::try_from(h).map_err(|e| ParseError::Height(e.to_string()))
 }
 
+/// A transparent address. The validator's string is expected to be a valid
+/// transparent address, so a rejection here is corrupt source data.
+pub(crate) fn as_transparent_address(
+    value: &serde_json::Value,
+) -> Result<TransparentAddress, ParseError> {
+    TransparentAddress::try_new(as_str(value)?).map_err(|e| ParseError::Address(e.to_string()))
+}
+
 // ---------------------------------------------------------------------------
 // 32-byte values
 //
@@ -306,6 +314,9 @@ pub(crate) enum ParseError {
     /// A monetary amount was invalid or out of range.
     #[error("invalid amount: {0}")]
     Amount(String),
+
+    #[error("invalid transparent address: {0}")]
+    Address(String),
 
     /// Block deserialization failed.
     #[error("deserialize: {0}")]
@@ -586,9 +597,7 @@ pub(crate) fn parse_tx_out(value: &serde_json::Value) -> Result<Option<TxOut>, P
                 .map(|v| as_str(v).map(str::to_owned))
                 .transpose()?,
             required_signatures: opt_field(script, "reqSigs").map(as_u32).transpose()?,
-            addresses: parse_optional_list(script, "addresses", |a| {
-                Ok(TransparentAddress::new(as_str(a)?.to_owned()))
-            })?,
+            addresses: parse_optional_list(script, "addresses", as_transparent_address)?,
         },
     }))
 }
@@ -637,7 +646,7 @@ pub(crate) fn parse_address_deltas(
                 txid: as_txid(field(d, "txid")?)?,
                 index: as_u32(field(d, "index")?)?,
                 height: as_height(field(d, "height")?)?,
-                address: TransparentAddress::new(as_str(field(d, "address")?)?.to_owned()),
+                address: as_transparent_address(field(d, "address")?)?,
                 // the legacy full node emits `blockindex`; a validator that does not is
                 // reported as not knowing it rather than as position zero.
                 block_index: match opt_field(d, "blockindex") {
@@ -655,7 +664,7 @@ pub(crate) fn parse_address_utxos(value: &serde_json::Value) -> Result<Vec<Utxo>
         .iter()
         .map(|u| {
             Ok(Utxo {
-                address: TransparentAddress::new(as_str(field(u, "address")?)?.to_owned()),
+                address: as_transparent_address(field(u, "address")?)?,
                 txid: as_txid(field(u, "txid")?)?,
                 output_index: as_u32(field(u, "outputIndex")?)?,
                 script: Script::new(
@@ -1066,7 +1075,7 @@ pub(crate) fn parse_block_deltas(value: &serde_json::Value) -> Result<BlockDelta
                 index: as_u32(field(d, "index")?)?,
                 inputs: parse_optional_list(d, "inputs", |i| {
                     Ok(InputDelta {
-                        address: TransparentAddress::new(as_str(field(i, "address")?)?.to_owned()),
+                        address: as_transparent_address(field(i, "address")?)?,
                         satoshis: SignedZatoshis::try_new(as_i64(field(i, "satoshis")?)?)
                             .map_err(|e| ParseError::Amount(e.to_string()))?,
                         index: as_u32(field(i, "index")?)?,
@@ -1076,7 +1085,7 @@ pub(crate) fn parse_block_deltas(value: &serde_json::Value) -> Result<BlockDelta
                 })?,
                 outputs: parse_optional_list(d, "outputs", |o| {
                     Ok(OutputDelta {
-                        address: TransparentAddress::new(as_str(field(o, "address")?)?.to_owned()),
+                        address: as_transparent_address(field(o, "address")?)?,
                         satoshis: Zatoshis::new(as_u64(field(o, "satoshis")?)?)
                             .map_err(|e| ParseError::Amount(e.to_string()))?,
                         index: as_u32(field(o, "index")?)?,

--- a/packages/zaino-state/src/chain_index/source/mockchain_source.rs
+++ b/packages/zaino-state/src/chain_index/source/mockchain_source.rs
@@ -1155,7 +1155,8 @@ impl zaino_source::OneShotGetAddressUtxos for MockchainSource {
             .into_iter()
             .map(|(_, output)| {
                 Ok(domain::Utxo {
-                    address: domain::TransparentAddress::new(output.address.to_string()),
+                    address: domain::TransparentAddress::try_new(output.address.to_string())
+                        .map_err(|e| port_fault(e.to_string()))?,
                     txid: domain::TransactionId::from(output.transaction_hash.0),
                     output_index: output.output_index,
                     script: domain::Script::new(output.output.lock_script.as_raw_bytes().to_vec()),
@@ -1220,7 +1221,8 @@ impl MockchainSource {
         let output = prev.outputs().get(outpoint.index as usize)?;
         let address = output.address(network)?;
         Some((
-            domain::TransparentAddress::new(address.to_string()),
+            domain::TransparentAddress::try_new(address.to_string())
+                .expect("zebra derived this address from the output, so it is well-formed"),
             u64::from(output.value()),
         ))
     }
@@ -1270,7 +1272,8 @@ impl zaino_source::OneShotGetBlockDeltas for MockchainSource {
                     continue;
                 };
                 outputs.push(domain::rpc::OutputDelta {
-                    address: domain::TransparentAddress::new(address.to_string()),
+                    address: domain::TransparentAddress::try_new(address.to_string())
+                        .map_err(|e| port_fault(e.to_string()))?,
                     satoshis: domain::Zatoshis::new(u64::from(output.value()))
                         .map_err(|e| port_fault(e.to_string()))?,
                     index: output_index as u32,
@@ -1364,7 +1367,8 @@ impl zaino_source::OneShotGetAddressDeltas for MockchainSource {
                     index: output_index as u32,
                     height: domain::Height::try_from(height.0)
                         .map_err(|e| port_fault(e.to_string()))?,
-                    address: domain::TransparentAddress::new(address),
+                    address: domain::TransparentAddress::try_new(address)
+                        .map_err(|e| port_fault(e.to_string()))?,
                     block_index: Some(*block_index as u32),
                 });
             }

--- a/packages/zaino-state/src/chain_index/tests/mockchain_tests.rs
+++ b/packages/zaino-state/src/chain_index/tests/mockchain_tests.rs
@@ -807,7 +807,10 @@ fn filtered_deltas_request(
     AddressDeltasRequest::Filtered {
         addresses: addresses
             .into_iter()
-            .map(zaino_primitives::types::TransparentAddress::new)
+            .map(|address| {
+                zaino_primitives::types::TransparentAddress::try_new(address)
+                    .expect("test address is a valid transparent address")
+            })
             .collect(),
         start,
         end,
@@ -881,15 +884,14 @@ async fn get_address_deltas() {
         }
     }
 
-    let invalid_address_result = index_reader
-        .get_address_deltas(AddressDeltasRequest::Address(
-            zaino_primitives::types::TransparentAddress::new(
-                "not_a_valid_transparent_address".to_string(),
-            ),
-        ))
-        .await;
-
-    assert!(invalid_address_result.is_err());
+    // An invalid address is now rejected when the request is built — a
+    // `TransparentAddress` cannot hold a non-address — so a bogus filter string
+    // never reaches the index. The rejection this test used to observe at the
+    // query has moved down to the type's constructor, where it is asserted.
+    assert!(zaino_primitives::types::TransparentAddress::try_new(
+        "not_a_valid_transparent_address"
+    )
+    .is_err());
 
     assert!(
         active_height > 0,


### PR DESCRIPTION
## Summary

Stacked on #1509. Final Tier-1 item of the primitives invariance audit:
transparent address validation.

`TransparentAddress(String)` had an unchecked `new()` while its doc claimed a
validated address — so a client-supplied filter string, and literally
`TransparentAddress::new("not an address")`, entered the domain unvalidated.
It now parses at construction:

- `TransparentAddress::try_new(impl Into<String>) -> Result<Self, TransparentAddressError>`
  parses via the `zcash_address` protocol library, accepts only transparent
  kinds (P2PKH / P2SH), and rejects shielded / unified / Sprout / TEX and
  undecodable strings (Base58Check incl. checksum) with typed reasons. The
  unchecked `new` is deleted.
- Network-blind: any Zcash network's transparent prefix parses; `network()`
  (new `AddressNetwork { Mainnet | Testnet | Regtest }` primitive) and
  `script_type()` (existing `ScriptType`) are decoded from the address. The
  primitive states what the address *is*; matching it to the running chain is
  the consumer's policy.
- **Containment is a hard rule**: no `zcash_address` (or `zcash_protocol`) type
  appears in any public signature, error, or re-export of `zaino-primitives`.
  The foreign crate lives only inside `try_new`'s body and a private conversion
  carrier. (`grep -rn zcash_address packages/zaino-primitives/src | grep -v
  'use \|//'` is empty.)
- The security-relevant migration: client input on the `getaddressdeltas` path
  (`wire/address_deltas.rs::into_domain`) is now fallible and rejects an invalid
  address as invalid-params instead of admitting it. Boundary parsers
  (zebra-rpc, readstate) construct through `try_new` with typed errors.

This amends the crate's historical "dependency list is `thiserror` only" rule.
The rule's intent survives — no serde, no node implementation, no transport —
but the letter now admits protocol-*specification* libraries when their API is
fully contained. Hand-rolling Base58Check + SHA-256 would buy risk, not
ownership; the spec steward's parser is the spec artifact. `usage.md` is
rewritten to state the refined rule.

Dependency delta: `zaino-primitives` gains `zcash_address` (+ its light no_std
deps: bech32, bs58, f4jumble, zcash_encoding, zcash_protocol) and
`zcash_protocol` (for `NetworkType`, not re-exported by `zcash_address`).

## Test plan

- `cargo fmt --check`, `cargo check --workspace --all-targets`,
  `cargo clippy --workspace -- -D warnings` and
  `cargo clippy --all-targets --all-features -- -D warnings` — all clean.
- `cargo nextest run`: zaino-primitives + zaino-source-zebra-rpc + zaino-serve
  213 passed; readstate 2; zaino-state address paths 17.
- Real address vectors (mainnet t1/t3, testnet tm/t2) accepted; garbage, a
  Sapling address, a unified address, a Sprout address, TEX, and a
  bad-checksum string rejected with typed errors.
- The old `"not an address"` value is no longer constructible; that test now
  asserts rejection at the boundary.
