### PR TITLE
fix(relman): resolve the review findings pinned by the failing tests

### DIFF
--- a/.github/actions/cycle-ids/action.yml
+++ b/.github/actions/cycle-ids/action.yml
@@ -1,0 +1,63 @@
+name: Cycle ids
+description: >-
+  Derive the release-cycle identity from the existing git tags: the open
+  cycle N (the one a new rc or a blessing belongs to) and the next prerelease
+  number M within it. The checkout must have fetched all tags (fetch-depth: 0).
+  Two tag shapes carry the numbers: `cycle-<N>` (final, blessed) and
+  `cycle-<N>-rc.<M>` (deployment prerelease). Date-style ids such as
+  `cycle-2026-08-15` never match and are ignored.
+
+outputs:
+  open:
+    description: "The open cycle N: 1 with no cycle tags, hi+1 when `cycle-<hi>` is final, else hi."
+    value: ${{ steps.ids.outputs.open }}
+  next_rc:
+    description: "The next prerelease number M within the open cycle (max existing + 1, or 1)."
+    value: ${{ steps.ids.outputs.next_rc }}
+  last_rc_tag:
+    description: "The highest existing `cycle-<N>-rc.<M>` tag of the open cycle, or empty."
+    value: ${{ steps.ids.outputs.last_rc_tag }}
+
+runs:
+  using: composite
+  steps:
+    - name: Derive cycle ids from tags
+      id: ids
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # highest_cycle(): the max integer N seen across BOTH tag shapes, or
+        # empty when no cycle tags exist.
+        highest_cycle() {
+          git tag --list 'cycle-*' \
+            | sed -n 's/^cycle-\([0-9][0-9]*\)\(-rc\.[0-9][0-9]*\)\{0,1\}$/\1/p' \
+            | sort -n | tail -1
+        }
+        # open_cycle(): the cycle a NEW rc (or a blessing) belongs to.
+        open_cycle() {
+          hi="$(highest_cycle)"
+          if [ -z "$hi" ]; then
+            echo 1
+          elif git rev-parse -q --verify "refs/tags/cycle-${hi}" >/dev/null; then
+            echo $((hi + 1))
+          else
+            echo "$hi"
+          fi
+        }
+        # last_rc(N): the highest existing M of `cycle-<N>-rc.<M>`, or empty.
+        last_rc() {
+          git tag --list "cycle-${1}-rc.*" \
+            | sed -n "s/^cycle-${1}-rc\.\([0-9][0-9]*\)$/\1/p" \
+            | sort -n | tail -1
+        }
+
+        N="$(open_cycle)"
+        last="$(last_rc "$N")"
+        if [ -z "$last" ]; then M=1; last_tag=""; else M=$((last + 1)); last_tag="cycle-${N}-rc.${last}"; fi
+        echo "open cycle N=$N, next rc M=$M, last rc tag=${last_tag:-none}"
+        {
+          echo "open=$N"
+          echo "next_rc=$M"
+          echo "last_rc_tag=$last_tag"
+        } >> "$GITHUB_OUTPUT"

--- a/.github/actions/setup-relman/action.yml
+++ b/.github/actions/setup-relman/action.yml
@@ -9,6 +9,20 @@ description: >-
 runs:
   using: composite
   steps:
+    - name: Probe for cargo
+      id: probe
+      shell: bash
+      run: |
+        if command -v cargo >/dev/null 2>&1; then echo "has_cargo=true"; else echo "has_cargo=false"; fi >> "${GITHUB_OUTPUT}"
+
+    # Only the cargo fallback below benefits; a runner without cargo (the
+    # minimal changeset-check container) skips the cache entirely.
+    - name: Cache the relman build
+      if: steps.probe.outputs.has_cargo == 'true'
+      uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: tools/relman
+
     - name: Resolve relman onto PATH
       shell: bash
       run: |

--- a/.github/workflows/auto-tag-rc.yml
+++ b/.github/workflows/auto-tag-rc.yml
@@ -1,0 +1,44 @@
+# LEGACY tag producer for the pre-cutover release protocol (rc/<version>
+# branches). It stays live until the repo variable RELMAN_PIPELINE_ACTIVE is
+# set to true, at which point the release pipeline (rc-gate / blessing) owns
+# every tag and this workflow goes dormant. Delete it after the cutover.
+name: Auto RC Tag
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - 'rc/*'
+
+jobs:
+  auto-tag-rc:
+    if: github.event.pull_request.merged == true && vars.RELMAN_PIPELINE_ACTIVE != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Get next RC tag
+        id: tagger
+        run: |
+          VERSION=$(echo "${{ github.ref }}" | sed -E 's#refs/heads/rc/##')
+          PREFIX="$VERSION-rc"
+
+          echo "Looking for previous tags matching $PREFIX.*"
+          git fetch --tags
+
+          LATEST=$(git tag -l "$PREFIX.*" | sed -E "s/.*rc\.//" | sort -n | tail -1)
+          NEXT=$((LATEST + 1))
+          TAG="$PREFIX.$NEXT"
+
+          echo "TAG=$TAG" >> $GITHUB_OUTPUT
+
+      - name: Create and push tag
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@users.noreply.github.com
+          git tag ${{ steps.tagger.outputs.TAG }}
+          git push origin ${{ steps.tagger.outputs.TAG }}

--- a/.github/workflows/backport-sentinel.yml
+++ b/.github/workflows/backport-sentinel.yml
@@ -7,11 +7,14 @@
 # Guarantees no commit that reached `stable` is ever stranded outside `dev`:
 # the release (blessing) commit — version bumps, CHANGELOGs, and `.changesets/`
 # consumed marks — plus any emergency hotfix pushed straight to `stable`. It
-# fires on every push to `stable`; when `stable \ dev` is non-empty it opens an
-# ordinary PR into `dev` from a disposable `sync/stable-to-dev` branch cut at
-# stable's tip, so any conflict resolution happens off to the side and never
-# blocks `stable`. This is the reverse of the forward desync sentinel (the
-# standing release PR). See docs/release/pipeline.md
+# fires on every push to `stable` and again when a sync PR merges; when
+# `stable \ dev` is non-empty it opens an ordinary PR into `dev` from a
+# disposable `sync/stable-to-dev` branch cut at stable's tip, so any conflict
+# resolution happens off to the side and never blocks `stable`. While a sync PR
+# is open, each new `stable` push is MERGED into its branch (never force-pushed
+# over it), so in-flight conflict resolution survives and the PR always carries
+# the whole of `stable \ dev`. This is the reverse of the forward desync
+# sentinel (the standing release PR). See docs/release/pipeline.md
 # § "Reverse: the Backport Sentinel".
 #
 # Auto-merging that PR is OPT-IN (repo var RELMAN_BACKPORT_AUTOMERGE=true). By
@@ -19,12 +22,14 @@
 # auto-merge lets it self-dissolve once clean + gate-green.
 #
 # No self-trigger: it pushes `sync/stable-to-dev` and opens a PR into `dev` —
-# neither writes to `stable` — so it never re-fires itself.
+# neither writes to `stable` — so it never re-fires itself from a push.
 #
 # Requires the GitHub App (RELEASE_APP_ID / RELEASE_APP_PRIVATE_KEY): a
 # GITHUB_TOKEN cannot create pull requests (setting-dependent) and any PR it
 # opens does not trigger the dev-gate checks. An App with pull_requests:write
-# is subject to neither limit.
+# is subject to neither limit. The sync PR is therefore App-authored, which is
+# how `changeset-check` recognises it (author type Bot + the `backport` label
+# + the branch name), so the label is applied before the PR is left alone.
 # ============================================================================
 
 name: Backport sentinel
@@ -32,6 +37,12 @@ name: Backport sentinel
 on:
   push:
     branches: [stable]
+  # A merged sync PR may have been cut before a later `stable` push; re-check
+  # the set difference once it lands so nothing stays stranded until the next
+  # release.
+  pull_request:
+    types: [closed]
+    branches: [dev]
   workflow_dispatch:
 
 # Least privilege: create/update the disposable sync branch, and open the PR.
@@ -42,12 +53,16 @@ permissions:
 jobs:
   backport:
     name: Carry stable into dev
-    if: vars.RELMAN_PIPELINE_ACTIVE == 'true'
+    if: >-
+      vars.RELMAN_PIPELINE_ACTIVE == 'true' &&
+      (github.event_name != 'pull_request' ||
+       (github.event.pull_request.merged == true &&
+        github.event.pull_request.head.ref == 'sync/stable-to-dev'))
     runs-on: ubuntu-latest
     steps:
       - name: Mint GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -56,9 +71,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: stable
-          # Full history so `origin/dev..origin/stable` is computable and the
-          # sync branch carries real ancestry. Token so `git push` (below)
-          # authenticates as the App.
+          # Full history and every branch, so `origin/dev..origin/stable` is
+          # computable without a separate fetch and the sync branch carries real
+          # ancestry. Token so `git push` (below) authenticates as the App.
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
@@ -66,21 +81,16 @@ jobs:
         id: delta
         run: |
           set -euo pipefail
-          # `origin/dev` is not fetched by a single-ref checkout; fetch it (and
-          # stable) so the set difference is readable.
-          git fetch --no-tags --quiet origin dev stable
           ahead="$(git rev-list --count origin/dev..origin/stable)"
           echo "stable is $ahead commit(s) ahead of dev"
           echo "ahead=$ahead" >> "$GITHUB_OUTPUT"
 
-      # Ensure exactly one sync PR is open into `dev`. Auto-merge is OPT-IN
-      # (RELMAN_BACKPORT_AUTOMERGE=true); when enabled this step is idempotent and
-      # SELF-HEALING — if a sync PR is already open we re-assert auto-merge on it
-      # (rather than skip), so a PR that never got auto-merge (a transient failure
-      # or the post-create mergeability race below) is not left stuck blocking
-      # every future backport. Re-asserting never touches the branch, so in-flight
-      # human conflict resolution is safe. When auto-merge is off (the default),
-      # the PR is simply opened/kept open for a maintainer to review and merge.
+      # Ensure exactly one sync PR is open into `dev`, carrying all of
+      # `stable \ dev`. With no open PR, cut a fresh snapshot of stable's tip.
+      # With one open, MERGE stable's tip into its branch: a force-push would
+      # discard a human's conflict resolution, and leaving the branch untouched
+      # would strand every later `stable` push until the PR merged. Auto-merge is
+      # OPT-IN (RELMAN_BACKPORT_AUTOMERGE=true) and re-asserted idempotently.
       - name: Ensure a backport PR (auto-merge opt-in)
         if: steps.delta.outputs.ahead != '0'
         env:
@@ -92,6 +102,8 @@ jobs:
         run: |
           set -euo pipefail
           branch="sync/stable-to-dev"
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           num="$(gh pr list --base dev --head "$branch" --state open \
             --json number --jq '.[0].number // empty')"
@@ -99,8 +111,6 @@ jobs:
           if [ -z "$num" ]; then
             # No open sync PR: cut a fresh snapshot of stable's tip and open one.
             # Force is safe — with no open PR there is no resolution to lose.
-            git config user.name  "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git branch -f "$branch" origin/stable
             git push -f origin "$branch"
 
@@ -126,13 +136,27 @@ jobs:
             num="$(gh pr create --base dev --head "$branch" \
               --title "sync: backport stable → dev" --body-file body.md \
               | sed 's#.*/##')"
-            # Scannability labels; tolerate their absence (a fresh repo may not
-            # have them until the one-time label setup runs).
+            # The `backport` label is one of the three signals changeset-check
+            # uses to exempt this PR; without it the dev-gate runs on the sync PR.
             gh pr edit "$num" --add-label "automated,backport" \
-              || echo "::warning::labels 'automated'/'backport' not applied (create them once on the repo)."
+              || echo "::warning::labels 'automated'/'backport' not applied (create them once on the repo); changeset-check will NOT exempt #$num until the 'backport' label is present."
             echo "Opened backport PR #$num"
           else
-            echo "::notice::Backport PR #$num already open (branch untouched)."
+            # A sync PR is open: bring its branch up to stable's tip by merging,
+            # so the PR carries this push too and any resolution already on the
+            # branch is kept. A merge conflict here is left for the human on the
+            # branch — the PR is still the signal, and its body lists the delta.
+            git fetch --no-tags --quiet origin "$branch"
+            git checkout -q -B "$branch" "origin/$branch"
+            if git merge-base --is-ancestor origin/stable HEAD; then
+              echo "Backport PR #$num already carries stable's tip; branch untouched."
+            elif git merge --no-edit origin/stable; then
+              git push origin "$branch"
+              echo "Merged stable's tip into $branch; backport PR #$num now carries it."
+            else
+              git merge --abort
+              echo "::warning::stable's tip conflicts with the open backport PR #$num's branch; resolve on $branch (merge origin/stable into it) so the PR carries the newest stable."
+            fi
           fi
 
           # Auto-merge is OPT-IN. By default the sync PR is opened/kept open for a

--- a/.github/workflows/backport-sentinel.yml
+++ b/.github/workflows/backport-sentinel.yml
@@ -133,13 +133,22 @@ jobs:
               printf '%s\n' 'See docs/release/pipeline.md § "Reverse: the Backport Sentinel".'
             } > body.md
 
-            num="$(gh pr create --base dev --head "$branch" \
-              --title "sync: backport stable → dev" --body-file body.md \
-              | sed 's#.*/##')"
             # The `backport` label is one of the three signals changeset-check
-            # uses to exempt this PR; without it the dev-gate runs on the sync PR.
-            gh pr edit "$num" --add-label "automated,backport" \
-              || echo "::warning::labels 'automated'/'backport' not applied (create them once on the repo); changeset-check will NOT exempt #$num until the 'backport' label is present."
+            # and changeset-rename use to exempt this PR, and only labels present
+            # on the `opened` event count — a label added afterwards misses that
+            # first run. So the PR is created WITH its labels; the unlabelled
+            # fallback covers a fresh repo where the labels do not exist yet.
+            if num="$(gh pr create --base dev --head "$branch" \
+                  --title "sync: backport stable → dev" --body-file body.md \
+                  --label automated --label backport \
+                  | sed 's#.*/##')"; then
+              :
+            else
+              echo "::warning::labels 'automated'/'backport' not applied (create them once on the repo); the dev-gate will run on the sync PR."
+              num="$(gh pr create --base dev --head "$branch" \
+                --title "sync: backport stable → dev" --body-file body.md \
+                | sed 's#.*/##')"
+            fi
             echo "Opened backport PR #$num"
           else
             # A sync PR is open: bring its branch up to stable's tip by merging,

--- a/.github/workflows/blessing.yml
+++ b/.github/workflows/blessing.yml
@@ -5,8 +5,8 @@
 # INERT until the repo variable RELMAN_PIPELINE_ACTIVE=true. Activated only at
 # the coordinated pipeline cutover; until then this workflow does nothing.
 #
-# WARNING: step 4 publishes to crates.io, which CANNOT be undone. This workflow
-# stays dormant until RELMAN_PIPELINE_ACTIVE=true AND it requires:
+# WARNING: the publish step uploads to crates.io, which CANNOT be undone. This
+# workflow stays dormant until RELMAN_PIPELINE_ACTIVE=true AND it requires:
 #   - a GitHub App (RELEASE_APP_ID + RELEASE_APP_PRIVATE_KEY secrets) installed
 #     with `contents: write` and on the `stable` branch-protection bypass list,
 #     to push the release commit + tags to protected `stable`
@@ -15,6 +15,13 @@
 # already exists and is pushed by the current live release process — the
 # RELMAN_PIPELINE_ACTIVE gate is exactly what keeps this from firing on it
 # before cutover.
+#
+# PROVENANCE: a release is blessed only when the push to `stable` is the merge
+# of the standing release PR (`release-ready` -> `stable`). Any other push —
+# an emergency hotfix pushed straight to `stable`, or this workflow's own
+# release commit — is recorded by the backport sentinel but never released
+# from here, so content that skipped the rc-gate and the deployment gate cannot
+# reach crates.io.
 #
 # See docs/release/pipeline.md § "Blessing" and
 # implementation.md (bump / changelog / tags / publish-plan responsibilities).
@@ -32,14 +39,56 @@ permissions:
   contents: write
 
 jobs:
+  guard:
+    name: Check release provenance
+    # Master safety switch. Every job in every pipeline workflow carries this
+    # gate so these files can land dormant.
+    if: vars.RELMAN_PIPELINE_ACTIVE == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.provenance.outputs.proceed }}
+    steps:
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      # Two identity checks, neither of which a commit message can forge:
+      #   1. self-trigger: the pusher is this pipeline's own App (the release
+      #      commit it pushed below), so there is nothing new to release;
+      #   2. provenance: the pushed commit is the merge of a pull request from
+      #      `release-ready` into `stable` — the standing release PR — so the
+      #      content cleared every gate before it arrived here.
+      - name: Decide whether this push is a release to bless
+        id: provenance
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ACTOR: ${{ github.actor }}
+          APP_LOGIN: ${{ steps.app-token.outputs.app-slug }}[bot]
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ "${ACTOR}" = "${APP_LOGIN}" ]; then
+            echo "::notice::push to stable by ${APP_LOGIN} is this pipeline's own release commit; nothing to bless."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          release_prs="$(gh api "repos/${{ github.repository }}/commits/${SHA}/pulls" \
+            --jq '[.[] | select(.merged_at != null and .base.ref == "stable" and .head.ref == "release-ready")] | length')"
+          if [ "${release_prs:-0}" -ge 1 ]; then
+            echo "stable ${SHA:0:9} is the merge of the release PR (release-ready -> stable); blessing."
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::stable ${SHA:0:9} did not arrive through the release PR (release-ready -> stable); it is NOT blessed. The backport sentinel carries it into dev; release it through the normal rc-gate -> deployment -> release-ready path."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   bless:
     name: Bump, tag, publish
-    # Master safety switch AND a self-trigger guard: this job pushes a
-    # `chore(release): ...` commit to `stable`, which would re-fire this
-    # push-triggered workflow. Skipping our own release commit breaks the loop.
-    if: >-
-      vars.RELMAN_PIPELINE_ACTIVE == 'true' &&
-      !startsWith(github.event.head_commit.message, 'chore(release): ')
+    needs: guard
+    if: needs.guard.outputs.proceed == 'true'
     runs-on: ubuntu-latest
     steps:
       # Mint a short-lived GitHub App installation token (no PATs). The App must
@@ -48,7 +97,7 @@ jobs:
       # + tags. Store its credentials as RELEASE_APP_ID / RELEASE_APP_PRIVATE_KEY.
       - name: Mint GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -63,33 +112,14 @@ jobs:
           # *protected* `stable` branch (GITHUB_TOKEN cannot).
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Set up relman
+        uses: ./.github/actions/setup-relman
+
+      # The open cycle is the one being blessed: it has rc tags but no final
+      # `cycle-<N>` tag yet (we create that below).
       - name: Compute cycle N being released
         id: cycle
-        run: |
-          set -euo pipefail
-
-          # --- shared cycle tag-numbering (see rc-gate.yml for full doc) ---
-          # The open cycle is the one being blessed: it has rc tags but no final
-          # `cycle-<N>` tag yet (we create that below).
-          highest_cycle() {
-            git tag --list 'cycle-*' \
-              | sed -n 's/^cycle-\([0-9][0-9]*\)\(-rc\.[0-9][0-9]*\)\{0,1\}$/\1/p' \
-              | sort -n | tail -1
-          }
-          open_cycle() {
-            hi="$(highest_cycle)"
-            if [ -z "$hi" ]; then
-              echo 1
-            elif git rev-parse -q --verify "refs/tags/cycle-${hi}" >/dev/null; then
-              echo $((hi + 1))
-            else
-              echo "$hi"
-            fi
-          }
-
-          N="$(open_cycle)"
-          echo "Releasing cycle: $N"
-          echo "n=$N" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/cycle-ids
 
       # Restore the authoritative consumed-UID ledger from the LAST released
       # cycle tag, so the accumulation is a clean function of past releases and
@@ -124,19 +154,24 @@ jobs:
       # AFTER the bump (new versions) and consume (changesets marked, filtered out)
       # yields an EMPTY per-crate tag set and publish plan (the cycle tag is still
       # emitted, which is why a naive order produces `cycle-N` but no
-      # `<crate>-vX.Y.Z`). Written to RUNNER_TEMP so they are never swept into the
-      # release commit by `git add -A`.
+      # `<crate>-X.Y.Z`). Written to RUNNER_TEMP so they are never swept into the
+      # release commit by `git add -A`. An empty publish plan is an empty file:
+      # relman keeps stdout machine-readable and puts its note on stderr.
       - name: Derive tag + publish plans and release notes (before consuming changesets)
         run: |
           set -euo pipefail
-          root="tools/relman/Cargo.toml"
-          cargo run -q --manifest-path "$root" -- tags --cycle "${{ steps.cycle.outputs.n }}" > "$RUNNER_TEMP/tags.txt"
-          cargo run -q --manifest-path "$root" -- publish-plan > "$RUNNER_TEMP/plan.txt"
-          cargo run -q --manifest-path "$root" -- pr-body --cycle "${{ steps.cycle.outputs.n }}" > "$RUNNER_TEMP/notes.md"
+          relman tags --cycle "${{ steps.cycle.outputs.open }}" > "$RUNNER_TEMP/tags.txt"
+          relman publish-plan > "$RUNNER_TEMP/plan.txt"
+          relman pr-body --cycle "${{ steps.cycle.outputs.open }}" > "$RUNNER_TEMP/notes.md"
           echo "--- tag plan ---"; cat "$RUNNER_TEMP/tags.txt"
           echo "--- publish plan ---"; cat "$RUNNER_TEMP/plan.txt"
+          if [ ! -s "$RUNNER_TEMP/plan.txt" ]; then
+            echo "::error::No crate publishes this cycle (no unconsumed changeset affects a governed target) — nothing to bless."
+            exit 1
+          fi
 
       # 2. Apply versions + changelogs, consume changesets. All working-tree edits.
+      # `bump` also refreshes Cargo.lock so the `--locked` steps below pass.
       # `consume` MARKS each changeset with `consumed_in = "cycle-N"` (it does not
       # delete): derivation filters consumed changesets out, so the next cycle sees
       # an empty set while `.changesets/` keeps the provenance ledger. The stamp is
@@ -145,19 +180,35 @@ jobs:
       - name: Apply bump, changelog, consume changesets
         run: |
           set -euo pipefail
-          root="tools/relman/Cargo.toml"
-          cargo run -q --manifest-path "$root" -- bump              # edit manifests + root pins
-          cargo run -q --manifest-path "$root" -- changelog         # write CHANGELOGs
+          relman bump              # edit manifests + root pins + Cargo.lock
+          relman changelog         # write CHANGELOGs
           # `consume` stores its --cycle verbatim as the on-disk audit stamp, so
           # we pass the fully-rendered period id `cycle-N` (matching the git tag)
           # for a clean cross-reference — unlike `tags`/`pr-body`, which take the
           # bare ordinal N and render the `cycle-` prefix themselves.
-          cargo run -q --manifest-path "$root" -- \
-            changeset consume --cycle "cycle-${{ steps.cycle.outputs.n }}" --yes  # mark consumed
+          relman changeset consume --cycle "cycle-${{ steps.cycle.outputs.open }}" --yes  # mark consumed
 
-      # 3. Pre-flight publishability check — validate the ENTIRE publish plan is
+      # 3. Commit the release edits to the working tree FIRST: `cargo publish`
+      # refuses a dirty package directory, and the per-crate CHANGELOG.md and
+      # Cargo.toml edits above live inside the packages. Nothing is pushed until
+      # pre-flight passes.
+      - name: Commit release (local)
+        id: commit
+        run: |
+          set -euo pipefail
+          if [ -z "$(git status --porcelain)" ]; then
+            echo "::error::No release edits produced by bump/changelog/consume — nothing to bless (were there any changesets?)."
+            exit 1
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore(release): cycle-${{ steps.cycle.outputs.open }}"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # 4. Pre-flight publishability check — validate the ENTIRE publish plan is
       # actually publishable (no version-reuse, no yanked/unresolvable deps)
-      # BEFORE any commit/tag/Release, so a real release fails fast and leaves
+      # BEFORE any push/tag/Release, so a real release fails fast and leaves
       # nothing orphaned on stable. BLOCKING for a real release; ADVISORY under
       # RELMAN_PUBLISH_DRY_RUN (a fork can't truly publish — crate names are a
       # global namespace — so it warns and proceeds to exercise the rest).
@@ -185,31 +236,25 @@ jobs:
             fi
           done < "$RUNNER_TEMP/plan.txt"
 
-      # 4. Commit the release edits back to `stable`.
-      - name: Commit release
-        id: commit
+      # 5. Push the release commit to `stable`. The push is made by the App, so
+      # the `guard` job above recognises it as this pipeline's own commit and
+      # does not re-run the release.
+      - name: Push release commit
         run: |
           set -euo pipefail
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "::error::No release edits produced by bump/changelog/clear — nothing to bless (were there any changesets?)."
-            exit 1
-          fi
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          # The `chore(release): ` prefix is matched by this job's `if` guard so the
-          # resulting push to `stable` does not re-trigger the workflow.
-          git commit -m "chore(release): cycle-${{ steps.cycle.outputs.n }}"
           git push origin "HEAD:refs/heads/stable"
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      # 4. Tags: final `cycle-<N>` + per-crate `<crate>-vX.Y.Z`, all at the release
-      # commit. tags.txt was derived in step 1, before the changesets were consumed.
+      # 6. Tags: final `cycle-<N>` + per-crate `<crate>-X.Y.Z`, all at the release
+      # commit. tags.txt was derived in step 1, before the changesets were
+      # consumed. All tags go in ONE push: `ci.yml` excludes these tag shapes from
+      # its `push.tags` trigger, and a single push keeps the release atomic on the
+      # remote (no half-tagged release if the runner dies mid-loop).
       - name: Create and push release tags
         run: |
           set -euo pipefail
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          refs=()
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue
             if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
@@ -217,12 +262,15 @@ jobs:
               continue
             fi
             git tag "$tag" "${{ steps.commit.outputs.sha }}"
-            git push origin "$tag"
+            refs+=("refs/tags/$tag")
           done < "$RUNNER_TEMP/tags.txt"
+          if [ "${#refs[@]}" -gt 0 ]; then
+            git push origin "${refs[@]}"
+          fi
 
-      # 5. A GitHub Release for the cycle — the visible UI entry. Body = the
+      # 7. A GitHub Release for the cycle — the visible UI entry. Body = the
       # derived per-crate version table + changelog (rendered in step 1). Anchored
-      # on the `cycle-<N>` tag; the per-crate `<crate>-vX.Y.Z` tags are pushed
+      # on the `cycle-<N>` tag; the per-crate `<crate>-X.Y.Z` tags are pushed
       # above and referenced in the notes. Marked prerelease iff RC-only (never
       # here — blessing is the final release).
       - name: Create GitHub Release
@@ -230,7 +278,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          tag="cycle-${{ steps.cycle.outputs.n }}"
+          tag="cycle-${{ steps.cycle.outputs.open }}"
           if gh release view "$tag" >/dev/null 2>&1; then
             gh release edit "$tag" --notes-file "$RUNNER_TEMP/notes.md" --title "Release $tag"
             echo "Updated release $tag"
@@ -239,7 +287,7 @@ jobs:
             echo "Created release $tag"
           fi
 
-      # 4. Publish to crates.io in dependency order.
+      # 8. Publish to crates.io in dependency order.
       # IRREVERSIBLE unless RELMAN_PUBLISH_DRY_RUN=true (fork/sandbox testing),
       # which runs `cargo publish --dry-run --no-verify` — packages each crate and
       # exercises the orchestration WITHOUT uploading. (`--no-verify` is required
@@ -272,7 +320,7 @@ jobs:
           # step 1, before the changesets were consumed.
           while read -r crate version; do
             [ -z "${crate:-}" ] && continue
-            echo "::group::Publish ${crate} ${version}${DRY_RUN:+ (dry-run)}"
+            echo "::group::Publish ${crate} ${version}"
             # shellcheck disable=SC2086 # publish_flags is intentionally word-split
             if out="$(cargo publish -p "${crate}" ${publish_flags} 2>&1)"; then
               echo "${out}"
@@ -290,16 +338,14 @@ jobs:
             echo "::endgroup::"
             # cargo (>= 1.66, sparse index) already blocks until the new version is
             # visible in the index; this pause is extra margin before dependents
-            # publish. Skipped in dry-run (nothing was uploaded).
-            [ "${DRY_RUN:-}" = "true" ] || sleep 15
+            # publish.
+            sleep 15
           done < "$RUNNER_TEMP/plan.txt"
 
-      # 5. TODO(cutover): Docker image (zainod version + cycle handle), GitHub
-      # Release, and gh-pages doc publish follow from the pushed tags, via a
-      # reworked release.yaml (see pipeline.md "Existing-workflow teardown":
-      # release.yaml is retargeted to cycle-*/<crate>-vX.Y.Z tags). Not built in
-      # this draft — wire it at cutover.
-      - name: Post-publish artifacts (TODO)
+      # 9. Container images follow from the pushed tags: `release.yaml` builds
+      # and pushes the zainod images on the `zainod-X.Y.Z` tag push above.
+      # gh-pages doc publish is a cutover TODO.
+      - name: Post-publish artifacts
         run: |
           set -euo pipefail
-          echo "::notice::Docker image + GitHub Release + gh-pages are a cutover TODO (reworked release.yaml); not performed here."
+          echo "::notice::Container images are built by release.yaml on the zainod-X.Y.Z tag; gh-pages publish is a cutover TODO."

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -21,12 +21,16 @@ jobs:
     # backport sentinel's `sync/stable-to-dev` PR: it mechanically carries a
     # release commit (Cargo.toml bumps, CHANGELOGs, and `.changesets/`
     # consumed marks) back into `dev` and by design introduces no *new*
-    # changeset — same spirit as an RC-cut PR of already-reviewed work. See
-    # docs/release/pipeline.md § "Reverse: the Backport
-    # Sentinel".
+    # changeset — same spirit as an RC-cut PR of already-reviewed work. The
+    # exemption needs all three signals — the branch name, a Bot author (the
+    # sentinel's App), and the `backport` label only a writer can apply — so a
+    # contributor cannot claim it by naming a fork branch. See
+    # docs/release/pipeline.md § "Reverse: the Backport Sentinel".
     if: >-
       github.event.pull_request.draft == false &&
-      github.head_ref != 'sync/stable-to-dev'
+      !(github.head_ref == 'sync/stable-to-dev' &&
+        github.event.pull_request.user.type == 'Bot' &&
+        contains(github.event.pull_request.labels.*.name, 'backport'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR
@@ -36,6 +40,8 @@ jobs:
           # for relman's `git diff base...HEAD`.
           fetch-depth: 0
 
+      # `fetch-depth: 0` already brought every branch; this only refreshes the
+      # base ref in case it moved since the checkout resolved.
       - name: Fetch base branch
         run: git fetch --no-tags origin "${{ github.event.pull_request.base.ref }}"
 

--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -48,8 +48,16 @@ jobs:
           ENFORCE: ${{ vars.RELMAN_ENFORCE_CHANGESETS }}
         run: |
           set -o pipefail
-          if relman changeset check --base "origin/${BASE_REF}"; then
+          # relman exits 0 when compliant, 2 when one of this PR's changesets is
+          # malformed (unparseable or naming an unknown target), and 1 for any
+          # other violation. Only the last is advisory during rollout.
+          status=0
+          relman changeset check --base "origin/${BASE_REF}" || status=$?
+          if [ "${status}" -eq 0 ]; then
             echo "changeset check passed"
+          elif [ "${status}" -eq 2 ]; then
+            echo "::error::A changeset in this PR is malformed. Fix the file under .changesets/ (see the relman output above); this fails regardless of RELMAN_ENFORCE_CHANGESETS."
+            exit 1
           elif [ "${ENFORCE}" = "true" ]; then
             echo "::error::Changeset coverage check failed. Add a covering changeset (\`relman changeset new\`) for the governed crates this PR touches, or \`relman changeset new --empty \"<reason>\"\` if it is release-irrelevant."
             exit 1

--- a/.github/workflows/changeset-rename.yml
+++ b/.github/workflows/changeset-rename.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Mint GitHub App token
         id: app-token
         if: steps.guard.outputs.same_repo == 'true'
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -88,6 +88,10 @@ jobs:
         if: steps.guard.outputs.same_repo == 'true'
         run: git fetch --no-tags origin "${{ github.event.pull_request.base.ref }}"
 
+      - name: Set up relman
+        if: steps.guard.outputs.same_repo == 'true'
+        uses: ./.github/actions/setup-relman
+
       - name: Rename changeset(s) to pr-<N> and push if changed
         if: steps.guard.outputs.same_repo == 'true'
         env:
@@ -102,8 +106,7 @@ jobs:
           # edits the working tree; committing/pushing is this workflow's job. It
           # renames only the author changesets in this PR's diff against the
           # base, never files inherited from it or already shipped.
-          cargo run -q --manifest-path tools/relman/Cargo.toml -- \
-            changeset rename --pr "${{ github.event.number }}" --base "origin/${BASE_REF}"
+          relman changeset rename --pr "${{ github.event.number }}" --base "origin/${BASE_REF}"
 
           if [ -z "$(git status --porcelain .changesets/)" ]; then
             echo "Changesets already canonically named; nothing to commit."

--- a/.github/workflows/changeset-rename.yml
+++ b/.github/workflows/changeset-rename.yml
@@ -80,6 +80,13 @@ jobs:
           # Push with the App token (see the mint step above) so the resulting
           # synchronize re-runs the dev-gate on the canonical pr-<N> changeset.
           token: ${{ steps.app-token.outputs.token }}
+          # Full history so the merge-base with the base branch is available:
+          # relman renames only the changesets this PR's diff added.
+          fetch-depth: 0
+
+      - name: Fetch base branch
+        if: steps.guard.outputs.same_repo == 'true'
+        run: git fetch --no-tags origin "${{ github.event.pull_request.base.ref }}"
 
       - name: Rename changeset(s) to pr-<N> and push if changed
         if: steps.guard.outputs.same_repo == 'true'
@@ -88,12 +95,15 @@ jobs:
           # script — a branch name is attacker-controlled and inlining it risks
           # script injection (actionlint expression check).
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           set -euo pipefail
           # relman runs from the repo root (discovers relman.toml upward) and only
-          # edits the working tree; committing/pushing is this workflow's job.
+          # edits the working tree; committing/pushing is this workflow's job. It
+          # renames only the author changesets in this PR's diff against the
+          # base, never files inherited from it or already shipped.
           cargo run -q --manifest-path tools/relman/Cargo.toml -- \
-            changeset rename --pr "${{ github.event.number }}"
+            changeset rename --pr "${{ github.event.number }}" --base "origin/${BASE_REF}"
 
           if [ -z "$(git status --porcelain .changesets/)" ]; then
             echo "Changesets already canonically named; nothing to commit."

--- a/.github/workflows/changeset-rename.yml
+++ b/.github/workflows/changeset-rename.yml
@@ -25,8 +25,15 @@ jobs:
   changeset-rename:
     name: Name changeset for PR
     # Master safety switch (see file header). Every job in every pipeline
-    # workflow carries this gate so these files can land dormant.
-    if: vars.RELMAN_PIPELINE_ACTIVE == 'true'
+    # workflow carries this gate so these files can land dormant. The backport
+    # sentinel's `sync/stable-to-dev` PR is exempt on the same three signals
+    # changeset-check uses: its changesets are shipped provenance whose slugs
+    # the consumed ledger records, so renaming them would orphan the ledger.
+    if: >-
+      vars.RELMAN_PIPELINE_ACTIVE == 'true' &&
+      !(github.head_ref == 'sync/stable-to-dev' &&
+        github.event.pull_request.user.type == 'Bot' &&
+        contains(github.event.pull_request.labels.*.name, 'backport'))
     runs-on: ubuntu-latest
     steps:
       # A PR opened against `rc` is a hotfix (the normal path advances rc by a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,11 @@ on:
   push:
     tags:
       - "**"
+      # Release-pipeline tags (`cycle-<N>`, `cycle-<N>-rc.<M>`, `<crate>-X.Y.Z`)
+      # point at commits `stable`/`rc` already validated; blessing pushes up to
+      # one per governed crate, so they must not fan out into full CI runs.
+      - "!cycle-*"
+      - "!zaino*-[0-9]*.[0-9]*.[0-9]*"
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
@@ -68,17 +73,27 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Cache the tool-crate builds
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            tools/workbench
+            tools/relman
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@nextest
+
       - name: Lint and test the workbench crate
         run: |
           cargo fmt --manifest-path tools/workbench/Cargo.toml -- --check
           cargo clippy --manifest-path tools/workbench/Cargo.toml --all-targets -- -D warnings
-          cargo test --manifest-path tools/workbench/Cargo.toml
+          cargo nextest run --manifest-path tools/workbench/Cargo.toml
 
       - name: Lint and test the relman crate
         run: |
           cargo fmt --manifest-path tools/relman/Cargo.toml --all -- --check
           cargo clippy --manifest-path tools/relman/Cargo.toml --workspace --all-targets -- -D warnings
-          cargo test --manifest-path tools/relman/Cargo.toml --workspace
+          cargo nextest run --manifest-path tools/relman/Cargo.toml --workspace
 
       - name: Check toolchain pin
         run: cargo run -q --manifest-path tools/workbench/Cargo.toml --bin check-toolchain-pin

--- a/.github/workflows/deployment-advance.yml
+++ b/.github/workflows/deployment-advance.yml
@@ -14,6 +14,11 @@
 # `deployment_status` events run the workflow from the DEFAULT branch, so this
 # file must be on the default branch at cutover. `tools/scripts/mark-deployment.sh`
 # posts the same signal to exercise this reaction in seconds instead of days.
+#
+# Any account with `deployments: write` can post a `success`, so set the repo
+# variable RELMAN_DEPLOYMENT_REPORTER to the login of the account the cluster
+# posts as; once set, a status from any other login is refused. Leave it unset
+# while the bridge is exercised by hand with mark-deployment.sh.
 # See docs/release/implementation.md § "The deployment-gate bridge".
 # ============================================================================
 
@@ -37,12 +42,25 @@ jobs:
       github.event.deployment.environment == 'deployment'
     runs-on: ubuntu-latest
     steps:
+      - name: Require the status from the configured reporter
+        if: vars.RELMAN_DEPLOYMENT_REPORTER != ''
+        env:
+          REPORTER: ${{ vars.RELMAN_DEPLOYMENT_REPORTER }}
+          CREATOR: ${{ github.event.deployment_status.creator.login }}
+        run: |
+          set -euo pipefail
+          if [ "${CREATOR}" != "${REPORTER}" ]; then
+            echo "::error::deployment_status posted by '${CREATOR}', not the configured reporter '${REPORTER}'; refusing to advance release-ready."
+            exit 1
+          fi
+          echo "deployment_status posted by the configured reporter '${REPORTER}'."
+
       # App token: the ff push to the protected `release-ready` branch cannot be
       # done with GITHUB_TOKEN, and an App-token push (unlike GITHUB_TOKEN) also
       # re-triggers `release-pr-body` on `release-ready` to refresh the release PR.
       - name: Mint GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/deployment-signoff.yml
+++ b/.github/workflows/deployment-signoff.yml
@@ -53,7 +53,7 @@ jobs:
       # what lets deployment-advance react to the resulting status.
       - name: Mint GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/final-tag-on-stable.yml
+++ b/.github/workflows/final-tag-on-stable.yml
@@ -1,0 +1,49 @@
+# LEGACY tag producer for the pre-cutover release protocol (rc/<version>
+# branches). It stays live until the repo variable RELMAN_PIPELINE_ACTIVE is
+# set to true, at which point the release pipeline (rc-gate / blessing) owns
+# every tag and this workflow goes dormant. Delete it after the cutover.
+name: Final Tag on Stable
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - stable
+
+jobs:
+  tag-stable:
+    if: github.event.pull_request.merged == true && vars.RELMAN_PIPELINE_ACTIVE != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Lookup merged PR and extract version
+        id: get-version
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.number,
+            });
+
+            const baseBranch = pr.data.base.ref;
+            const headBranch = pr.data.head.ref;
+
+            if (!headBranch.startsWith("rc/")) throw new Error("PR is not from an rc/* branch");
+            const version = headBranch.replace(/^rc\//, "");
+            core.setOutput("version", version);
+
+      - name: Create final release tag
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@users.noreply.github.com
+          git tag ${{ steps.get-version.outputs.version }}
+          git push origin ${{ steps.get-version.outputs.version }}
+

--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'rc/**'
+      - rc
       - stable
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
@@ -13,11 +13,12 @@ jobs:
   publish-dry-run:
     name: cargo publish --dry-run
     runs-on: ubuntu-latest
-    # Blocking context: direct pushes to rc/** or stable — the branch is in
-    # release-prep state and must publish cleanly.  Advisory context: everything
-    # else, including PRs that *target* rc/** or stable.  Those PRs carry
-    # unbumped dev code; version bumps happen on the RC branch after merge, so
-    # a publish failure at PR time is expected, not actionable.
+    # Blocking context: pushes to stable — the release commit is on it and must
+    # publish cleanly.  Advisory context: everything else, including pushes to
+    # `rc` and PRs that *target* rc or stable.  Every pipeline branch is
+    # version-agnostic and `rc` carries unbumped code by design (versions are
+    # bumped at blessing), so a publish failure there is expected, not
+    # actionable; blessing's own pre-flight is the blocking check at release.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -31,11 +32,11 @@ jobs:
           if [[ "${{ github.event_name }}" == "push" ]]; then
             target="${{ github.ref_name }}"
           else
-            # PRs (including those targeting rc/** or stable) are always
+            # PRs (including those targeting rc or stable) are always
             # advisory — they carry pre-bump code by design.
             target=""
           fi
-          if [[ "$target" == rc/* || "$target" == stable ]]; then
+          if [[ "$target" == stable ]]; then
             echo "mode=blocking" >> "$GITHUB_OUTPUT"
           else
             echo "mode=advisory" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/rc-gate.yml
+++ b/.github/workflows/rc-gate.yml
@@ -12,6 +12,11 @@
 # to be green on dev HEAD. `CI - Nightly` publishes it on a fully-green run; this
 # workflow only reads it (a `force` dispatch bypasses). The gate does not run the
 # suite itself — that would duplicate the runner.
+#
+# IDEMPOTENT: a night on which `dev` did not move cuts nothing. The prerelease
+# tag is applied only when rc HEAD differs from the commit the last rc tag of
+# the open cycle points at, so a quiet weekend never restarts the deployment
+# soak with a duplicate tag at the same commit.
 
 name: RC gate
 
@@ -47,7 +52,7 @@ jobs:
       # secrets.
       - name: Mint GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
@@ -56,8 +61,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: dev
-          # Full history + all tags: needed for fast-forward checks and the
-          # cycle-numbering helper.
+          # Full history, every branch, and all tags: needed for the
+          # fast-forward checks and the cycle-numbering helper. No separate
+          # fetch is needed for `rc`.
           fetch-depth: 0
           # Use the App token so the push step below can advance the *protected*
           # `rc` branch (GITHUB_TOKEN cannot push a protected branch).
@@ -94,11 +100,6 @@ jobs:
             exit 1
           fi
 
-      - name: Fetch dev and rc
-        run: |
-          set -euo pipefail
-          git fetch --no-tags origin dev rc || git fetch --no-tags origin dev
-
       - name: Fast-forward rc to dev HEAD
         id: ff
         run: |
@@ -130,77 +131,44 @@ jobs:
 
       - name: Compute cycle N and next rc M
         id: ids
+        uses: ./.github/actions/cycle-ids
+
+      # Cut a prerelease tag only when rc HEAD moved since the open cycle's last
+      # rc tag: an idle night (or a re-run) finds the last tag already at this
+      # commit and cuts nothing, so no duplicate tag and no restarted soak.
+      - name: Decide whether rc HEAD needs a new prerelease tag
+        id: need
+        env:
+          LAST_TAG: ${{ steps.ids.outputs.last_rc_tag }}
+          RC_SHA: ${{ steps.ff.outputs.rc_sha }}
         run: |
           set -euo pipefail
+          if [ -n "${LAST_TAG}" ] && [ "$(git rev-parse "refs/tags/${LAST_TAG}^{commit}")" = "${RC_SHA}" ]; then
+            echo "::notice::${LAST_TAG} already points at rc HEAD ${RC_SHA:0:9}; nothing new to cut."
+            echo "cut=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "cut=true" >> "$GITHUB_OUTPUT"
+          fi
 
-          # --- shared cycle tag-numbering scheme (canonical documentation) ---
-          # Identity is derived purely from existing git tags (checkout fetched
-          # them via fetch-depth: 0). Two tag shapes carry the numbers:
-          #   cycle-<N>          final (blessed) cycle tag
-          #   cycle-<N>-rc.<M>   deployment prerelease tag number M within cycle N
-          #
-          # highest_cycle(): the max integer N seen across BOTH shapes (empty if
-          #   no cycle tags exist). The sed matches `cycle-<N>` and
-          #   `cycle-<N>-rc.<M>` exactly and prints N; date-style ids like
-          #   `cycle-2026-08-15` do not match and are ignored (this scheme is
-          #   integer-numbered per the pipeline draft).
-          highest_cycle() {
-            git tag --list 'cycle-*' \
-              | sed -n 's/^cycle-\([0-9][0-9]*\)\(-rc\.[0-9][0-9]*\)\{0,1\}$/\1/p' \
-              | sort -n | tail -1
-          }
-          # open_cycle(): the cycle a NEW rc (or a blessing) belongs to.
-          #   - no cycle tags yet            -> 1
-          #   - a final `cycle-<hi>` exists  -> hi+1 (that cycle already released)
-          #   - otherwise                    -> hi   (cycle hi still open/deploying)
-          open_cycle() {
-            hi="$(highest_cycle)"
-            if [ -z "$hi" ]; then
-              echo 1
-            elif git rev-parse -q --verify "refs/tags/cycle-${hi}" >/dev/null; then
-              echo $((hi + 1))
-            else
-              echo "$hi"
-            fi
-          }
-          # next_rc(N): the next prerelease number M within cycle N (max existing
-          #   `cycle-<N>-rc.<M>` + 1, or 1 if none).
-          next_rc() {
-            n="$1"
-            last="$(git tag --list "cycle-${n}-rc.*" \
-              | sed -n "s/^cycle-${n}-rc\.\([0-9][0-9]*\)$/\1/p" \
-              | sort -n | tail -1)"
-            if [ -z "$last" ]; then echo 1; else echo $((last + 1)); fi
-          }
-
-          N="$(open_cycle)"
-          M="$(next_rc "$N")"
-          echo "Open cycle N=$N, next rc M=$M"
-          echo "n=$N" >> "$GITHUB_OUTPUT"
-          echo "m=$M" >> "$GITHUB_OUTPUT"
+      - name: Set up relman
+        if: steps.need.outputs.cut == 'true'
+        uses: ./.github/actions/setup-relman
 
       - name: Create and push prerelease tag
         id: tag
+        if: steps.need.outputs.cut == 'true'
         run: |
           set -euo pipefail
           # relman prints the single prerelease tag name for cycle N, rc M.
-          tag="$(cargo run -q --manifest-path tools/relman/Cargo.toml -- \
-            tags --cycle "${{ steps.ids.outputs.n }}" --rc "${{ steps.ids.outputs.m }}" \
+          tag="$(relman tags --cycle "${{ steps.ids.outputs.open }}" --rc "${{ steps.ids.outputs.next_rc }}" \
             | tr -d '[:space:]')"
           echo "Prerelease tag: $tag"
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
-          if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
-            echo "Tag $tag already exists; skipping (rc HEAD unchanged since last cut)."
-            echo "cut=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag "$tag" "${{ steps.ff.outputs.rc_sha }}"
-          git push origin "$tag"
-          echo "cut=true" >> "$GITHUB_OUTPUT"
+          git push origin "refs/tags/$tag"
 
       # Record the cut on the standing release PR: an append-only comment (the
       # event timeline) plus a re-render of the body (the live snapshot). The
@@ -209,7 +177,7 @@ jobs:
       # is its record until the PR opens. GITHUB_TOKEN suffices to comment and to
       # dispatch the renderer.
       - name: Note the RC cut on the release PR
-        if: steps.tag.outputs.cut == 'true'
+        if: steps.need.outputs.cut == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -241,7 +209,7 @@ jobs:
       # bridge". (`tools/scripts/mark-deployment.sh` injects the same signal for
       # testing without waiting days.)
       - name: Dispatch the RC to the deployment gate
-        if: steps.tag.outputs.cut == 'true'
+        if: steps.need.outputs.cut == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/release-pr-body.yml
+++ b/.github/workflows/release-pr-body.yml
@@ -37,39 +37,14 @@ jobs:
       # is not subject to that restriction, so this is setting-independent.
       - name: Mint GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Compute open cycle N
         id: cycle
-        run: |
-          set -euo pipefail
-
-          # --- shared cycle tag-numbering (see rc-gate.yml for the full doc) ---
-          # Cycle identity is derived purely from existing git tags:
-          #   cycle-<N>        final (blessed) cycle tag
-          #   cycle-<N>-rc.<M> deployment prerelease tag within cycle N
-          highest_cycle() {
-            git tag --list 'cycle-*' \
-              | sed -n 's/^cycle-\([0-9][0-9]*\)\(-rc\.[0-9][0-9]*\)\{0,1\}$/\1/p' \
-              | sort -n | tail -1
-          }
-          open_cycle() {
-            hi="$(highest_cycle)"
-            if [ -z "$hi" ]; then
-              echo 1
-            elif git rev-parse -q --verify "refs/tags/cycle-${hi}" >/dev/null; then
-              echo $((hi + 1))
-            else
-              echo "$hi"
-            fi
-          }
-
-          N="$(open_cycle)"
-          echo "Open cycle: $N"
-          echo "n=$N" >> "$GITHUB_OUTPUT"
+        uses: ./.github/actions/cycle-ids
 
       - name: Gather cycle status
         id: status
@@ -80,7 +55,7 @@ jobs:
           # relman-core `CycleStatus` and docs/release/pipeline.md
           # § "Blessing".
           status="$RUNNER_TEMP/status.toml"
-          N="${{ steps.cycle.outputs.n }}"
+          N="${{ steps.cycle.outputs.open }}"
 
           # Fetch the four gate branches so their tips are readable; each may be
           # missing in an early cycle, so never fail on a branch that is absent.
@@ -158,12 +133,14 @@ jobs:
             echo "stable has no ledger yet; treating as empty."
           fi
 
+      - name: Set up relman
+        uses: ./.github/actions/setup-relman
+
       - name: Render release PR body
         run: |
           set -euo pipefail
           # relman runs from the repo root and writes markdown to stdout.
-          cargo run -q --manifest-path tools/relman/Cargo.toml -- \
-            pr-body --cycle "${{ steps.cycle.outputs.n }}" \
+          relman pr-body --cycle "${{ steps.cycle.outputs.open }}" \
             --status "${{ steps.status.outputs.path }}" > body.md
 
       - name: Create or update the release PR
@@ -183,7 +160,7 @@ jobs:
             echo "::notice::release-ready is not ahead of stable; no release PR to open yet."
           else
             new="$(gh pr create --base stable --head release-ready \
-              --title "Release cycle-${{ steps.cycle.outputs.n }}" \
+              --title "Release cycle-${{ steps.cycle.outputs.open }}" \
               --body-file body.md | sed 's#.*/##')"
             gh pr edit "$new" --add-label "automated,release" \
               || echo "::warning::labels 'automated'/'release' not applied (create them once on the repo)."

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,13 +1,11 @@
-# TODO(cutover): this builds+pushes the Docker images and fires on the OLD
-# version-tag format (`X.Y.Z`, `X.Y.Z-rc.N`). The release pipeline tags releases
-# as `cycle-<N>` (period), `cycle-<N>-rc.<M>` (prerelease), and
-# `<crate>-vX.Y.Z` (per-crate provenance) — NONE of which match the patterns
-# below, so this workflow no longer fires on a pipeline release and the images
-# are not built. Rework at cutover: decide the image-tag scheme for the new
-# model (likely build+push the zainod/zaino images on the `zainod-v*` tag, or
-# trigger image builds from `blessing`) and update the trigger + metadata-action
-# `type=semver` extraction accordingly. Blessing already owns the GitHub Release
-# + git tags; this file's remaining job is only the container images.
+# Builds and pushes the Docker images. It fires on the legacy version tags
+# (`X.Y.Z`, `X.Y.Z-rc.N`, cut by auto-tag-rc / final-tag-on-stable until the
+# pipeline cutover) and on the per-crate `zainod-X.Y.Z` provenance tag the
+# release pipeline's blessing pushes, from which the image version is taken.
+# The pipeline's `cycle-<N>` and other `<crate>-X.Y.Z` tags carry no zainod
+# image and are ignored here. Blessing owns the GitHub Release for pipeline
+# tags, so the `create-release` job below runs only for the legacy tags.
+# TODO(cutover): gh-pages doc publish.
 name: Zaino Release
 
 on:
@@ -15,6 +13,7 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
       - '[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+      - 'zainod-[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:
     inputs:
       push:
@@ -54,6 +53,7 @@ jobs:
             ${{ secrets.DOCKERHUB_USERNAME }}/zainod
           tags: |
             type=semver,pattern={{version}}
+            type=match,pattern=zainod-(.*),group=1
             type=ref,event=branch
             type=sha,prefix=,format=short
 
@@ -85,6 +85,7 @@ jobs:
             suffix=-no-tls
           tags: |
             type=semver,pattern={{version}}
+            type=match,pattern=zainod-(.*),group=1
             type=ref,event=branch
             type=sha,prefix=,format=short
 
@@ -110,9 +111,11 @@ jobs:
     needs: docker
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    # Only create a GitHub release when triggered by a real semver tag push.
-    # workflow_dispatch (e.g. for verification on a feature branch) skips this.
-    if: startsWith(github.ref, 'refs/tags/')
+    # Only create a GitHub release when triggered by a legacy semver tag push.
+    # workflow_dispatch (e.g. for verification on a feature branch) skips this,
+    # and so does a pipeline `zainod-X.Y.Z` tag: blessing already created the
+    # cycle's GitHub Release.
+    if: startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/zainod-')
     steps:
       - uses: actions/checkout@v7
         with:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,8 +14,8 @@ hard-coded list.
 _Avoid_: crate list, publish list
 
 **Blocking context**:
-A CI context in which release checks must pass: pushes to `rc/**` or
-`stable`, and pull requests targeting them.
+A CI context in which release checks must pass: pushes to `stable`, whose
+tip is the release commit.
 _Avoid_: strict mode, release mode
 
 **Advisory context**:

--- a/docs/release/implementation.md
+++ b/docs/release/implementation.md
@@ -40,7 +40,7 @@ applies `relman`'s outputs as side-effects on the outside world.
 | ----------------- | ----- | -------- | ------- |
 | `changeset new [--empty <reason>]` | — | a `.changesets/<slug>.toml` scaffold | working tree |
 | `changeset check` | git diff vs base, `.changesets/`, crate graph | pass/fail + diagnostics (enforcement) | nothing (read-only) |
-| `changeset rename --pr <N>` | `.changesets/` | renamed `pr-<N>.toml` | working tree |
+| `changeset rename --pr <N> [--base <REF>]` | `.changesets/`, the PR's diff against `<REF>` | renamed `pr-<N>.toml` | working tree |
 | `derive` | `.changesets/`, all `Cargo.toml`, crate graph | per-crate next-version table (highest-`kind` + pre-1.0 map + transitive) | nothing (read-only) |
 | `bump` | derive output | edited `Cargo.toml` versions + root `[workspace.dependencies]` pins (via `toml_edit`, format-preserving) | working tree |
 | `changelog` | `.changesets/`, derive output | per-crate + workspace changelog edits | working tree |

--- a/docs/release/implementation.md
+++ b/docs/release/implementation.md
@@ -45,7 +45,7 @@ applies `relman`'s outputs as side-effects on the outside world.
 | `bump` | derive output | edited `Cargo.toml` versions + root `[workspace.dependencies]` pins (via `toml_edit`, format-preserving) | working tree |
 | `changelog` | `.changesets/`, derive output | per-crate + workspace changelog edits | working tree |
 | `pr-body` | derive output, deployment status input | rendered release-PR description | stdout/file |
-| `tags` | derive output, cycle id | the tag set to apply (`<crate>-vX.Y.Z`, `cycle-<id>`, `cycle-<id>-rc.N`) | stdout/file |
+| `tags` | derive output, cycle id | the tag set to apply (`<crate>-X.Y.Z`, `cycle-<id>`, `cycle-<id>-rc.N`) | stdout/file |
 | `publish-plan` | crate graph, crates.io state (reuse `workbench check-published-versions`) | topo-ordered publish list, skipping unchanged | stdout/file |
 | `changeset clear` (release consume) | `.changesets/` | empties `.changesets/` | working tree |
 
@@ -266,8 +266,11 @@ Every path below is inert until the repo variable `RELMAN_PIPELINE_ACTIVE`
 is `true`; `RELMAN_PUBLISH_DRY_RUN` additionally downgrades publishing to
 advisory.
 
-1. **Merge/push to `stable`** → `blessing` publishes to crates.io, tags, cuts
-   the GitHub Release. `stable` is protected; the release App bypasses the
+1. **Merge of the release PR (`release-ready` → `stable`)** → `blessing`
+   publishes to crates.io, tags, cuts the GitHub Release. Blessing checks
+   that provenance (the pushed commit is the merge of a PR from
+   `release-ready`) and that the pusher is not its own App; any other push
+   to `stable` is carried back by the backport sentinel but never released. `stable` is protected; the release App bypasses the
    protection by design.
 2. **`rc-gate` nightly cron** advances the rc frontier when the gate condition
    holds. Its `workflow_dispatch` input `force=true` bypasses the gate and is

--- a/docs/release/pipeline.md
+++ b/docs/release/pipeline.md
@@ -46,11 +46,13 @@ landed. We do not cherry-pick from `dev` to cut releases — a release is always
 a **prefix** of `dev`'s history (the hotfix path, below, is the sole, contained
 exception).
 
-There are 17 publishable crates (`zainod`, `zaino-serve`, `zaino-state`,
+There are 23 publishable crates (`zainod`, `zaino-serve`, `zaino-state`,
 `zaino-proto`, `zaino-common`, `zaino-primitives`, `zaino-address`,
-`zaino-source`, `zaino-rpc`, `zaino-convert-zebra`, `zaino-source-zebra-rpc`,
-`zaino-source-zebra-readstate`, `zaino-source-zebra`, `zaino-consensus`,
-`zaino-mempool`, `zaino-mempool-service`, `zaino-status`) and 3 internal-only
+`zaino-source`, `zaino-source-macros`, `zaino-rpc`, `zaino-convert-zebra`,
+`zaino-source-zebra-rpc`, `zaino-source-zebra-readstate`, `zaino-source-zebra`,
+`zaino-consensus`, `zaino-mempool`, `zaino-mempool-service`, `zaino-status`,
+`zaino-encoding`, `zaino-chain-head`, `zaino-chain-head-service`,
+`zaino-chain-store`, `zaino-chain-store-zainodb`) and 3 internal-only
 (`e2e`, `clientless`, `zaino-testutils`). Each public crate is versioned and
 released **independently**. The authoritative, machine-read list of governed
 targets is [`relman.toml`](../../../relman.toml) at the repo root; this prose
@@ -1014,7 +1016,7 @@ From [ADR 003 §5, "Public interfaces governed by this ADR"](https://github.com/
 > This section defines the "compatibility surface" that drives SemVer bumps and stable-branch gatekeeping.
 
 **Authoritative crate list (this repo)**: [Context](#context) enumerates the
-**17 crates.io-published packages** and **3 internal-only packages** (`e2e`,
+**23 crates.io-published packages** and **3 internal-only packages** (`e2e`,
 `clientless`, `zaino-testutils`), mirroring the machine-read
 [`relman.toml`](../../../relman.toml). This list has grown since ADR 003:
 `zaino-fetch` was **deleted** and the source stack (`zaino-source*`,

--- a/docs/release/pipeline.md
+++ b/docs/release/pipeline.md
@@ -676,7 +676,7 @@ were already cleared by the commit being promoted. "Whatever cleared all gates
 by Friday" is exactly whatever is on `release-ready` on Friday; work that only
 cleared the deployment gate after the cut simply ships the next cycle — *easy as that*.
 
-At blessing, CI: finalizes the derived versions, applies the `<crate>-vX.Y.Z`
+At blessing, CI: finalizes the derived versions, applies the `<crate>-X.Y.Z`
 and `cycle-<id>` tags, publishes (Docker, GitHub Release, crates.io in
 dependency order), **marks the shipped changesets consumed** (stamps each
 `consumed_in`, rather than deleting — see
@@ -713,6 +713,9 @@ fast-forward and nothing is lost. Version-agnostic branches make this safe:
 there is no version-named branch to reconcile.
 
 **Nuclear option.** A true emergency may go straight to `stable`. Both
+Such a push is **not blessed**: blessing releases only the merge of the
+release PR, so the hotfix reaches users through the next cycle after the
+sentinel carries it back to `dev`.
 sentinels then catch the fallout: the forward Release PR flags `release-ready`
 as behind `stable` (forcing the fix into `rc`/`release-ready`), and the reverse
 sentinel forces it into `dev`.
@@ -757,10 +760,10 @@ replacement):
 
 | Workflow | Verdict |
 | -------- | ------- |
-| `auto-tag-rc.yml` | **delete** — derives version from the `rc/<version>` branch name; obsolete under version-agnostic branches |
-| `final-tag-on-stable.yml` | **delete** — same branch-name→version coupling; replaced by blessing-time tagging from changesets |
-| `release.yaml` | **rework** — retarget to `cycle-*` + `<crate>-vX.Y.Z` tags; Docker image = `zainod` version + cycle handle |
-| `publish-dry-run.yml` + `check-published-versions` | **keep / rework** — the Rust guard is reusable; fold into the new publish flow |
+| `auto-tag-rc.yml` | **keep until cutover** — derives version from the `rc/<version>` branch name; gated off by `RELMAN_PIPELINE_ACTIVE=true`, delete afterwards |
+| `final-tag-on-stable.yml` | **keep until cutover** — same branch-name→version coupling; gated off by `RELMAN_PIPELINE_ACTIVE=true`, replaced by blessing-time tagging from changesets |
+| `release.yaml` | **reworked** — also fires on the `zainod-X.Y.Z` provenance tag and takes the image version from it; the GitHub Release job runs only for legacy tags |
+| `publish-dry-run.yml` + `check-published-versions` | **kept** — blocking on `stable` pushes, advisory elsewhere (`rc` is version-agnostic); the Rust guard also runs in blessing's pre-flight |
 | `ci.yml`, `ci-nightly.yaml` | **rework** into the `dev`-gate and `rc`-gate suite runners |
 | `compute-tag.yml`, `build-n-push-ci-image.yaml`, `trigger-integration-tests.yml`, `shellcheck.yaml` | **keep** — orthogonal to release versioning |
 

--- a/relman.toml
+++ b/relman.toml
@@ -6,9 +6,12 @@
 # and the publish plan covers exactly this set. No `cargo metadata` heuristic
 # decides governance — this file does.
 #
-# Target set: the 17 crates.io-published packages (docs/release/
+# Target set: the 23 crates.io-published packages (docs/release/
 # pipeline.md § Context). The internal-only crates
 # (live-tests/{e2e,clientless,zaino-testutils}) are deliberately absent.
+# Every workspace crate a target depends on through a path + version
+# requirement is itself a target: `cargo publish` resolves that requirement
+# against crates.io, so an ungoverned dependency would never be released.
 
 [options]
 changesets_dir      = ".changesets"
@@ -89,3 +92,27 @@ path = "packages/zaino-mempool-service"
 [[target]]
 name = "zaino-status"
 path = "packages/zaino-status"
+
+[[target]]
+name = "zaino-encoding"
+path = "packages/zaino-encoding"
+
+[[target]]
+name = "zaino-source-macros"
+path = "packages/zaino-source-macros"
+
+[[target]]
+name = "zaino-chain-head"
+path = "packages/zaino-chain-head"
+
+[[target]]
+name = "zaino-chain-head-service"
+path = "packages/zaino-chain-head-service"
+
+[[target]]
+name = "zaino-chain-store"
+path = "packages/zaino-chain-store"
+
+[[target]]
+name = "zaino-chain-store-zainodb"
+path = "packages/zaino-chain-store-zainodb"

--- a/tools/relman/crates/adapters/src/cargo_metadata_workspace.rs
+++ b/tools/relman/crates/adapters/src/cargo_metadata_workspace.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
+use std::process::Command;
 
 use cargo_metadata::{DependencyKind, MetadataCommand};
 use relman_core::ports::{Workspace, WorkspaceError};
@@ -111,6 +112,32 @@ impl Workspace for CargoMetadataWorkspace {
             }
         }
         Ok(edges)
+    }
+
+    fn refresh_lockfile(&self) -> Result<(), WorkspaceError> {
+        // `--workspace` rewrites only the members' own lock entries, leaving
+        // every third-party pin as it was; `--offline` keeps the refresh from
+        // touching the registry, which the member-only update never needs.
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into());
+        let output = Command::new(cargo)
+            .arg("update")
+            .arg("--workspace")
+            .arg("--offline")
+            .arg("--manifest-path")
+            .arg(&self.manifest_path)
+            .output()
+            .map_err(|err| WorkspaceError::Backend {
+                message: format!("failed to run cargo update: {err}"),
+            })?;
+        if output.status.success() {
+            return Ok(());
+        }
+        Err(WorkspaceError::Backend {
+            message: format!(
+                "cargo update --workspace failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            ),
+        })
     }
 }
 
@@ -262,6 +289,29 @@ mod tests {
             ungoverned.is_empty(),
             "governed targets depend on workspace crates relman.toml does not govern:\n{}",
             ungoverned.into_iter().collect::<Vec<_>>().join("\n")
+        );
+    }
+
+    #[test]
+    fn refresh_lockfile_records_a_changed_member_version() {
+        let tmp = tempfile::tempdir().expect("temp dir");
+        build_workspace(tmp.path(), "0.3");
+        let adapter = adapter(tmp.path());
+        adapter
+            .versions()
+            .expect("first metadata run writes Cargo.lock");
+
+        write_member(
+            tmp.path(),
+            "dependency",
+            "[package]\nname = \"dependency\"\nversion = \"0.3.2\"\nedition = \"2021\"\n",
+        );
+        adapter.refresh_lockfile().expect("refresh succeeds");
+
+        let lock = fs::read_to_string(tmp.path().join("Cargo.lock")).expect("read lock");
+        assert!(
+            lock.contains("version = \"0.3.2\""),
+            "lock not refreshed:\n{lock}"
         );
     }
 

--- a/tools/relman/crates/adapters/src/lib.rs
+++ b/tools/relman/crates/adapters/src/lib.rs
@@ -5,6 +5,8 @@
 //! Only the binary's composition root names these; the domain depends on the
 //! port traits, never on this crate.
 
+#![forbid(unsafe_code)]
+
 mod cargo_metadata_workspace;
 mod fs_changelog_store;
 mod fs_changeset_store;

--- a/tools/relman/crates/app/src/main.rs
+++ b/tools/relman/crates/app/src/main.rs
@@ -10,8 +10,11 @@
 //! `ChangesetService` → `ChangesetStore` + `SlugSource`). Later slices add the
 //! remaining release adapters and commands.
 
+#![forbid(unsafe_code)]
+
 use std::collections::BTreeSet;
 use std::path::PathBuf;
+use std::process::ExitCode;
 use std::sync::Arc;
 
 use anyhow::{Context, Result, bail};
@@ -21,10 +24,10 @@ use relman_adapters::{
     CargoMetadataWorkspace, FsChangelogStore, FsChangesetStore, FsConsumedLedgerStore, GitVcs,
     RandomSlugSource, RandomUidSource, TomlEditManifestEditor,
 };
-use relman_cli::{Cli, Command, Ctx, commands};
+use relman_cli::{ChangesetCommandError, Cli, Command, Ctx, commands};
 use relman_core::ports::{
     ApplyBump, Changelog, ChangelogStore, ChangesetCheck, ChangesetStore, Changesets, Clock,
-    ConsumedLedgerStore, ManifestEditor, ReleaseArtifacts, SlugSource, UidSource, Vcs, Versions,
+    ConsumedLedgerStore, ManifestEditor, ReleaseArtifacts, SlugSource, UidSource, Versions,
     Workspace,
 };
 use relman_core::types::{CrateName, DateTime, Utc};
@@ -66,42 +69,70 @@ impl Clock for SystemClock {
     }
 }
 
-fn main() -> Result<()> {
+/// A failed run: the exit status to report and the error to print.
+struct Failure {
+    code: ExitCode,
+    error: anyhow::Error,
+}
+
+impl From<anyhow::Error> for Failure {
+    fn from(error: anyhow::Error) -> Self {
+        Self {
+            code: ExitCode::FAILURE,
+            error,
+        }
+    }
+}
+
+impl From<ChangesetCommandError> for Failure {
+    fn from(error: ChangesetCommandError) -> Self {
+        Self {
+            code: ExitCode::from(error.exit_code()),
+            error: error.into(),
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(failure) => {
+            eprintln!("Error: {:?}", failure.error);
+            failure.code
+        }
+    }
+}
+
+fn run() -> Result<(), Failure> {
     let cli = Cli::parse();
 
     match &cli.command {
-        Command::About(args) => with_ctx(|ctx| {
-            commands::about::run(args, ctx);
+        // `about` needs no repository: it reports the binary's own version and
+        // the clock, so it must work wherever `relman --version` does.
+        Command::About(args) => {
+            let clock: Arc<dyn Clock> = Arc::new(SystemClock);
+            commands::about::run(args, &AboutService::new(clock));
             Ok(())
-        }),
-        Command::Changeset(args) => with_ctx(|ctx| {
-            commands::changeset::run(args, ctx)?;
-            Ok(())
-        }),
-        Command::Versions(args) => with_ctx(|ctx| {
-            commands::versions::run(args, ctx)?;
-            Ok(())
-        }),
-        Command::Bump(args) => with_ctx(|ctx| {
-            commands::bump::run(args, ctx)?;
-            Ok(())
-        }),
-        Command::Changelog(args) => with_ctx(|ctx| {
-            commands::changelog::run(args, ctx)?;
-            Ok(())
-        }),
-        Command::Tags(args) => with_ctx(|ctx| {
-            commands::tags::run(args, ctx)?;
-            Ok(())
-        }),
-        Command::PrBody(args) => with_ctx(|ctx| {
-            commands::pr_body::run(args, ctx)?;
-            Ok(())
-        }),
-        Command::PublishPlan(args) => with_ctx(|ctx| {
-            commands::publish_plan::run(args, ctx)?;
-            Ok(())
-        }),
+        }
+        Command::Changeset(args) => with_ctx(|ctx| commands::changeset::run(args, ctx)),
+        Command::Versions(args) => {
+            with_ctx(|ctx| commands::versions::run(args, ctx).map_err(anyhow::Error::new))
+        }
+        Command::Bump(args) => {
+            with_ctx(|ctx| commands::bump::run(args, ctx).map_err(anyhow::Error::new))
+        }
+        Command::Changelog(args) => {
+            with_ctx(|ctx| commands::changelog::run(args, ctx).map_err(anyhow::Error::new))
+        }
+        Command::Tags(args) => {
+            with_ctx(|ctx| commands::tags::run(args, ctx).map_err(anyhow::Error::new))
+        }
+        Command::PrBody(args) => {
+            with_ctx(|ctx| commands::pr_body::run(args, ctx).map_err(anyhow::Error::new))
+        }
+        Command::PublishPlan(args) => {
+            with_ctx(|ctx| commands::publish_plan::run(args, ctx).map_err(anyhow::Error::new))
+        }
     }
 }
 
@@ -109,7 +140,7 @@ fn main() -> Result<()> {
 ///
 /// Loads `relman.toml` from the current directory, resolves the changesets
 /// directory relative to it, and wires the real adapters into the services.
-fn with_ctx(f: impl FnOnce(&Ctx) -> Result<()>) -> Result<()> {
+fn with_ctx<E: Into<Failure>>(f: impl FnOnce(&Ctx) -> Result<(), E>) -> Result<(), Failure> {
     let root_dir = find_manifest_dir()?;
     let manifest_path = root_dir.join(MANIFEST_NAME);
     let config = relman_config::load(&manifest_path)
@@ -119,9 +150,6 @@ fn with_ctx(f: impl FnOnce(&Ctx) -> Result<()>) -> Result<()> {
     // `relman.toml` lives); resolve them against the discovered root so the
     // command works regardless of the current directory.
     let changesets_dir = root_dir.join(config.options().changesets_dir().as_path());
-
-    let clock: Arc<dyn Clock> = Arc::new(SystemClock);
-    let about = Arc::new(AboutService::new(clock));
 
     // The consumed-UID ledger store, rooted at the resolved path. CI refreshes
     // the file from `origin/stable` before a derivation; relman reads it as a
@@ -138,16 +166,17 @@ fn with_ctx(f: impl FnOnce(&Ctx) -> Result<()>) -> Result<()> {
     let store: Arc<dyn ChangesetStore> = Arc::new(FsChangesetStore::new(changesets_dir.clone()));
     let slugs: Arc<dyn SlugSource> = Arc::new(RandomSlugSource::new());
     let uids: Arc<dyn UidSource> = Arc::new(RandomUidSource::new());
+    // Run git in the repo root so it reports paths relative to that root,
+    // matching the target `path`s in `relman.toml`. The rename step matches
+    // those paths against the repo-relative changesets dir.
     let changesets: Arc<dyn Changesets> = Arc::new(ChangesetService::new(
         store.clone(),
         slugs,
         uids,
         ledger_store.clone(),
+        GitVcs::new(root_dir.clone()),
+        config.options().changesets_dir().as_path().to_path_buf(),
     ));
-
-    // Run git in the repo root so it reports paths relative to that root,
-    // matching the target `path`s in `relman.toml`.
-    let vcs: Arc<dyn Vcs> = Arc::new(GitVcs::new(root_dir.clone()));
 
     // The workspace adapter reads resolved versions and dependency edges from
     // the repo-root manifest via `cargo metadata`, filtered to the governed set.
@@ -157,8 +186,7 @@ fn with_ctx(f: impl FnOnce(&Ctx) -> Result<()>) -> Result<()> {
         .map(|target| target.name().clone())
         .collect();
     let root_manifest = root_dir.join(config.options().root_manifest().as_path());
-    let workspace: Arc<dyn Workspace> =
-        Arc::new(CargoMetadataWorkspace::new(root_manifest.clone(), governed));
+    let workspace = Arc::new(CargoMetadataWorkspace::new(root_manifest.clone(), governed));
     let versions: Arc<dyn Versions> = Arc::new(VersionService::new(
         config.clone(),
         store.clone(),
@@ -166,13 +194,14 @@ fn with_ctx(f: impl FnOnce(&Ctx) -> Result<()>) -> Result<()> {
         ledger.clone(),
     ));
 
-    // Applies the derived table to the manifests via format-preserving edits.
+    // Applies the derived table to the manifests via format-preserving edits,
+    // then refreshes the lockfile through the workspace adapter.
     let editor: Arc<dyn ManifestEditor> = Arc::new(TomlEditManifestEditor::new());
-    let apply_bump: Arc<dyn ApplyBump> = Arc::new(BumpService::new(config.clone(), editor));
+    let apply_bump: Arc<dyn ApplyBump> =
+        Arc::new(BumpService::new(config.clone(), editor, workspace.clone()));
 
     // Generates changelog sections and splices them into the per-crate and
-    // workspace `CHANGELOG.md` files (a fresh clock: the earlier one moved into
-    // the about service).
+    // workspace `CHANGELOG.md` files.
     let changelog_store: Arc<dyn ChangelogStore> = Arc::new(FsChangelogStore::new());
     let changelog: Arc<dyn Changelog> = Arc::new(ChangelogService::new(
         config.clone(),
@@ -186,18 +215,22 @@ fn with_ctx(f: impl FnOnce(&Ctx) -> Result<()>) -> Result<()> {
     // Computes the release artifacts (tag plan, PR body, publish order) as pure
     // plans for CI to apply — reuses the derived table, the changesets, and the
     // crate graph, and mutates nothing.
+    let workspace_port: Arc<dyn Workspace> = workspace;
     let release_artifacts: Arc<dyn ReleaseArtifacts> = Arc::new(ReleaseArtifactsService::new(
         versions.clone(),
         store.clone(),
-        workspace,
+        workspace_port,
         ledger.clone(),
     ));
 
-    let changeset_check: Arc<dyn ChangesetCheck> =
-        Arc::new(ChangesetCheckService::new(config, vcs, store, ledger));
+    let changeset_check: Arc<dyn ChangesetCheck> = Arc::new(ChangesetCheckService::new(
+        config,
+        Arc::new(GitVcs::new(root_dir.clone())),
+        store,
+        ledger,
+    ));
 
     let ctx = Ctx {
-        about,
         changesets,
         changeset_check,
         versions,
@@ -207,5 +240,5 @@ fn with_ctx(f: impl FnOnce(&Ctx) -> Result<()>) -> Result<()> {
         changesets_dir,
         root_manifest,
     };
-    f(&ctx)
+    f(&ctx).map_err(Into::into)
 }

--- a/tools/relman/crates/cli/src/commands/about.rs
+++ b/tools/relman/crates/cli/src/commands/about.rs
@@ -1,12 +1,14 @@
 use clap::Args as ClapArgs;
 
-use crate::context::Ctx;
+use relman_core::ports::About;
+
 use crate::format;
 
 #[derive(ClapArgs)]
 pub struct Args {}
 
-pub fn run(_args: &Args, ctx: &Ctx) {
-    let report = ctx.about.report();
+/// Print relman's version and clock; needs no manifest, ledger, or repository.
+pub fn run<A: About>(_args: &Args, about: &A) {
+    let report = about.report();
     println!("{}", format::about(&report));
 }

--- a/tools/relman/crates/cli/src/commands/changeset.rs
+++ b/tools/relman/crates/cli/src/commands/changeset.rs
@@ -11,6 +11,16 @@ mod consume;
 mod new;
 mod rename;
 
+/// The default base ref: PRs are gated against `dev`.
+const DEFAULT_BASE: &str = "dev";
+
+/// The exit status for a check that found the PR non-compliant.
+const EXIT_CHECK_FAILED: u8 = 1;
+
+/// The exit status for a check that found a malformed changeset, so CI can
+/// always fail it regardless of the advisory rollout flag.
+const EXIT_CHECK_MALFORMED: u8 = 2;
+
 /// `relman changeset <action>` — author and manage changeset files.
 #[derive(ClapArgs)]
 pub struct Args {
@@ -54,9 +64,27 @@ pub enum ChangesetCommandError {
         /// How many violations were reported.
         count: usize,
     },
+    /// The check ran and at least one of this PR's changesets is malformed
+    /// (unparseable, or naming an unknown target), which no rollout flag may
+    /// downgrade to a warning.
+    #[error("changeset check failed: {count} violation(s), including a malformed changeset")]
+    CheckMalformed {
+        /// How many violations were reported.
+        count: usize,
+    },
     /// The check could not run because of an infrastructure failure.
     #[error("changeset check could not run")]
     Check(#[from] CheckError),
+}
+
+impl ChangesetCommandError {
+    /// The process exit status this error maps to.
+    pub fn exit_code(&self) -> u8 {
+        match self {
+            Self::CheckMalformed { .. } => EXIT_CHECK_MALFORMED,
+            _ => EXIT_CHECK_FAILED,
+        }
+    }
 }
 
 pub fn run(args: &Args, ctx: &Ctx) -> Result<(), ChangesetCommandError> {

--- a/tools/relman/crates/cli/src/commands/changeset/check.rs
+++ b/tools/relman/crates/cli/src/commands/changeset/check.rs
@@ -1,10 +1,9 @@
 use clap::Args as ClapArgs;
 
-use crate::commands::changeset::ChangesetCommandError;
-use crate::context::Ctx;
+use relman_core::ports::Violation;
 
-/// The default base ref: PRs are gated against `dev`.
-const DEFAULT_BASE: &str = "dev";
+use crate::commands::changeset::{ChangesetCommandError, DEFAULT_BASE};
+use crate::context::Ctx;
 
 /// `relman changeset check [--base <REF>]`.
 #[derive(ClapArgs)]
@@ -23,7 +22,16 @@ pub fn run(args: &Args, ctx: &Ctx) -> Result<(), ChangesetCommandError> {
     for violation in &report.violations {
         eprintln!("relman: {}", violation.message());
     }
-    Err(ChangesetCommandError::CheckFailed {
-        count: report.violations.len(),
-    })
+    let count = report.violations.len();
+    let malformed = report.violations.iter().any(|violation| {
+        matches!(
+            violation,
+            Violation::ChangesetParse { .. } | Violation::UnknownTargetInChangeset(_)
+        )
+    });
+    if malformed {
+        Err(ChangesetCommandError::CheckMalformed { count })
+    } else {
+        Err(ChangesetCommandError::CheckFailed { count })
+    }
 }

--- a/tools/relman/crates/cli/src/commands/changeset/rename.rs
+++ b/tools/relman/crates/cli/src/commands/changeset/rename.rs
@@ -1,24 +1,28 @@
 use clap::Args as ClapArgs;
 
-use crate::commands::changeset::ChangesetCommandError;
+use crate::commands::changeset::{ChangesetCommandError, DEFAULT_BASE};
 use crate::context::Ctx;
 
-/// `relman changeset rename --pr <N>`.
+/// `relman changeset rename --pr <N> [--base <REF>]`.
 ///
 /// The PR-gate bot step: rename this PR's author changeset(s) — the random
-/// `adjective-noun` slug(s) — to the canonical `pr-<N>` name(s). Accumulated
-/// `pr-*` files from earlier merged PRs are left untouched, and the command is
-/// a no-op (exit 0) when the PR carries no author changesets, so the bot may
-/// safely re-run it.
+/// `adjective-noun` slug(s) the PR's diff against `--base` added — to the
+/// canonical `pr-<N>` name(s). Accumulated `pr-*` files, non-canonical files
+/// inherited from the base, and already-shipped changesets are left untouched,
+/// and the command is a no-op (exit 0) when the PR carries no author
+/// changesets, so the bot may safely re-run it.
 #[derive(ClapArgs)]
 pub struct Args {
     /// The PR number to rename this PR's author changeset(s) under.
     #[arg(long, value_name = "N")]
     pr: u32,
+    /// The base ref to diff `HEAD` against (the PR's merge target).
+    #[arg(long, value_name = "REF", default_value = DEFAULT_BASE)]
+    base: String,
 }
 
 pub fn run(args: &Args, ctx: &Ctx) -> Result<(), ChangesetCommandError> {
-    let renamed = ctx.changesets.rename_to_pr(args.pr)?;
+    let renamed = ctx.changesets.rename_to_pr(args.pr, &args.base)?;
     if renamed.is_empty() {
         println!("relman: no author changesets to rename");
         return Ok(());

--- a/tools/relman/crates/cli/src/commands/publish_plan.rs
+++ b/tools/relman/crates/cli/src/commands/publish_plan.rs
@@ -21,6 +21,11 @@ pub enum PublishPlanCommandError {
 pub fn run(_args: &Args, ctx: &Ctx) -> Result<(), PublishPlanCommandError> {
     crate::warn::unfilled_templates(ctx);
     let plan = ctx.release_artifacts.publish_plan()?;
+    // The note goes to stderr: stdout is the machine-read plan, one crate per
+    // line, and an empty plan must leave it empty.
+    if plan.is_empty() {
+        eprintln!("relman: nothing to publish (no changesets affect a governed target)");
+    }
     print!("{}", format::publish_plan(&plan));
     Ok(())
 }

--- a/tools/relman/crates/cli/src/context.rs
+++ b/tools/relman/crates/cli/src/context.rs
@@ -2,13 +2,13 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use relman_core::ports::{
-    About, ApplyBump, Changelog, ChangesetCheck, Changesets, ReleaseArtifacts, Versions,
+    ApplyBump, Changelog, ChangesetCheck, Changesets, ReleaseArtifacts, Versions,
 };
 
-/// The driving ports the CLI needs, injected by the binary's composition
-/// root. Add a field per port as relman grows.
+/// The repo-bound driving ports the CLI needs, injected by the binary's
+/// composition root. Add a field per port as relman grows; `about` is not
+/// here because it needs no repository.
 pub struct Ctx {
-    pub about: Arc<dyn About>,
     pub changesets: Arc<dyn Changesets>,
     pub changeset_check: Arc<dyn ChangesetCheck>,
     pub versions: Arc<dyn Versions>,

--- a/tools/relman/crates/cli/src/format.rs
+++ b/tools/relman/crates/cli/src/format.rs
@@ -53,11 +53,9 @@ pub fn tag_plan(plan: &TagPlan) -> String {
     out
 }
 
-/// Render a publish plan: one `crate version` per line, in publish order.
+/// Render a publish plan: one `crate version` per line, in publish order, and
+/// nothing at all for an empty plan, since CI parses every line as a crate.
 pub fn publish_plan(plan: &PublishPlan) -> String {
-    if plan.is_empty() {
-        return "relman: nothing to publish (no changesets affect a governed target)\n".to_owned();
-    }
     let mut out = String::new();
     for (name, version) in plan.entries() {
         out.push_str(&format!("{name} {version}\n"));

--- a/tools/relman/crates/cli/src/lib.rs
+++ b/tools/relman/crates/cli/src/lib.rs
@@ -4,6 +4,8 @@
 //! held in [`Ctx`]. It knows nothing of concrete services or adapters — the
 //! binary builds [`Ctx`] and hands it in.
 
+#![forbid(unsafe_code)]
+
 mod app;
 pub mod commands;
 mod context;

--- a/tools/relman/crates/config/src/lib.rs
+++ b/tools/relman/crates/config/src/lib.rs
@@ -6,6 +6,8 @@
 //! defaults and parse-don't-validate so invalid input fails at [`load`], not
 //! deep in a later slice. The typed result is [`ReleaseConfig`].
 
+#![forbid(unsafe_code)]
+
 mod config;
 mod error;
 mod load;

--- a/tools/relman/crates/config/src/load.rs
+++ b/tools/relman/crates/config/src/load.rs
@@ -330,8 +330,8 @@ path = "../escape"
         let manifest = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../../../relman.toml");
         let config = load(&manifest).expect("repo relman.toml should parse");
 
-        // The 17 crates.io-published targets from the release ADR § Context.
-        assert_eq!(config.targets().len(), 17);
+        // The 23 crates.io-published targets from the release ADR § Context.
+        assert_eq!(config.targets().len(), 23);
         for name in [
             "zainod",
             "zaino-serve",
@@ -350,6 +350,12 @@ path = "../escape"
             "zaino-mempool",
             "zaino-mempool-service",
             "zaino-status",
+            "zaino-encoding",
+            "zaino-source-macros",
+            "zaino-chain-head",
+            "zaino-chain-head-service",
+            "zaino-chain-store",
+            "zaino-chain-store-zainodb",
         ] {
             let crate_name = CrateName::parse(name).expect("governed name is valid");
             assert!(

--- a/tools/relman/crates/core/src/lib.rs
+++ b/tools/relman/crates/core/src/lib.rs
@@ -11,6 +11,8 @@
 //! - [`mocks`] — in-memory port implementations for tests, behind the
 //!   `test-support` feature.
 
+#![forbid(unsafe_code)]
+
 pub mod ports;
 pub mod types;
 

--- a/tools/relman/crates/core/src/mocks/workspace.rs
+++ b/tools/relman/crates/core/src/mocks/workspace.rs
@@ -46,4 +46,8 @@ impl Workspace for MapWorkspace {
     ) -> Result<BTreeMap<CrateName, Vec<(CrateName, semver::VersionReq)>>, WorkspaceError> {
         Ok(self.internal_deps.clone())
     }
+
+    fn refresh_lockfile(&self) -> Result<(), WorkspaceError> {
+        Ok(())
+    }
 }

--- a/tools/relman/crates/core/src/ports/driven.rs
+++ b/tools/relman/crates/core/src/ports/driven.rs
@@ -261,6 +261,9 @@ pub trait Workspace: Send + Sync {
     fn internal_deps(
         &self,
     ) -> Result<BTreeMap<CrateName, Vec<(CrateName, semver::VersionReq)>>, WorkspaceError>;
+
+    /// Bring the workspace lockfile back in step with the member manifests after their versions changed.
+    fn refresh_lockfile(&self) -> Result<(), WorkspaceError>;
 }
 
 /// Everything that can go wrong applying a derived bump to a manifest.

--- a/tools/relman/crates/core/src/ports/driving.rs
+++ b/tools/relman/crates/core/src/ports/driving.rs
@@ -474,7 +474,7 @@ pub trait ReleaseArtifacts: Send + Sync {
     /// - `rc = Some(n)` (a soak/prerelease cut): a single `cycle-<id>-rc.<n>`
     ///   prerelease tag.
     /// - `rc = None` (a blessing): the `cycle-<id>` period tag followed by one
-    ///   `<crate>-v<next>` provenance tag per bumping crate, in config order.
+    ///   `<crate>-<next>` provenance tag per bumping crate, in config order.
     fn tags(&self, cycle: &CycleId, rc: Option<u32>) -> Result<TagPlan, ArtifactError>;
 
     /// The rendered release-PR body for `cycle`.

--- a/tools/relman/crates/core/src/ports/driving.rs
+++ b/tools/relman/crates/core/src/ports/driving.rs
@@ -45,6 +45,9 @@ pub enum ChangesetsError {
     /// A consumed-ledger store operation failed while recording shipped ids.
     #[error("consumed-ledger store operation failed")]
     Ledger(#[from] ConsumedLedgerStoreError),
+    /// Querying version control for the PR's changed files failed.
+    #[error("version-control query failed")]
+    Vcs(#[from] VcsError),
     /// Every candidate slug collided with an existing file within the retry
     /// budget — vanishingly unlikely, so it signals an exhausted or degenerate
     /// slug source rather than ordinary contention.
@@ -93,15 +96,18 @@ pub trait Changesets: Send + Sync {
     /// name(s), returning the new slug(s).
     ///
     /// Backs the `relman changeset rename --pr <N>` step the PR-gate bot runs.
-    /// "This PR's files" are the changesets whose slug is *not* already a
-    /// [canonical PR name](Slug::is_canonical_pr) — the author's random slug(s);
-    /// accumulated `pr-*` files from earlier merged PRs are left untouched. The
-    /// non-canonical sources are renamed in sorted order: the first becomes
-    /// `pr-<pr>`, the second `pr-<pr>-2`, and so on
-    /// ([`Slug::for_pr`](crate::types::Slug::for_pr)). A pre-existing target
-    /// name is an error. Zero author files is a no-op returning an empty vec —
-    /// the bot may safely re-run, since renaming is idempotent once canonical.
-    fn rename_to_pr(&self, pr: u32) -> Result<Vec<Slug>, ChangesetsError>;
+    /// "This PR's files" are the changesets that appear in the PR's diff
+    /// against `base` and whose slug is *not* already a
+    /// [canonical PR name](Slug::is_canonical_pr) — the author's random slug(s).
+    /// Accumulated `pr-*` files from earlier merged PRs, non-canonical files the
+    /// PR merely inherited from `base`, and already-shipped changesets (marked
+    /// `consumed_in` or recorded in the ledger) are left untouched. The sources
+    /// are renamed in sorted order: the first becomes `pr-<pr>`, the second
+    /// `pr-<pr>-2`, and so on ([`Slug::for_pr`](crate::types::Slug::for_pr)). A
+    /// pre-existing target name is an error. Zero author files is a no-op
+    /// returning an empty vec — the bot may safely re-run, since renaming is
+    /// idempotent once canonical.
+    fn rename_to_pr(&self, pr: u32, base: &str) -> Result<Vec<Slug>, ChangesetsError>;
 
     /// The slugs of every *pending* (not-yet-consumed) changeset in the store,
     /// sorted. A read-only listing that mutates nothing, backing the dry run of
@@ -308,6 +314,9 @@ pub enum ApplyError {
     /// Editing one of the manifests failed.
     #[error("manifest edit failed")]
     Manifest(#[from] ManifestError),
+    /// Refreshing the workspace lockfile after the manifest edits failed.
+    #[error("lockfile refresh failed")]
+    Workspace(#[from] WorkspaceError),
 }
 
 /// Inbound port: mechanically apply a derived [`BumpTable`] to the workspace

--- a/tools/relman/crates/core/src/types/cycle_status.rs
+++ b/tools/relman/crates/core/src/types/cycle_status.rs
@@ -385,6 +385,12 @@ impl RawRcEntry {
             value: self.tag.clone(),
             source,
         })?;
+        if tag.rc_ordinal().is_none() {
+            return Err(CycleStatusError::InvalidRcTag {
+                value: self.tag.clone(),
+                source: InvalidTag::MissingRcOrdinal,
+            });
+        }
         let sha = Commit::parse(&self.sha).map_err(|source| CycleStatusError::InvalidRcSha {
             value: self.sha.clone(),
             source,

--- a/tools/relman/crates/core/src/types/slug.rs
+++ b/tools/relman/crates/core/src/types/slug.rs
@@ -12,6 +12,9 @@
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Slug(String);
 
+/// The changeset-file extension; only `*.toml` under the changesets dir count as changeset files.
+const CHANGESET_EXT: &str = "toml";
+
 /// Why a string was rejected as a [`Slug`].
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum InvalidSlug {
@@ -60,6 +63,21 @@ impl Slug {
     /// The changeset file name this slug maps to: `<slug>.toml`.
     pub fn file_name(&self) -> String {
         format!("{}.toml", self.0)
+    }
+
+    /// The slug of `file` when it is a `*.toml` under `changesets_dir` whose stem is a valid slug.
+    pub fn of_changeset_file(
+        file: &std::path::Path,
+        changesets_dir: &std::path::Path,
+    ) -> Option<Self> {
+        if !file.starts_with(changesets_dir) {
+            return None;
+        }
+        if file.extension().and_then(|e| e.to_str()) != Some(CHANGESET_EXT) {
+            return None;
+        }
+        let stem = file.file_stem().and_then(|s| s.to_str())?;
+        Self::parse(stem).ok()
     }
 
     /// The canonical changeset slug for PR number `pr`, `index`-th file.

--- a/tools/relman/crates/core/src/types/tag.rs
+++ b/tools/relman/crates/core/src/types/tag.rs
@@ -41,7 +41,14 @@ pub enum InvalidTag {
     /// The name contained `..`, which git rejects in a ref.
     #[error("tag name must not contain '..'")]
     DoubleDot,
+    /// The name was expected to be a release-candidate tag but carries no
+    /// numeric `-rc.<M>` suffix.
+    #[error("tag name carries no numeric '-rc.<M>' suffix")]
+    MissingRcOrdinal,
 }
+
+/// The separator a release-candidate tag places before its ordinal.
+const RC_SEPARATOR: &str = "-rc.";
 
 impl Tag {
     /// Wrap a string produced from already-validated parts. Private: the only
@@ -67,7 +74,16 @@ impl Tag {
     /// The soak-prerelease tag `"cycle-{id}-rc.{n}"` (e.g.
     /// `cycle-2026-08-15-rc.6`) applied to each release-candidate cut.
     pub fn cycle_rc(cycle: &CycleId, n: u32) -> Self {
-        Self::from_valid(format!("cycle-{cycle}-rc.{n}"))
+        Self::from_valid(format!("cycle-{cycle}{RC_SEPARATOR}{n}"))
+    }
+
+    /// The numeric `<M>` of a `-rc.<M>` suffix, or `None` when the tag is not a release candidate.
+    pub fn rc_ordinal(&self) -> Option<u32> {
+        let (_, ordinal) = self.0.rsplit_once(RC_SEPARATOR)?;
+        if ordinal.is_empty() || !ordinal.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+        ordinal.parse().ok()
     }
 
     /// Parse an arbitrary string as a git tag name, enforcing the invariants
@@ -143,6 +159,23 @@ mod tests {
             "v1.2.3",
         ] {
             assert_eq!(Tag::parse(raw).expect("valid").as_str(), raw);
+        }
+    }
+
+    #[test]
+    fn rc_ordinal_reads_only_a_numeric_rc_suffix() {
+        assert_eq!(
+            Tag::cycle_rc(&cycle_id("2026-08-15"), 6).rc_ordinal(),
+            Some(6)
+        );
+        for raw in [
+            "cycle-1",
+            "nightly_build",
+            "cycle-1-rc.",
+            "cycle-1-rc.x",
+            "rc.3",
+        ] {
+            assert_eq!(Tag::parse(raw).expect("valid").rc_ordinal(), None, "{raw}");
         }
     }
 

--- a/tools/relman/crates/domain/src/lib.rs
+++ b/tools/relman/crates/domain/src/lib.rs
@@ -4,5 +4,7 @@
 //! `Arc<dyn Trait>`. It never names a concrete adapter, so it is unit-tested
 //! against the in-memory mocks from `relman-core`'s `test-support` feature.
 
+#![forbid(unsafe_code)]
+
 pub mod render;
 pub mod services;

--- a/tools/relman/crates/domain/src/render.rs
+++ b/tools/relman/crates/domain/src/render.rs
@@ -171,10 +171,8 @@ fn rc_label(tag: &str) -> &str {
 /// The numeric `<M>` of a prerelease tag's `rc.<M>` suffix, for ordering RCs by
 /// recency independent of the input order. A tag with no parseable suffix
 /// sorts as `0`.
-fn rc_number(tag: &str) -> u32 {
-    tag.rfind("-rc.")
-        .and_then(|idx| tag[idx + 4..].parse().ok())
-        .unwrap_or(0)
+fn rc_number(tag: &Tag) -> u32 {
+    tag.rc_ordinal().unwrap_or(0)
 }
 
 /// The most recent release-candidate tag in `status` — the `[[rc]]` entry with
@@ -184,7 +182,7 @@ fn latest_rc_tag(status: &CycleStatus) -> Option<&Tag> {
     status
         .rc()
         .iter()
-        .max_by_key(|entry| rc_number(entry.tag().as_str()))
+        .max_by_key(|entry| rc_number(entry.tag()))
         .map(|entry| entry.tag())
 }
 

--- a/tools/relman/crates/domain/src/render.rs
+++ b/tools/relman/crates/domain/src/render.rs
@@ -257,7 +257,7 @@ pub(crate) fn render_rc_table(cycle: &CycleId, status: &CycleStatus) -> String {
 /// trailing newline.
 ///
 /// With `with_tags`, a per-target `Tag` column carries each bumping crate's
-/// `<crate>-v<next>` provenance tag (the tag CI applies at blessing); without
+/// `<crate>-<next>` provenance tag (the tag CI applies at blessing); without
 /// it, the classic four-column table.
 pub(crate) fn render_version_table(table: &BumpTable, with_tags: bool) -> String {
     let mut out = String::from("## Version bumps (derived, since last stable)\n\n");

--- a/tools/relman/crates/domain/src/services/apply_bump.rs
+++ b/tools/relman/crates/domain/src/services/apply_bump.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use relman_config::ReleaseConfig;
-use relman_core::ports::{ApplyBump, ApplyError, ManifestEditor};
+use relman_core::ports::{ApplyBump, ApplyError, ManifestEditor, Workspace};
 use relman_core::types::{BumpTable, CrateBump};
 
 /// The `Cargo.toml` file name, joined onto a target's directory to reach its
@@ -20,16 +20,24 @@ const MANIFEST_NAME: &str = "Cargo.toml";
 ///    `[workspace.dependencies]` — how a bumped crate's new version reaches its
 ///    dependents (a crate not centrally pinned is simply skipped).
 ///
+/// It then refreshes the workspace lockfile through the [`Workspace`] port, so
+/// the tree it leaves behind passes the `--locked` checks that follow.
+///
 /// Every referenced crate is resolved against the config *before* any edit, so
 /// a bump naming an unknown target fails without leaving a half-edited tree.
-pub struct BumpService {
+pub struct BumpService<W: Workspace> {
     config: ReleaseConfig,
     editor: Arc<dyn ManifestEditor>,
+    workspace: Arc<W>,
 }
 
-impl BumpService {
-    pub fn new(config: ReleaseConfig, editor: Arc<dyn ManifestEditor>) -> Self {
-        Self { config, editor }
+impl<W: Workspace> BumpService<W> {
+    pub fn new(config: ReleaseConfig, editor: Arc<dyn ManifestEditor>, workspace: Arc<W>) -> Self {
+        Self {
+            config,
+            editor,
+            workspace,
+        }
     }
 
     /// Resolve `bump`'s crate to its manifest path, erroring if it is not a
@@ -46,7 +54,7 @@ impl BumpService {
     }
 }
 
-impl ApplyBump for BumpService {
+impl<W: Workspace> ApplyBump for BumpService<W> {
     fn apply(&self, table: &BumpTable) -> Result<(), ApplyError> {
         // Resolve every target up front so an unknown crate aborts before we
         // touch any file.
@@ -68,6 +76,12 @@ impl ApplyBump for BumpService {
                 .set_workspace_dep_version(root_manifest, bump.crate_name(), bump.next())?;
         }
 
+        // The manifests now disagree with the lockfile's recorded member
+        // versions; bring it back in step so a following `--locked` passes.
+        if !resolved.is_empty() {
+            self.workspace.refresh_lockfile()?;
+        }
+
         Ok(())
     }
 }
@@ -76,8 +90,12 @@ impl ApplyBump for BumpService {
 mod tests {
     use super::*;
 
-    use relman_core::mocks::RecordingManifestEditor;
+    use relman_core::mocks::{MapWorkspace, RecordingManifestEditor};
     use relman_core::types::{Bump, CrateName, ReleaseOptions, Target, Version, WorkspacePath};
+
+    fn service(names: &[&str], editor: Arc<RecordingManifestEditor>) -> BumpService<MapWorkspace> {
+        BumpService::new(config(names), editor, Arc::new(MapWorkspace::default()))
+    }
 
     fn name(raw: &str) -> CrateName {
         CrateName::parse(raw).expect("valid crate name")
@@ -123,7 +141,7 @@ mod tests {
     #[test]
     fn applies_package_versions_and_root_pins_for_every_bump() {
         let editor = Arc::new(RecordingManifestEditor::new());
-        let service = BumpService::new(config(&["zaino-state", "zainod"]), editor.clone());
+        let service = service(&["zaino-state", "zainod"], editor.clone());
 
         let table = BumpTable::new(vec![
             crate_bump("zaino-state", "0.6.0", "0.7.0", Bump::Minor),
@@ -167,7 +185,7 @@ mod tests {
     #[test]
     fn an_empty_table_edits_nothing() {
         let editor = Arc::new(RecordingManifestEditor::new());
-        let service = BumpService::new(config(&["zaino-state"]), editor.clone());
+        let service = service(&["zaino-state"], editor.clone());
         service
             .apply(&BumpTable::default())
             .expect("apply succeeds");
@@ -179,7 +197,7 @@ mod tests {
     fn a_bump_naming_an_unknown_target_errors_before_any_edit() {
         let editor = Arc::new(RecordingManifestEditor::new());
         // Config governs only zaino-state; the table also names zaino-proto.
-        let service = BumpService::new(config(&["zaino-state"]), editor.clone());
+        let service = service(&["zaino-state"], editor.clone());
         let table = BumpTable::new(vec![
             crate_bump("zaino-state", "0.6.0", "0.7.0", Bump::Minor),
             crate_bump("zaino-proto", "0.3.0", "0.3.1", Bump::Patch),

--- a/tools/relman/crates/domain/src/services/changeset_check.rs
+++ b/tools/relman/crates/domain/src/services/changeset_check.rs
@@ -1,5 +1,5 @@
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use relman_config::ReleaseConfig;
@@ -7,10 +7,6 @@ use relman_core::ports::{ChangesetCheck, ChangesetStore, CheckError, CheckReport
 use relman_core::types::{
     Changeset, ChangesetError, ConsumedLedger, CrateName, Slug, StoredChangeset,
 };
-
-/// The changeset-file extension. Only `*.toml` under the changesets dir count as
-/// this-PR changeset files.
-const TOML_EXT: &str = "toml";
 
 /// Enforces the `dev`-gate rule: a PR touching a governed target's source must
 /// carry a covering changeset **in its own diff**. Implements the
@@ -47,19 +43,6 @@ impl ChangesetCheckService {
         }
     }
 
-    /// The slug of a changed path iff it is a this-PR changeset file: a
-    /// `*.toml` under the configured changesets dir whose stem is a valid slug.
-    fn changeset_slug(&self, file: &Path, changesets_dir: &Path) -> Option<Slug> {
-        if !file.starts_with(changesets_dir) {
-            return None;
-        }
-        if file.extension().and_then(|e| e.to_str()) != Some(TOML_EXT) {
-            return None;
-        }
-        let stem = file.file_stem().and_then(|s| s.to_str())?;
-        Slug::parse(stem).ok()
-    }
-
     /// The set of targets whose source `files` touch, sorted by name for
     /// deterministic violation ordering.
     fn touched_targets(&self, files: &[PathBuf]) -> Vec<CrateName> {
@@ -80,12 +63,15 @@ impl ChangesetCheck for ChangesetCheckService {
         let changesets_dir = self.config.options().changesets_dir().as_path();
 
         // Partition the diff into this-PR changeset files (by slug) and
-        // everything else (candidate source files).
+        // everything else (candidate source files). A changeset path the PR
+        // deleted is in the diff but not in the store; it is not a this-PR
+        // changeset and covers nothing.
         let mut pr_changeset_slugs: Vec<Slug> = Vec::new();
         let mut source_files: Vec<PathBuf> = Vec::new();
         for file in changed {
-            match self.changeset_slug(&file, changesets_dir) {
-                Some(slug) => pr_changeset_slugs.push(slug),
+            match Slug::of_changeset_file(&file, changesets_dir) {
+                Some(slug) if self.store.exists(&slug)? => pr_changeset_slugs.push(slug),
+                Some(_deleted) => {}
                 None => source_files.push(file),
             }
         }

--- a/tools/relman/crates/domain/src/services/changesets.rs
+++ b/tools/relman/crates/domain/src/services/changesets.rs
@@ -1,8 +1,10 @@
+use std::collections::HashSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use relman_core::ports::{
     ChangesetStore, Changesets, ChangesetsError, ConsumedLedgerStore, NewChangeset, SlugSource,
-    UidSource,
+    UidSource, Vcs,
 };
 use relman_core::types::{CONSUMED_IN_KEY, Changeset, CycleId, Slug, StoredChangeset, Uid};
 
@@ -51,7 +53,7 @@ const TEMPLATE: &str = "\
 /// Its whole job: mint an immutable id, pick a slug that doesn't already exist,
 /// render the requested shape (id-stamped) to TOML text, write it, and return
 /// the chosen slug.
-pub struct ChangesetService {
+pub struct ChangesetService<V: Vcs> {
     store: Arc<dyn ChangesetStore>,
     slugs: Arc<dyn SlugSource>,
     uids: Arc<dyn UidSource>,
@@ -59,21 +61,48 @@ pub struct ChangesetService {
     /// each newly-consumed changeset's id here so a later derivation on `dev` can
     /// exclude it by id even before the per-file `consumed_in` mark backports.
     ledger: Arc<dyn ConsumedLedgerStore>,
+    /// The version-control view, so [`rename_to_pr`](Changesets::rename_to_pr)
+    /// renames only the changesets the PR itself added.
+    vcs: V,
+    /// The repo-relative changesets directory the diff's paths are matched
+    /// against.
+    changesets_dir: PathBuf,
 }
 
-impl ChangesetService {
+impl<V: Vcs> ChangesetService<V> {
     pub fn new(
         store: Arc<dyn ChangesetStore>,
         slugs: Arc<dyn SlugSource>,
         uids: Arc<dyn UidSource>,
         ledger: Arc<dyn ConsumedLedgerStore>,
+        vcs: V,
+        changesets_dir: PathBuf,
     ) -> Self {
         Self {
             store,
             slugs,
             uids,
             ledger,
+            vcs,
+            changesets_dir,
         }
+    }
+
+    /// Whether the changeset at `slug` has already shipped, by its in-file mark
+    /// or by its id in the ledger.
+    fn is_shipped(
+        &self,
+        slug: &Slug,
+        raw: &str,
+        ledger: &relman_core::types::ConsumedLedger,
+    ) -> Result<bool, ChangesetsError> {
+        let consumed =
+            StoredChangeset::consumed_marker(raw).map_err(|e| Self::parse_error(slug, e))?;
+        if consumed.is_some() {
+            return Ok(true);
+        }
+        let id = StoredChangeset::id_marker(raw).map_err(|e| Self::parse_error(slug, e))?;
+        Ok(id.is_some_and(|id| ledger.contains(&id)))
     }
 
     /// Map a changeset-parse failure to a [`ChangesetsError::Parse`] carrying
@@ -99,7 +128,7 @@ impl ChangesetService {
     }
 }
 
-impl Changesets for ChangesetService {
+impl<V: Vcs> Changesets for ChangesetService<V> {
     fn new(&self, req: NewChangeset) -> Result<Slug, ChangesetsError> {
         // Every changeset gets an immutable id at creation — before it is
         // written — so its identity is stamped from birth regardless of shape.
@@ -121,16 +150,30 @@ impl Changesets for ChangesetService {
         Ok(slugs)
     }
 
-    fn rename_to_pr(&self, pr: u32) -> Result<Vec<Slug>, ChangesetsError> {
-        // Only the author's random-slug files belong to this PR; accumulated
-        // `pr-*` files from earlier merged PRs are already canonical and left
-        // alone. Sort for deterministic ordinal assignment.
-        let mut sources: Vec<Slug> = self
-            .store
-            .list()?
-            .into_iter()
-            .filter(|slug| !slug.is_canonical_pr())
+    fn rename_to_pr(&self, pr: u32, base: &str) -> Result<Vec<Slug>, ChangesetsError> {
+        // Only the author's random-slug files that this PR itself added belong
+        // to it: accumulated `pr-*` files are already canonical, a non-canonical
+        // file inherited from `base` belongs to whichever PR merged it, and a
+        // shipped changeset is ledger provenance whose slug must not move.
+        let in_diff: HashSet<Slug> = self
+            .vcs
+            .changed_files(base)?
+            .iter()
+            .filter_map(|file| Slug::of_changeset_file(file, &self.changesets_dir))
             .collect();
+        let ledger = self.ledger.read()?;
+        let mut sources: Vec<Slug> = Vec::new();
+        for slug in self.store.list()? {
+            if slug.is_canonical_pr() || !in_diff.contains(&slug) {
+                continue;
+            }
+            let raw = self.store.read(&slug)?;
+            if self.is_shipped(&slug, &raw, &ledger)? {
+                continue;
+            }
+            sources.push(slug);
+        }
+        // Sort for deterministic ordinal assignment.
         sources.sort_by(|a, b| a.as_str().cmp(b.as_str()));
 
         let mut renamed = Vec::with_capacity(sources.len());
@@ -224,10 +267,13 @@ fn stamp_consumed(raw: &str, cycle: &CycleId) -> Result<String, toml_edit::TomlE
 mod tests {
     use super::*;
     use relman_core::mocks::{
-        MapChangesetStore, MapConsumedLedgerStore, SequenceSlugSource, SequenceUidSource,
+        MapChangesetStore, MapConsumedLedgerStore, SequenceSlugSource, SequenceUidSource, StubVcs,
     };
     use relman_core::ports::{ChangesetStoreError, ConsumedLedgerStore};
     use relman_core::types::{ChangesetError, Description};
+
+    /// The repo-relative changesets directory the test diffs are rooted at.
+    const CHANGESETS_DIR: &str = ".changesets";
 
     /// A canonical UUIDv7 the test uid source hands out, so a created changeset's
     /// id is deterministic.
@@ -241,7 +287,8 @@ mod tests {
         Uid::parse(raw).expect("valid test uid")
     }
 
-    fn service(store: Arc<dyn ChangesetStore>, slugs: Vec<Slug>) -> ChangesetService {
+    /// A service whose PR diff contains every changeset currently in `store`.
+    fn service(store: Arc<dyn ChangesetStore>, slugs: Vec<Slug>) -> ChangesetService<StubVcs> {
         service_with_ledger(store, slugs, Arc::new(MapConsumedLedgerStore::new()))
     }
 
@@ -251,12 +298,35 @@ mod tests {
         store: Arc<dyn ChangesetStore>,
         slugs: Vec<Slug>,
         ledger: Arc<dyn ConsumedLedgerStore>,
-    ) -> ChangesetService {
+    ) -> ChangesetService<StubVcs> {
+        let in_diff: Vec<String> = store
+            .list()
+            .expect("list store")
+            .iter()
+            .map(|slug| format!("{CHANGESETS_DIR}/{}", slug.file_name()))
+            .collect();
+        service_with_diff(
+            store,
+            slugs,
+            ledger,
+            in_diff.iter().map(String::as_str).collect(),
+        )
+    }
+
+    /// As [`service_with_ledger`], with an explicit PR diff.
+    fn service_with_diff(
+        store: Arc<dyn ChangesetStore>,
+        slugs: Vec<Slug>,
+        ledger: Arc<dyn ConsumedLedgerStore>,
+        in_diff: Vec<&str>,
+    ) -> ChangesetService<StubVcs> {
         ChangesetService::new(
             store,
             Arc::new(SequenceSlugSource::new(slugs)),
             Arc::new(SequenceUidSource::new(vec![uid(SAMPLE_UID)])),
             ledger,
+            StubVcs::new(in_diff.into_iter().map(PathBuf::from).collect()),
+            PathBuf::from(CHANGESETS_DIR),
         )
     }
 
@@ -355,15 +425,17 @@ mod tests {
     fn rename_to_pr_renames_only_the_author_file() {
         let store = Arc::new(MapChangesetStore::new());
         store
-            .write(&slug("wandering-quokka"), "[empty]\n")
+            .write(&slug("wandering-quokka"), "[empty]\nreason = \"seed\"\n")
             .expect("seed author");
         // An accumulated changeset from an earlier merged PR — already canonical.
         store
-            .write(&slug("pr-1490"), "[empty]\n")
+            .write(&slug("pr-1490"), "[empty]\nreason = \"seed\"\n")
             .expect("seed accumulated");
         let svc = service(store.clone(), vec![slug("unused-source")]);
 
-        let renamed = svc.rename_to_pr(1501).expect("rename should succeed");
+        let renamed = svc
+            .rename_to_pr(1501, "dev")
+            .expect("rename should succeed");
 
         assert_eq!(as_strs(&renamed), ["pr-1501"]);
         assert_eq!(slugs_in(&store), ["pr-1490", "pr-1501"]);
@@ -373,16 +445,50 @@ mod tests {
     fn rename_to_pr_numbers_multiple_author_files_deterministically() {
         let store = Arc::new(MapChangesetStore::new());
         store
-            .write(&slug("wandering-quokka"), "a")
+            .write(&slug("wandering-quokka"), "[empty]\nreason = \"a\"\n")
             .expect("seed one");
-        store.write(&slug("brisk-heron"), "b").expect("seed two");
+        store
+            .write(&slug("brisk-heron"), "[empty]\nreason = \"b\"\n")
+            .expect("seed two");
         let svc = service(store.clone(), vec![slug("unused-source")]);
 
-        let renamed = svc.rename_to_pr(1501).expect("rename should succeed");
+        let renamed = svc
+            .rename_to_pr(1501, "dev")
+            .expect("rename should succeed");
 
         // Sorted sources: brisk-heron < wandering-quokka, so brisk-heron is first.
         assert_eq!(as_strs(&renamed), ["pr-1501", "pr-1501-2"]);
         assert_eq!(slugs_in(&store), ["pr-1501", "pr-1501-2"]);
+    }
+
+    #[test]
+    fn rename_to_pr_ignores_non_canonical_files_outside_the_diff() {
+        // `brisk-heron` is a random-slug changeset the PR inherited from `dev`
+        // (a fork PR merged without the rename bot); only `wandering-quokka`
+        // is in this PR's diff, so only it is renamed.
+        let store = Arc::new(MapChangesetStore::new());
+        store
+            .write(&slug("wandering-quokka"), "[empty]\nreason = \"mine\"\n")
+            .expect("seed author");
+        store
+            .write(&slug("brisk-heron"), "[empty]\nreason = \"inherited\"\n")
+            .expect("seed inherited");
+        let svc = service_with_diff(
+            store.clone(),
+            vec![slug("unused-source")],
+            Arc::new(MapConsumedLedgerStore::new()),
+            vec![
+                ".changesets/wandering-quokka.toml",
+                "packages/zainod/src/lib.rs",
+            ],
+        );
+
+        let renamed = svc
+            .rename_to_pr(1501, "dev")
+            .expect("rename should succeed");
+
+        assert_eq!(as_strs(&renamed), ["pr-1501"]);
+        assert_eq!(slugs_in(&store), ["brisk-heron", "pr-1501"]);
     }
 
     #[test]
@@ -403,7 +509,9 @@ mod tests {
             .expect("seed consumed");
         let svc = service(store.clone(), vec![slug("unused-source")]);
 
-        let renamed = svc.rename_to_pr(1501).expect("rename should succeed");
+        let renamed = svc
+            .rename_to_pr(1501, "dev")
+            .expect("rename should succeed");
 
         assert_eq!(as_strs(&renamed), ["pr-1501"]);
         assert_eq!(slugs_in(&store), ["brisk-heron", "pr-1501"]);
@@ -435,7 +543,9 @@ mod tests {
             Arc::new(MapConsumedLedgerStore::with_ledger(ledger)),
         );
 
-        let renamed = svc.rename_to_pr(1501).expect("rename should succeed");
+        let renamed = svc
+            .rename_to_pr(1501, "dev")
+            .expect("rename should succeed");
 
         assert_eq!(as_strs(&renamed), ["pr-1501"]);
         assert_eq!(slugs_in(&store), ["brisk-heron", "pr-1501"]);
@@ -445,16 +555,16 @@ mod tests {
     fn rename_to_pr_errors_when_target_already_exists() {
         let store = Arc::new(MapChangesetStore::new());
         store
-            .write(&slug("wandering-quokka"), "a")
+            .write(&slug("wandering-quokka"), "[empty]\nreason = \"a\"\n")
             .expect("seed author");
         // A stale `pr-1501` already occupies the canonical target.
         store
-            .write(&slug("pr-1501"), "occupied")
+            .write(&slug("pr-1501"), "[empty]\nreason = \"occupied\"\n")
             .expect("seed target");
         let svc = service(store.clone(), vec![slug("unused-source")]);
 
         let err = svc
-            .rename_to_pr(1501)
+            .rename_to_pr(1501, "dev")
             .expect_err("colliding target must error");
         assert!(matches!(
             err,
@@ -466,14 +576,14 @@ mod tests {
     fn rename_to_pr_is_a_noop_without_author_files() {
         let store = Arc::new(MapChangesetStore::new());
         store
-            .write(&slug("pr-1490"), "a")
+            .write(&slug("pr-1490"), "[empty]\nreason = \"a\"\n")
             .expect("seed accumulated");
         store
-            .write(&slug("pr-1491"), "b")
+            .write(&slug("pr-1491"), "[empty]\nreason = \"b\"\n")
             .expect("seed accumulated");
         let svc = service(store.clone(), vec![slug("unused-source")]);
 
-        let renamed = svc.rename_to_pr(1501).expect("no-op should succeed");
+        let renamed = svc.rename_to_pr(1501, "dev").expect("no-op should succeed");
 
         assert!(renamed.is_empty());
         assert_eq!(slugs_in(&store), ["pr-1490", "pr-1491"]);
@@ -483,9 +593,11 @@ mod tests {
     fn clear_empties_the_store_and_reports_removed() {
         let store = Arc::new(MapChangesetStore::new());
         store
-            .write(&slug("wandering-quokka"), "a")
+            .write(&slug("wandering-quokka"), "[empty]\nreason = \"a\"\n")
             .expect("seed one");
-        store.write(&slug("pr-1490"), "b").expect("seed two");
+        store
+            .write(&slug("pr-1490"), "[empty]\nreason = \"b\"\n")
+            .expect("seed two");
         let svc = service(store.clone(), vec![slug("unused-source")]);
 
         let removed = svc.clear().expect("clear should succeed");

--- a/tools/scripts/sandbox-bless-ledger-check.sh
+++ b/tools/scripts/sandbox-bless-ledger-check.sh
@@ -63,10 +63,17 @@ rr_tip="$(git commit-tree "$newtree" -p "$tip" \
 git push -f "$REMOTE" "${tip}:refs/heads/dev"
 git push -f "$REMOTE" "${tip}:refs/heads/stable"
 git push -f "$REMOTE" "${rr_tip}:refs/heads/release-ready"
-pr="$(gh pr create -R "$REPO" --base stable --head release-ready \
-  --title "Release cycle-1 (sandbox ledger check)" \
-  --body "Sandbox: merge to exercise consume -> ledger -> bless -> sentinel." \
-  | sed 's#.*/##')"
+# A release PR between these two branches may already be open from an earlier
+# cycle on the fork; GitHub allows one per branch pair, so reuse it.
+pr="$(gh pr list -R "$REPO" --base stable --head release-ready --state open \
+  --json number --jq '.[0].number // empty')"
+if [ -z "$pr" ]; then
+  pr="$(gh pr create -R "$REPO" --base stable --head release-ready \
+    --title "Release cycle-1 (sandbox ledger check)" \
+    --body "Sandbox: merge to exercise consume -> ledger -> bless -> sentinel." \
+    | sed 's#.*/##')"
+fi
+echo "Merging release PR #${pr} (release-ready -> stable)"
 gh pr merge "$pr" -R "$REPO" --merge
 
 # 5. Restore protection.

--- a/tools/scripts/sandbox-bless-ledger-check.sh
+++ b/tools/scripts/sandbox-bless-ledger-check.sh
@@ -2,13 +2,14 @@
 # Drive a targeted end-to-end check of the consume→ledger→bless→sentinel path on
 # the DISPOSABLE sandbox fork, without staging a full dev→rc→release-ready cycle.
 #
-# It force-deploys the current branch tip and pushes a `stable` tip that already
-# carries one changeset (with a UID) for a governed crate. The push to `stable`:
-#   1. fires BLESSING (its guard only skips `chore(release):` commits, and this
-#      commit is not one) → relman restores the ledger from the last cycle tag
+# It force-deploys the current branch tip, puts one changeset (with a UID) for a
+# governed crate on `release-ready`, and merges the release PR
+# (release-ready -> stable), which is the provenance blessing requires. The
+# merge into `stable`:
+#   1. fires BLESSING → relman restores the ledger from the last cycle tag
 #      (none here → empty), derives the bump, then `consume` stamps the changeset
 #      `consumed_in` AND appends its UID to `.release/consumed-ledger.toml`; the
-#      release commit + `cycle-1` / `<crate>-vX.Y.Z` tags + GitHub Release land;
+#      release commit + `cycle-1` / `<crate>-X.Y.Z` tags + GitHub Release land;
 #   2. fires the BACKPORT SENTINEL (stable now ahead of dev) → it opens the
 #      `sync/stable-to-dev` PR with auto-merge; dev has no required checks or
 #      approvals, so it merges, carrying the ledger + marks back to `dev`.
@@ -21,10 +22,8 @@
 # because the sandbox is a throwaway fork; never point REPO at a real repository.
 set -euo pipefail
 
-REMOTE="${REMOTE:-sandbox}"
-REPO="${REPO:-nachog00/zaino-pipeline-sandbox}"
-DEV_RULESET="${DEV_RULESET:-21067396}"
-STABLE_RULESET="${STABLE_RULESET:-21067400}"
+# shellcheck source=tools/scripts/sandbox-common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/sandbox-common.sh"
 # A governed crate (must be a target in relman.toml) for the test changeset.
 CRATE="${CRATE:-zaino-state}"
 # A fixed, canonical UUID so the verification can grep for it deterministically.
@@ -33,32 +32,20 @@ LEDGER_UID="${LEDGER_UID:-018f4e0a-7b2c-7c3d-8e4f-1a2b3c4d5e6f}"
 tip="$(git rev-parse HEAD)"
 echo "Driving ledger+bless+sentinel check on ${REPO} from ${tip:0:12} ..."
 
-set_enforcement() { # <ruleset-id> <active|disabled>
-  gh api -X PUT "repos/${REPO}/rulesets/${1}" -f "enforcement=${2}" \
-    --jq '.name + " -> " + .enforcement'
-}
-
 # 0. Enable auto-merge so the sentinel's sync PR can self-merge.
 gh api -X PATCH "repos/${REPO}" -F allow_auto_merge=true --jq '"allow_auto_merge=" + (.allow_auto_merge|tostring)'
 
 # 1. Drop protection for the divergent reset.
 set_enforcement "$DEV_RULESET" disabled
+set_enforcement "$RR_RULESET" disabled
 set_enforcement "$STABLE_RULESET" disabled
 
 # 2. Clean slate: delete all cycle/prerelease/crate tags + any GitHub Release, so
 #    blessing releases a fresh `cycle-1` and the ledger restore finds no prior.
-mapfile -t tags < <(git ls-remote --tags "$REMOTE" \
-  | sed -n 's#.*refs/tags/\([^^]*\)$#\1#p' \
-  | grep -E '^cycle-|-v[0-9]' | sort -u)
-for t in "${tags[@]}"; do
-  echo "deleting tag $t"; git push --quiet "$REMOTE" ":refs/tags/$t" || true
-done
-for id in $(gh api "repos/${REPO}/releases" --jq '.[].id'); do
-  echo "deleting release $id"; gh api -X DELETE "repos/${REPO}/releases/${id}" || true
-done
+delete_pipeline_tags_and_releases
 
-# 3. Build a `stable` tip = current tree + one governed-crate changeset carrying a
-#    UID. Uses a throwaway index so the working tree is never touched.
+# 3. Build a `release-ready` tip = current tree + one governed-crate changeset
+#    carrying a UID. Uses a throwaway index so the working tree is never touched.
 changeset="$(printf 'id = "%s"\n\n[[changes]]\ncrate = "%s"\nkind = "feature"\ndescription = "Live-check change for the consumed-UID ledger verification."\n' \
   "$LEDGER_UID" "$CRATE")"
 tmpidx="$(mktemp)"
@@ -68,27 +55,34 @@ GIT_INDEX_FILE="$tmpidx" git update-index --add \
   --cacheinfo "100644,${blob},.changesets/pr-live.toml"
 newtree="$(GIT_INDEX_FILE="$tmpidx" git write-tree)"
 rm -f "$tmpidx"
-# NOT a `chore(release):` message, so the blessing guard lets it through.
-stable_tip="$(git commit-tree "$newtree" -p "$tip" \
+rr_tip="$(git commit-tree "$newtree" -p "$tip" \
   -m "test: add live-check changeset for ledger verification")"
 
-# 4. Deploy: dev at tip, stable at the changeset-carrying tip.
+# 4. Deploy: dev and stable at tip, release-ready at the changeset-carrying tip,
+#    then merge the release PR into stable — the provenance blessing requires.
 git push -f "$REMOTE" "${tip}:refs/heads/dev"
-git push -f "$REMOTE" "${stable_tip}:refs/heads/stable"
+git push -f "$REMOTE" "${tip}:refs/heads/stable"
+git push -f "$REMOTE" "${rr_tip}:refs/heads/release-ready"
+pr="$(gh pr create -R "$REPO" --base stable --head release-ready \
+  --title "Release cycle-1 (sandbox ledger check)" \
+  --body "Sandbox: merge to exercise consume -> ledger -> bless -> sentinel." \
+  | sed 's#.*/##')"
+gh pr merge "$pr" -R "$REPO" --merge
 
 # 5. Restore protection.
 set_enforcement "$DEV_RULESET" active
+set_enforcement "$RR_RULESET" active
 set_enforcement "$STABLE_RULESET" active
 
 cat <<EOF
 
-Deployed. The push to stable fires blessing, then the sentinel.
+Deployed. The release-PR merge into stable fires blessing, then the sentinel.
 Watch:
   gh run list  -R ${REPO} --limit 6
   gh run watch -R ${REPO} \$(gh run list -R ${REPO} --workflow 'Blessing (release on stable)' --limit 1 --json databaseId --jq '.[0].databaseId')
 Verify (read-only):
   git show ${REMOTE}/stable:.release/consumed-ledger.toml     # should list ${LEDGER_UID}
   git show ${REMOTE}/stable:.changesets/pr-live.toml          # should have consumed_in = "cycle-1"
-  git ls-remote --tags ${REMOTE} 'refs/tags/cycle-1' 'refs/tags/${CRATE}-v*'
+  git ls-remote --tags ${REMOTE} 'refs/tags/cycle-1' 'refs/tags/${CRATE}-[0-9]*'
   gh pr list -R ${REPO} --base dev --head sync/stable-to-dev --state all
 EOF

--- a/tools/scripts/sandbox-common.sh
+++ b/tools/scripts/sandbox-common.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Shared defaults and helpers for the sandbox-*.sh drivers. Source it; never
+# run it. Every value can be overridden from the environment.
+#
+# SENSITIVE — the helpers toggle branch-protection rulesets and delete tags and
+# releases. Safe only because REPO is a throwaway fork; never point it at a real
+# repository.
+
+REMOTE="${REMOTE:-sandbox}"
+REPO="${REPO:-nachog00/zaino-pipeline-sandbox}"
+# Ruleset ids for this sandbox (see: gh api repos/$REPO/rulesets).
+DEV_RULESET="${DEV_RULESET:-21067396}"
+RC_RULESET="${RC_RULESET:-21067398}"
+RR_RULESET="${RR_RULESET:-21067399}"
+STABLE_RULESET="${STABLE_RULESET:-21067400}"
+
+# The tags the release pipeline creates: `cycle-<N>`, `cycle-<N>-rc.<M>`, and
+# the per-crate `<crate>-X.Y.Z` provenance tag (no `v`).
+PIPELINE_TAG_PATTERN='^cycle-|-[0-9]+\.[0-9]+\.[0-9]+$'
+
+set_enforcement() { # <ruleset-id> <active|disabled>
+  gh api -X PUT "repos/${REPO}/rulesets/${1}" -f "enforcement=${2}" \
+    --jq '.name + " -> " + .enforcement'
+}
+
+list_pipeline_tags() { # every pipeline tag on the remote, one per line
+  git ls-remote --tags "$REMOTE" \
+    | sed -n 's#.*refs/tags/\([^^]*\)$#\1#p' | grep -E "$PIPELINE_TAG_PATTERN" | sort -u || true
+}
+
+delete_pipeline_tags_and_releases() { # clean slate: no cycle/rc/crate tags, no GitHub Releases
+  local tags t id
+  mapfile -t tags < <(list_pipeline_tags)
+  for t in "${tags[@]}"; do
+    echo "  del tag $t"; git push --quiet "$REMOTE" ":refs/tags/$t" || true
+  done
+  for id in $(gh api "repos/${REPO}/releases" --jq '.[].id'); do
+    echo "  del release $id"; gh api -X DELETE "repos/${REPO}/releases/${id}" || true
+  done
+}

--- a/tools/scripts/sandbox-cycle.sh
+++ b/tools/scripts/sandbox-cycle.sh
@@ -17,17 +17,8 @@
 # merges protected branches. Safe only because the sandbox is a throwaway fork.
 set -euo pipefail
 
-REMOTE="${REMOTE:-sandbox}"
-REPO="${REPO:-nachog00/zaino-pipeline-sandbox}"
-DEV_RULESET="${DEV_RULESET:-21067396}"
-RC_RULESET="${RC_RULESET:-21067398}"
-RR_RULESET="${RR_RULESET:-21067399}"
-STABLE_RULESET="${STABLE_RULESET:-21067400}"
-
-set_enforcement() { # <ruleset-id> <active|disabled>
-  gh api -X PUT "repos/${REPO}/rulesets/${1}" -f "enforcement=${2}" \
-    --jq '.name + " -> " + .enforcement'
-}
+# shellcheck source=tools/scripts/sandbox-common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/sandbox-common.sh"
 
 cmd_reset() { # [base-ref]  — pristine slate: all 4 branches := base, no changesets/tags
   local base; base="$(git rev-parse "${1:-HEAD}")"
@@ -40,14 +31,7 @@ cmd_reset() { # [base-ref]  — pristine slate: all 4 branches := base, no chang
   local r b
   for r in "$DEV_RULESET" "$RC_RULESET" "$RR_RULESET" "$STABLE_RULESET"; do set_enforcement "$r" disabled; done
   for b in dev rc release-ready stable; do git push -f "$REMOTE" "${base}:refs/heads/${b}"; done
-  local tags t
-  mapfile -t tags < <(git ls-remote --tags "$REMOTE" \
-    | sed -n 's#.*refs/tags/\([^^]*\)$#\1#p' | grep -E '^cycle-|-v[0-9]' | sort -u)
-  for t in "${tags[@]}"; do echo "  del tag $t"; git push --quiet "$REMOTE" ":refs/tags/$t" || true; done
-  local id
-  for id in $(gh api "repos/${REPO}/releases" --jq '.[].id'); do
-    echo "  del release $id"; gh api -X DELETE "repos/${REPO}/releases/${id}" || true
-  done
+  delete_pipeline_tags_and_releases
   for r in "$DEV_RULESET" "$RC_RULESET" "$RR_RULESET" "$STABLE_RULESET"; do set_enforcement "$r" active; done
   echo "Pristine. All branches at ${base:0:12}; no cycle tags; next bless = cycle-1."
 }
@@ -150,8 +134,7 @@ cmd_status() {
     printf '  %-14s %s\n' "$b" "$(git rev-parse --short "${REMOTE}/${b}" 2>/dev/null || echo '-')"
   done
   echo "tags:"
-  git ls-remote --tags "$REMOTE" \
-    | sed -n 's#.*refs/tags/\([^^]*\)$#\1#p' | grep -E '^cycle|-v[0-9]' | sort -u | sed 's/^/  /' || true
+  list_pipeline_tags | sed 's/^/  /'
   echo "open PRs:"
   gh pr list -R "$REPO" --state open \
     --json number,headRefName,baseRefName --jq '.[] | "  #\(.number) \(.headRefName)->\(.baseRefName)"'

--- a/tools/scripts/sandbox-sentinel-check.sh
+++ b/tools/scripts/sandbox-sentinel-check.sh
@@ -4,13 +4,13 @@
 #
 #   - dev    <- current branch tip (has the new relman + workflows + the
 #              changeset-check `sync/stable-to-dev` exemption)
-#   - stable <- tip + one `chore(release):` commit, so `stable \ dev` is
-#              non-empty and the push to stable fires the sentinel.
+#   - stable <- tip + one empty commit, so `stable \ dev` is non-empty and the
+#              push to stable fires the sentinel.
 #
-# Why the `chore(release):` prefix: a push to stable also triggers the blessing
-# workflow, whose job guard skips `chore(release):`-prefixed commits — so only
-# the sentinel runs. It is also the most faithful input: the sentinel exists to
-# backport exactly the blessing's release commit.
+# The push to stable also triggers the blessing workflow, but its provenance
+# guard releases only the merge of the release PR (release-ready -> stable);
+# a direct push like this one is skipped with a warning, so only the sentinel
+# does any work.
 #
 # SENSITIVE — run manually. It toggles branch-protection rulesets and
 # force-pushes protected branches. Safe only because the sandbox is a throwaway
@@ -21,28 +21,21 @@
 # configured (they are). Run from the repo root on `feat/release-pipeline`.
 set -euo pipefail
 
-REMOTE="${REMOTE:-sandbox}"
-REPO="${REPO:-nachog00/zaino-pipeline-sandbox}"
-# Ruleset ids for this sandbox (see: gh api repos/$REPO/rulesets).
-DEV_RULESET="${DEV_RULESET:-21067396}"
-STABLE_RULESET="${STABLE_RULESET:-21067400}"
+# shellcheck source=tools/scripts/sandbox-common.sh
+source "$(dirname "${BASH_SOURCE[0]}")/sandbox-common.sh"
 
 tip="$(git rev-parse HEAD)"
 echo "Deploying ${tip:0:12} to ${REPO} dev + stable ..."
-
-set_enforcement() { # <ruleset-id> <active|disabled>
-  gh api -X PUT "repos/${REPO}/rulesets/${1}" -f "enforcement=${2}" \
-    --jq '.name + " -> " + .enforcement'
-}
 
 # 1. Drop protection so the divergent reset can force-push.
 set_enforcement "$DEV_RULESET" disabled
 set_enforcement "$STABLE_RULESET" disabled
 
 # 2. Mint the stable tip inline (no branch switch, no working-tree churn): the
-#    current tree, parented on the tip, as a `chore(release):` commit.
+#    current tree, parented on the tip, as a commit that stands in for a
+#    release commit the sentinel must carry back.
 stable_tip="$(git commit-tree "$(git rev-parse 'HEAD^{tree}')" -p "$tip" \
-  -m 'chore(release): cycle-test release commit (sandbox sentinel test)')"
+  -m 'test: stand-in release commit (sandbox sentinel test)')"
 
 git push -f "$REMOTE" "${tip}:refs/heads/dev"
 git push -f "$REMOTE" "${stable_tip}:refs/heads/stable"

--- a/tools/workbench/src/bin/check-published-versions.rs
+++ b/tools/workbench/src/bin/check-published-versions.rs
@@ -17,7 +17,7 @@
 //! `--mode advisory` reports violations as warnings and exits 0 (feature
 //! branches, where unbumped-but-changed crates are the normal
 //! bump-at-release state). `--mode blocking` reports them as errors and
-//! exits 1 (`rc/**` and `stable` release gates).
+//! exits 1 (the `stable` release gate and blessing's pre-flight).
 //!
 //! Std-only by crate design: network, extraction, and diffing go through
 //! `curl`, `tar`, and `diff` subprocesses.


### PR DESCRIPTION
## Summary

This PR fixes the findings from the review of #1462. The failing tests that pin the relman findings landed on the base branch as 1e5eb5473. The first commit here fixes those. The second commit fixes the workflow findings. The relman workspace passes all 220 tests, clippy, and fmt.

## relman fixes

- **Deleted changeset paths.** The changeset check treats a changeset path the PR deleted as absent. A PR that prunes stale changesets now gets a verdict instead of an I/O error.
- **Empty publish plan.** `relman publish-plan` prints nothing to stdout when nothing publishes. The note moves to stderr.
- **Rename scope.** `relman changeset rename` takes `--base <REF>` and renames only the author changesets in the PR's own diff. It skips files inherited from the base and files already shipped.
- **Governed set.** `relman.toml` now governs `zaino-encoding`, `zaino-source-macros`, `zaino-chain-head`, `zaino-chain-head-service`, `zaino-chain-store`, and `zaino-chain-store-zainodb`. A new adapters test fails whenever a governed target depends on an ungoverned workspace crate through a path and version requirement.
- **Malformed changesets always fail.** `relman changeset check` exits 2 for a malformed changeset or an unknown target, and 1 for coverage violations. The changeset-check workflow fails on exit 2 regardless of `RELMAN_ENFORCE_CHANGESETS`.
- **Lockfile after bump.** The bump service refreshes `Cargo.lock` through a new `Workspace::refresh_lockfile` port. The `cargo publish --locked` steps that follow a bump now pass.
- **rc tag ordinal.** The cycle-status parser rejects an `[[rc]]` tag with no numeric `-rc.<M>` suffix.
- **`relman about`** runs without a repository. Every crate root carries `#![forbid(unsafe_code)]`.

## Workflow fixes

- **Blessing provenance.** A `guard` job blesses only the merge of a PR from `release-ready` into `stable`, and skips a push by the pipeline's own App. A straight-to-`stable` hotfix is backported but never released.
- **Blessing order.** The release commit is made locally before pre-flight, so `cargo publish --dry-run` sees a clean package directory, and nothing is pushed until pre-flight passes.
- **Tag fan-out.** All release tags go out in one push, and `ci.yml` excludes `cycle-*` and `<crate>-X.Y.Z` tags from its tag trigger.
- **Idle rc-gate.** A prerelease tag is cut only when rc HEAD differs from the open cycle's last rc tag.
- **Stale sync PR.** The backport sentinel merges each new `stable` tip into an open sync PR and re-runs when a sync PR merges.
- **Exemption identity.** The changeset-check exemption requires the branch name, a Bot author, and the `backport` label together.
- **Deployment reporter.** `deployment-advance` refuses a `deployment_status` from any login other than `vars.RELMAN_DEPLOYMENT_REPORTER` when that variable is set.
- **Pre-cutover tags.** `auto-tag-rc.yml` and `final-tag-on-stable.yml` return, gated off once `RELMAN_PIPELINE_ACTIVE` is true. `release.yaml` also builds the zainod images on the `zainod-X.Y.Z` tag.
- **Dead trigger.** `publish-dry-run.yml` targets the single `rc` branch and blocks only on `stable`. `CONTEXT.md` and the workbench guard's comment follow.
- **Duplication.** A `cycle-ids` composite action replaces three copies of the cycle tag arithmetic. Every workflow runs relman through `setup-relman`, which now caches the build. The App-token action is pinned to the sha the repo already uses. The sandbox scripts share `sandbox-common.sh`.
- **Stale spellings.** The sandbox scripts match `<crate>-X.Y.Z` without a `v`, and the docs and doc comments follow.
- **nextest.** The repo-guards job caches the tool crates and runs their tests with `cargo nextest run`.

## Design notes

The new service dependencies are generic parameters, not trait objects. `BumpService` is generic over its `Workspace` and `ChangesetService` over its `Vcs`.

## Sandbox run

`tools/scripts/sandbox-bless-ledger-check.sh` ran against `nachog00/zaino-pipeline-sandbox` from 5cb654d51. The direct push to `stable` was refused by the provenance guard. The release-PR merge was blessed end to end under `RELMAN_PUBLISH_DRY_RUN`: the ledger on `stable` lists the changeset id, the changeset carries `consumed_in = "cycle-1"`, `Cargo.lock` matches the bumped `zaino-state` 0.7.1, the tags `cycle-1` and `zaino-state-0.7.1` went out in one push with no CI fan-out, and the GitHub Release exists. The App's own release-commit push was skipped by identity. The sentinel opened the sync PR and, on the next `stable` push, merged the release commit into its branch.

The run also exposed two gaps, fixed in the last commit: labels were applied after the sync PR opened, so the first changeset-check run was not exempt, and the rename bot renamed the shipped changeset on the sync PR. A second run from 6bc26e132 confirmed both: the sync PR opened with its `automated` and `backport` labels, every changeset-check and changeset-rename run on it was skipped, its changeset kept its slug, and the sentinel merged the release commit into the open PR.

The `create-github-app-token` action at v3.2.0 warns that `app-id` is deprecated in favour of `client-id`. That is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7JrRSnyK9FFRWjXGj43ZS
