### PR TITLE
zaino-primitives: coinbase by block position, not a denormalized Transaction.index

### DIFF
--- a/packages/zaino-chain-head-service/src/snapshot.rs
+++ b/packages/zaino-chain-head-service/src/snapshot.rs
@@ -21,8 +21,19 @@ use zaino_chain_head::{
 };
 use zaino_primitives::types::{
     rpc::{ChainTip, ChainTipStatus},
-    BlockHash, BlockRef, ChainStateEpoch, Height, Outpoint, TransactionId,
+    BlockHash, BlockRef, ChainStateEpoch, Height, Outpoint, TransactionId, TxIndex,
 };
+
+/// A transaction's block-order position, as a [`TxIndex`].
+///
+/// The slot is a `usize` from iterating the block's transactions; the position
+/// type is `u32`. A block's transaction count is bounded well below `u32::MAX`
+/// by the consensus block-size limit, so the narrowing cannot fail for any real
+/// block — the `expect` names that invariant rather than asserting a hope.
+fn tx_index(position: usize) -> TxIndex {
+    TxIndex::try_from(position)
+        .expect("a block's transaction count fits TxIndex; consensus bounds it below u32::MAX")
+}
 
 /// The retained graph, held in hash maps.
 ///
@@ -290,18 +301,19 @@ impl ChainHeadTransactionService for MapBackedSnapshot {
         let mut locations = ChainHeadTransactionLocations::default();
 
         for block in self.blocks.values() {
-            let Some(transaction) = block
+            let Some((slot, _transaction)) = block
                 .block
                 .transactions
                 .iter()
-                .find(|transaction| &transaction.txid == txid)
+                .enumerate()
+                .find(|(_, transaction)| &transaction.txid == txid)
             else {
                 continue;
             };
 
             let position = ChainHeadTxPosition {
                 block: block.reference,
-                tx_index: transaction.index,
+                tx_index: tx_index(slot),
             };
             if self.is_on_best_chain(block.reference) {
                 locations.best_chain = Some(position);
@@ -328,7 +340,7 @@ impl ChainHeadTransactionService for MapBackedSnapshot {
             let Some(block) = self.blocks.get(hash) else {
                 continue;
             };
-            for transaction in &block.block.transactions {
+            for (slot, transaction) in block.block.transactions.iter().enumerate() {
                 for input in &transaction.transparent.inputs {
                     spenders.insert(
                         Outpoint {
@@ -338,7 +350,7 @@ impl ChainHeadTransactionService for MapBackedSnapshot {
                         SpenderLocation {
                             block: block.reference,
                             txid: transaction.txid,
-                            tx_index: transaction.index,
+                            tx_index: tx_index(slot),
                         },
                     );
                 }

--- a/packages/zaino-chain-store-zainodb/src/conversion.rs
+++ b/packages/zaino-chain-store-zainodb/src/conversion.rs
@@ -93,6 +93,23 @@ pub enum BlockConversionError {
         reason: String,
     },
 
+    /// A transaction's position in the block does not fit the stored index
+    /// width.
+    ///
+    /// The block-order position is a `usize`; the stored compact form records
+    /// it as `u64`. Rejected rather than truncated for the same reason as the
+    /// tree sizes: a wrapped position would put a wrong index on disk. This
+    /// cannot happen for any real block — the block size limit bounds the
+    /// transaction count far below `u64::MAX` — but the conversion refuses it
+    /// rather than assert it away.
+    #[error("block {hash} has a transaction position that does not fit into u64: {position}")]
+    TxPositionOverflow {
+        /// The block that could not be converted.
+        hash: BlockHash,
+        /// The position that did not fit.
+        position: usize,
+    },
+
     /// A commitment tree has grown past what the stored form can record.
     ///
     /// The domain counts tree sizes in `u64` where the stored form uses `u32`.
@@ -171,7 +188,8 @@ pub fn indexed_block(
     let transactions = block
         .transactions
         .iter()
-        .map(|transaction| compact_transaction(transaction, hash))
+        .enumerate()
+        .map(|(position, transaction)| compact_transaction(position, transaction, hash))
         .collect::<Result<Vec<_>, _>>()?;
 
     let context = BlockContext::new(
@@ -283,14 +301,23 @@ pub fn commitment_tree_data(
     ))
 }
 
+/// `position` is the transaction's slot in block order, the sole authority for
+/// both its served index and its coinbase-ness. It is threaded in from the
+/// caller's `enumerate` rather than read off the transaction, which no longer
+/// stores it.
 fn compact_transaction(
+    position: usize,
     transaction: &Transaction,
     block: BlockHash,
 ) -> Result<CompactTxData, BlockConversionError> {
+    let index = u64::try_from(position).map_err(|_| BlockConversionError::TxPositionOverflow {
+        hash: block,
+        position,
+    })?;
     Ok(CompactTxData::new(
-        u64::from(transaction.index),
+        index,
         TransactionHash(transaction.txid.into()),
-        transparent(transaction, block)?,
+        transparent(position, transaction, block)?,
         sapling(transaction),
         orchard_shaped(&transaction.orchard),
         orchard_shaped(&transaction.ironwood),
@@ -299,13 +326,16 @@ fn compact_transaction(
 
 /// The transparent inputs and outputs, in stored compact form.
 ///
-/// The transaction at index 0 gets its null prevout back — see this module's
-/// header. Every other transaction's inputs are already complete.
+/// The transaction at position 0 — the coinbase — gets its null prevout back;
+/// see this module's header. Coinbase-ness is decided by block-order position,
+/// not by any field on the transaction. Every other transaction's inputs are
+/// already complete.
 fn transparent(
+    position: usize,
     transaction: &Transaction,
     block: BlockHash,
 ) -> Result<TransparentCompactTx, BlockConversionError> {
-    let is_coinbase = u64::from(transaction.index) == 0;
+    let is_coinbase = position == 0;
 
     let mut inputs: Vec<TxInCompact> =
         Vec::with_capacity(transaction.transparent.inputs.len() + usize::from(is_coinbase));
@@ -407,4 +437,72 @@ fn ciphertext_prefix(ciphertext: &zaino_primitives::types::EncryptedCiphertext) 
     let usable = bytes.len().min(52);
     prefix[..usable].copy_from_slice(&bytes[..usable]);
     prefix
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zaino_primitives::types::{TransactionId, TransparentData, TransparentInput};
+
+    fn tx_with_one_real_input() -> Transaction {
+        Transaction {
+            txid: TransactionId::from([7u8; 32]),
+            transparent: TransparentData {
+                inputs: vec![TransparentInput {
+                    prev_txid: TransactionId::from([9u8; 32]),
+                    prev_index: 3,
+                }],
+                outputs: Vec::new(),
+            },
+            sapling: Default::default(),
+            orchard: Default::default(),
+            ironwood: Default::default(),
+        }
+    }
+
+    /// The coinbase's synthesised null prevout keys on block-order position,
+    /// nothing on the transaction. The *same* transaction gets the null prevout
+    /// prepended at position 0 and does not at any other position — proof that
+    /// position is the sole coinbase authority now that the transaction stores
+    /// no index that could disagree.
+    #[test]
+    fn null_prevout_is_synthesised_by_position_not_by_a_field() {
+        let hash = BlockHash([0u8; 32]);
+        let transaction = tx_with_one_real_input();
+
+        let at_zero = transparent(0, &transaction, hash).expect("a compactable tx");
+        assert!(
+            at_zero.inputs()[0].is_null_prevout(),
+            "position 0 is the coinbase, so it gets the null prevout"
+        );
+        assert_eq!(
+            at_zero.inputs().len(),
+            2,
+            "null prevout precedes the one real input"
+        );
+        assert!(!at_zero.inputs()[1].is_null_prevout());
+
+        let at_one = transparent(1, &transaction, hash).expect("a compactable tx");
+        assert_eq!(
+            at_one.inputs().len(),
+            1,
+            "a non-coinbase keeps only its real inputs"
+        );
+        assert!(!at_one.inputs()[0].is_null_prevout());
+    }
+
+    /// The served compact index is the block-order position handed in, so a
+    /// block converted transaction-by-transaction reports each transaction's
+    /// slot as its index.
+    #[test]
+    fn served_index_is_the_position() {
+        let hash = BlockHash([0u8; 32]);
+        let transaction = tx_with_one_real_input();
+
+        for (position, expected) in [(0usize, 0u64), (1, 1), (42, 42)] {
+            let compact =
+                compact_transaction(position, &transaction, hash).expect("a compactable tx");
+            assert_eq!(compact.index(), expected);
+        }
+    }
 }

--- a/packages/zaino-convert-zebra/src/lib.rs
+++ b/packages/zaino-convert-zebra/src/lib.rs
@@ -19,6 +19,9 @@ pub enum ConvertError {
     /// A value exceeded protocol limits.
     #[error("value overflow: {0}")]
     Value(String),
+    /// The converted transactions did not form a valid block.
+    #[error("block: {0}")]
+    Block(String),
 }
 
 /// Convert a zebra block into a domain [`Block`].
@@ -31,16 +34,14 @@ pub fn block_from_zebra(
     zb: &zebra_chain::block::Block,
     chain_metadata: ChainMetadata,
 ) -> Result<Block, ConvertError> {
-    Ok(Block {
-        header: header_from_zebra(zb)?,
-        transactions: zb
-            .transactions
-            .iter()
-            .enumerate()
-            .map(|(i, tx)| transaction_from_zebra(tx, i as u32))
-            .collect::<Result<Vec<_>, _>>()?,
-        chain_metadata,
-    })
+    let header = header_from_zebra(zb)?;
+    let transactions = zb
+        .transactions
+        .iter()
+        .map(|tx| transaction_from_zebra(tx))
+        .collect::<Result<Vec<_>, _>>()?;
+    Block::try_new(header, transactions, chain_metadata)
+        .map_err(|e| ConvertError::Block(e.to_string()))
 }
 
 /// Convert just the header — skips all transaction parsing.
@@ -98,20 +99,19 @@ pub fn header_from_parts(
 
 /// Convert one zebra transaction into the domain's.
 ///
-/// `index` is the transaction's position within its block. A transaction with
-/// no block — a mempool transaction — passes `0`, matching what the light-wallet
-/// protocol serves for one.
+/// A transaction carries no position: its slot in a block, and so whether it is
+/// the coinbase, is the block's to know (see [`block_from_zebra`], which reads
+/// it from order). A mempool transaction is in no block and has no position to
+/// invent.
 ///
 /// Public because the mempool stream converts a single transaction rather than
 /// a whole block; every other caller reaches this through
 /// [`block_from_zebra`].
 pub fn transaction_from_zebra(
     tx: &zebra_chain::transaction::Transaction,
-    index: u32,
 ) -> Result<Transaction, ConvertError> {
     Ok(Transaction {
         txid: TransactionId::from(tx.hash().0),
-        index,
         transparent: transparent_from_zebra(tx)?,
         sapling: sapling_from_zebra(tx)?,
         orchard: orchard_from_zebra(tx)?,

--- a/packages/zaino-convert-zebra/usage.md
+++ b/packages/zaino-convert-zebra/usage.md
@@ -7,14 +7,20 @@
 ```rust
 use zaino_convert_zebra::{block_from_zebra, header_from_zebra, transaction_from_zebra};
 
-let block = block_from_zebra(&zebra_block, height)?;
-let tx = transaction_from_zebra(&zebra_tx, index_in_block)?;
+let block = block_from_zebra(&zebra_block, chain_metadata)?;
+let tx = transaction_from_zebra(&zebra_tx)?;
 ```
 
 All conversions return `Result<_, ConvertError>`. They are fallible because
 `zebra-chain` types can hold values the domain types reject — a height above the
 protocol maximum, an amount outside the valid range — and that check is the
-point of the boundary, not an inconvenience at it.
+point of the boundary, not an inconvenience at it. `block_from_zebra` also
+rejects a block with no transactions, since a block always mines a coinbase.
+
+A transaction carries no block position. Whether it is the coinbase is read from
+its slot in the block — `block_from_zebra` builds the transaction list in order,
+and `Block::coinbase()` names position 0 — so `transaction_from_zebra` takes no
+index. A mempool transaction is in no block and has no position to supply.
 
 ## Why a separate crate
 

--- a/packages/zaino-primitives/src/types.rs
+++ b/packages/zaino-primitives/src/types.rs
@@ -45,7 +45,7 @@ pub use aliases::{
     BlockTime, CompactDifficulty, Confirmations, Difficulty, EquihashNonce, OutputIndex,
     SubtreeIndex, TreeSize, TxIndex,
 };
-pub use block::{Block, BlockHeader, ChainMetadata};
+pub use block::{Block, BlockError, BlockHeader, ChainMetadata};
 pub use block_commitments::BlockCommitments;
 pub use block_hash::BlockHash;
 pub use block_ref::BlockRef;

--- a/packages/zaino-primitives/src/types/block.rs
+++ b/packages/zaino-primitives/src/types/block.rs
@@ -42,6 +42,14 @@ pub struct BlockHeader {
 /// This is the domain-level block — not a wire format. Adapters
 /// parse from their wire format (hex RPC, ReadState, etc.) into
 /// this type. Indexes extract from it via `ProvideContext`.
+///
+/// Transaction position is the block's to know, not the transaction's: a
+/// transaction's slot — and so whether it is the coinbase — is read from the
+/// order of [`transactions`](Self::transactions), with [`coinbase`](Self::coinbase)
+/// as the named accessor for position 0. Prefer [`try_new`](Self::try_new) over a
+/// struct literal: it rejects an empty transaction list, the one whole-block
+/// invariant that outlives the removal of the per-transaction index (a block
+/// always contains at least its coinbase).
 #[derive(Debug, Clone)]
 pub struct Block {
     /// Block header.
@@ -50,6 +58,48 @@ pub struct Block {
     pub transactions: Vec<Transaction>,
     /// Commitment tree metadata after this block.
     pub chain_metadata: ChainMetadata,
+}
+
+/// A [`Block`] could not be constructed from the given parts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum BlockError {
+    /// The transaction list was empty. Every block mines a coinbase, so a
+    /// block with no transactions is malformed.
+    #[error("block has no transactions; a block must contain at least the coinbase")]
+    NoTransactions,
+}
+
+impl Block {
+    /// Assemble a block from its parts, rejecting a malformed transaction list.
+    ///
+    /// The only check is non-emptiness: a block always contains at least its
+    /// coinbase. With transaction position derived from list order rather than
+    /// stored per transaction, there is no index-versus-slot agreement left to
+    /// validate — the order *is* the position.
+    pub fn try_new(
+        header: BlockHeader,
+        transactions: Vec<Transaction>,
+        chain_metadata: ChainMetadata,
+    ) -> Result<Self, BlockError> {
+        if transactions.is_empty() {
+            return Err(BlockError::NoTransactions);
+        }
+        Ok(Self {
+            header,
+            transactions,
+            chain_metadata,
+        })
+    }
+
+    /// The coinbase transaction — the first in block order.
+    ///
+    /// Position is the sole authority for coinbase-ness: the coinbase is
+    /// consensus-guaranteed to be transaction 0. Returns `None` only for an
+    /// empty transaction list, which [`try_new`](Self::try_new) rejects at
+    /// construction.
+    pub fn coinbase(&self) -> Option<&Transaction> {
+        self.transactions.first()
+    }
 }
 
 /// Chain-level metadata attached to a block.
@@ -66,4 +116,77 @@ pub struct ChainMetadata {
     pub orchard_tree_size: u32,
     /// Cumulative Ironwood note commitment tree size after this block (NU6.3).
     pub ironwood_tree_size: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{EquihashSolution, Height, TransactionId};
+
+    fn header() -> BlockHeader {
+        BlockHeader {
+            hash: [0u8; 32].into(),
+            version: 4,
+            prev_hash: [0u8; 32].into(),
+            height: Height::try_from(1).expect("a valid height"),
+            time: 0,
+            merkle_root: [0u8; 32].into(),
+            block_commitments: [0u8; 32].into(),
+            bits: 0,
+            nonce: [0u8; 32],
+            solution: EquihashSolution::Regtest([0u8; 36]),
+        }
+    }
+
+    fn chain_metadata() -> ChainMetadata {
+        ChainMetadata {
+            sapling_tree_size: 0,
+            orchard_tree_size: 0,
+            ironwood_tree_size: 0,
+        }
+    }
+
+    fn tx(tag: u8) -> Transaction {
+        Transaction {
+            txid: TransactionId::from([tag; 32]),
+            transparent: Default::default(),
+            sapling: Default::default(),
+            orchard: Default::default(),
+            ironwood: Default::default(),
+        }
+    }
+
+    #[test]
+    fn try_new_rejects_an_empty_transaction_list() {
+        let result = Block::try_new(header(), Vec::new(), chain_metadata());
+
+        assert_eq!(result.unwrap_err(), BlockError::NoTransactions);
+    }
+
+    #[test]
+    fn try_new_accepts_a_block_with_a_coinbase() {
+        let block = Block::try_new(header(), vec![tx(0), tx(1)], chain_metadata())
+            .expect("a non-empty block is valid");
+
+        assert_eq!(block.transactions.len(), 2);
+    }
+
+    /// Coinbase-ness is positional: the coinbase is transaction 0, read from
+    /// block order, never from a field on the transaction. A block whose
+    /// transactions are supplied in some order reports whatever sits at
+    /// position 0 as its coinbase — there is no stored index that could name a
+    /// different one.
+    #[test]
+    fn coinbase_is_the_first_transaction_by_position() {
+        let coinbase = tx(0xcb);
+        let coinbase_txid = coinbase.txid;
+
+        let block = Block::try_new(header(), vec![coinbase, tx(0x11)], chain_metadata())
+            .expect("a non-empty block is valid");
+
+        assert_eq!(
+            block.coinbase().expect("a non-empty block has a coinbase").txid,
+            coinbase_txid
+        );
+    }
 }

--- a/packages/zaino-primitives/src/types/block.rs
+++ b/packages/zaino-primitives/src/types/block.rs
@@ -185,7 +185,10 @@ mod tests {
             .expect("a non-empty block is valid");
 
         assert_eq!(
-            block.coinbase().expect("a non-empty block has a coinbase").txid,
+            block
+                .coinbase()
+                .expect("a non-empty block has a coinbase")
+                .txid,
             coinbase_txid
         );
     }

--- a/packages/zaino-primitives/src/types/compact_block.rs
+++ b/packages/zaino-primitives/src/types/compact_block.rs
@@ -144,7 +144,6 @@ mod tests {
     fn compact_conversion_keeps_ironwood_and_orchard_apart() {
         let tx = Transaction {
             txid: [0; 32].into(),
-            index: 0,
             transparent: Default::default(),
             sapling: Default::default(),
             orchard: OrchardData {

--- a/packages/zaino-primitives/src/types/transaction.rs
+++ b/packages/zaino-primitives/src/types/transaction.rs
@@ -2,10 +2,17 @@
 
 use super::{
     EncryptedCiphertext, EphemeralKey, NoteCommitment, Nullifier, OutputIndex, Script,
-    SignedZatoshis, TransactionId, TxIndex, Zatoshis,
+    SignedZatoshis, TransactionId, Zatoshis,
 };
 
 /// A transaction within a block.
+///
+/// A transaction carries no position field. Its slot in the block — and so
+/// whether it is the coinbase (position 0) — is a property of the
+/// [`Block`](super::Block) that holds it, read from the order of
+/// [`Block::transactions`](super::Block::transactions), never restated here.
+/// A `Transaction` outside a block (a mempool transaction) has no position at
+/// all, so there is no value to invent for one.
 #[derive(Debug, Clone)]
 pub struct Transaction {
     /// Transaction id.
@@ -14,8 +21,6 @@ pub struct Transaction {
     /// - In pre V5 transactions this is the transaction hash (sha256 of serialized tx).
     /// - From V5 onwards this field is the transaction ID (as defined in [zip 224](https://github.com/zcash/zips/blob/main/zips/zip-0244.rst).
     pub txid: TransactionId,
-    /// Position within the block (0-indexed).
-    pub index: TxIndex,
     /// Transparent pool data.
     pub transparent: TransparentData,
     /// Sapling pool data.

--- a/packages/zaino-primitives/usage.md
+++ b/packages/zaino-primitives/usage.md
@@ -56,7 +56,13 @@ Types enforce what they claim:
 ```rust
 let h = Height::try_from(800_000u32)?;   // rejects above 2^31 - 1
 let z = Zatoshis::new(21_000_000)?;      // rejects out-of-range amounts
+let b = Block::try_new(header, txs, chain_metadata)?; // rejects an empty tx list
 ```
+
+A transaction's position is the block's to know, not the transaction's:
+`Transaction` stores no index, and coinbase-ness is read from block order via
+`Block::coinbase()` (position 0), never from a per-transaction field that could
+disagree with the container.
 
 `Height::checked_add` / `checked_sub` are checked, not wrapping. Prefer
 expressing an invariant in the type over asserting it at a call site — the

--- a/packages/zaino-state/src/indexer/node_backed_indexer.rs
+++ b/packages/zaino-state/src/indexer/node_backed_indexer.rs
@@ -1741,10 +1741,12 @@ impl<Source: BlockchainSource + WithChainHeadSource + WithChainStoreSource> Ligh
                                         ))
                                     })
                                     .and_then(|transaction| {
-                                        // Index 0: a mempool transaction is in no
-                                        // block, and this field is its position
-                                        // within one.
-                                        zaino_convert_zebra::transaction_from_zebra(&transaction, 0)
+                                        // A mempool transaction is in no block, so
+                                        // it carries no position. The served
+                                        // `CompactTx.index` is set to 0 at the
+                                        // proto boundary (`compact_tx_to_proto`),
+                                        // not on the domain type.
+                                        zaino_convert_zebra::transaction_from_zebra(&transaction)
                                             .map_err(|e| tonic::Status::unknown(e.to_string()))
                                     })
                                     .map(|transaction| {


### PR DESCRIPTION
## Summary

Worklist item #9 / bundle-invariance audit **B1**: the coinbase was detected
from a denormalized, self-synthesized field that could silently disagree with
block order. This drops the field and makes position the sole authority.

`Transaction.index` ("position within the block") was **not** a canonical
value — we set it ourselves from `.enumerate()` on the block path, and passed a
placeholder `0` on the mempool path (a lone tx has no block position). Two
authorities then read it: `conversion.rs:308` decided coinbase-ness via
`index == 0` (and synthesized the coinbase null prevout from it), while
`convert-zebra` dropped coinbase inputs by zebra's real `Input::Coinbase`
discriminant — coupled only by the unenforced `.enumerate()` assumption. A
reordered or hand-built block would silently misclassify the coinbase.

- **`Transaction.index` is dropped.** Position is derived from block order at
  the one place that iterates the transactions.
- **Coinbase-ness is positional**: `conversion.rs` now threads the enumerate
  position into `compact_transaction`, and `is_coinbase = position == 0` drives
  the null-prevout synthesis. The served `CompactTxData` index is that same
  position (checked `u64::try_from`, typed `TxPositionOverflow`). One authority
  replaces stored-field-plus-re-derivation.
- **`Block::try_new(...) -> Result<_, BlockError>`** rejects an empty
  transaction list (a block must contain at least the coinbase — previously
  only checked deep in the store), and **`Block::coinbase()`** is the named
  positional accessor. `block_from_zebra` returns `Block::try_new(...)`.
- The mempool served index already lives at the serialization boundary
  (`CompactTx.index = 0` in `compact_tx_to_proto`), independent of the domain
  type — the discarded placeholder is gone.

Swept every reader of the domain `Transaction`'s `.index`: five sites, all in
block-iteration contexts (incl. two in chain-head `snapshot.rs` not in the
original brief), so no standalone consumer depended on the field — the drop is
safe. `BlockDelta.index` (same shape, no divergent production reader) is left
for a follow-up; `InputDelta`/`OutputDelta.index` are vin/vout indices over
filtered vecs, not positions, and are correctly untouched.

## Test plan

- `cargo fmt --check`, `cargo check --workspace --all-targets`,
  `cargo clippy --workspace -- -D warnings` (+ `--all-targets`) — clean.
- `cargo nextest run`: primitives + convert-zebra + zainodb + chain-head-service
  231 passed; zaino-state 131 passed.
- New tests: empty block rejected; coinbase-is-first-by-position; null-prevout
  synthesis keyed on position not a field; served index == position.
