### PR TITLE
ci(release): publish multi-arch (amd64 + arm64) images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,13 @@
 # The pipeline's `cycle-<N>` and other `<crate>-X.Y.Z` tags carry no zainod
 # image and are ignored here. Blessing owns the GitHub Release for pipeline
 # tags, so the `create-release` job below runs only for the legacy tags.
+#
+# Images are multi-arch (linux/amd64 + linux/arm64):
+#
+# - per-platform legs fan out to native runners (arm64 under QEMU = ~5-10x on a Rust build)
+# - manifest assembly / push-by-digest via docker/github-builder (no per-arch tags in registry)
+# - cache-scope gets the platform appended upstream, so one scope per variant is enough
+#
 # TODO(cutover): gh-pages doc publish.
 name: Zaino Release
 
@@ -21,94 +28,73 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 jobs:
-  docker:
-    name: Docker images (build+push)
+  # Reusable workflows cannot host arbitrary steps, so the toolchain lookup is its own job.
+  prepare:
+    name: Resolve toolchain
     runs-on: ubuntu-latest
-    env:
-      # Push only on tag-push events, or when workflow_dispatch with input.push=true.
-      PUSH_IMAGES: ${{ github.event_name != 'workflow_dispatch' || inputs.push }}
+    outputs:
+      rust-version: ${{ steps.rust.outputs.version }}
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+      # vars (not secrets): reusable-workflow `with:` cannot read the secrets context.
+      - name: Require the DOCKERHUB_USERNAME repository variable
+        if: ${{ vars.DOCKERHUB_USERNAME == '' }}
+        run: |
+          echo "::error::repository variable DOCKERHUB_USERNAME is unset; image names would resolve to /zaino" >&2
+          exit 1
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v4
-        with:
+      - name: Determine Rust version from rust-toolchain.toml
+        id: rust
+        run: |
+          echo "version=$(cargo run -q --manifest-path tools/workbench/Cargo.toml --bin get-rust-version)" >> "$GITHUB_OUTPUT"
+
+  images:
+    name: ${{ matrix.variant }} image
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [default, no-tls]
+    uses: docker/github-builder/.github/workflows/build.yml@v1
+    permissions:
+      contents: read
+      # Keyless cosign signing of the provenance attestation (sign=auto, gated on push).
+      id-token: write
+    with:
+      output: image
+      job-name-prefix: ${{ matrix.variant }}
+      platforms: linux/amd64,linux/arm64
+      # Push only on tag-push events, or when workflow_dispatch with input.push=true.
+      push: ${{ github.event_name != 'workflow_dispatch' || inputs.push }}
+      build-args: |
+        RUST_VERSION=${{ needs.prepare.outputs.rust-version }}
+        ${{ matrix.variant == 'no-tls' && 'NO_TLS=true' || '' }}
+      cache: true
+      cache-mode: max
+      cache-scope: ${{ matrix.variant }}
+      set-meta-labels: true
+      meta-flavor: ${{ matrix.variant == 'no-tls' && 'suffix=-no-tls' || '' }}
+      meta-images: |
+        ${{ vars.DOCKERHUB_USERNAME }}/zaino
+        ${{ vars.DOCKERHUB_USERNAME }}/zainod
+      meta-tags: |
+        type=semver,pattern={{version}}
+        type=match,pattern=zainod-(.*),group=1
+        type=ref,event=branch
+        type=sha,prefix=,format=short
+    secrets:
+      registry-auths: |
+        - registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
-      - name: Determine Rust version from rust-toolchain.toml
-        run: |
-          echo "RUST_VERSION=$(cargo run -q --manifest-path tools/workbench/Cargo.toml --bin get-rust-version)" >> "$GITHUB_ENV"
-
-      - name: Extract metadata for Docker (default image)
-        id: meta-default
-        uses: docker/metadata-action@v6
-        with:
-          images: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/zaino
-            ${{ secrets.DOCKERHUB_USERNAME }}/zainod
-          tags: |
-            type=semver,pattern={{version}}
-            type=match,pattern=zainod-(.*),group=1
-            type=ref,event=branch
-            type=sha,prefix=,format=short
-
-      - name: Build and Push Default Image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          platforms: linux/amd64
-          push: ${{ env.PUSH_IMAGES }}
-          tags: ${{ steps.meta-default.outputs.tags }}
-          labels: ${{ steps.meta-default.outputs.labels }}
-          build-args: |
-            RUST_VERSION=${{ env.RUST_VERSION }}
-          cache-from: |
-            type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/zainod:buildcache
-            type=gha
-          cache-to: |
-            type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/zainod:buildcache,mode=max
-            type=gha,mode=max
-
-      - name: Extract metadata for Docker (no-tls image)
-        id: meta-no-tls
-        uses: docker/metadata-action@v6
-        with:
-          images: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/zaino
-            ${{ secrets.DOCKERHUB_USERNAME }}/zainod
-          flavor: |
-            suffix=-no-tls
-          tags: |
-            type=semver,pattern={{version}}
-            type=match,pattern=zainod-(.*),group=1
-            type=ref,event=branch
-            type=sha,prefix=,format=short
-
-      - name: Build and Push No-TLS Image
-        uses: docker/build-push-action@v7
-        with:
-          build-args: |
-            NO_TLS=true
-            RUST_VERSION=${{ env.RUST_VERSION }}
-          context: .
-          platforms: linux/amd64
-          push: ${{ env.PUSH_IMAGES }}
-          tags: "${{ steps.meta-no-tls.outputs.tags }}"
-          labels: ${{ steps.meta-no-tls.outputs.labels }}
-          cache-from: |
-            type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/zainod:buildcache-no-tls
-            type=gha
-          cache-to: |
-            type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/zainod:buildcache-no-tls,mode=max
-            type=gha,mode=max
-
   create-release:
-    needs: docker
+    needs: images
     name: Create GitHub Release
     runs-on: ubuntu-latest
     # Only create a GitHub release when triggered by a legacy semver tag push.
@@ -116,6 +102,8 @@ jobs:
     # and so does a pipeline `zainod-X.Y.Z` tag: blessing already created the
     # cycle's GitHub Release.
     if: startsWith(github.ref, 'refs/tags/') && !startsWith(github.ref, 'refs/tags/zainod-')
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v7
         with:

--- a/docs/release/pipeline.md
+++ b/docs/release/pipeline.md
@@ -762,7 +762,7 @@ replacement):
 | -------- | ------- |
 | `auto-tag-rc.yml` | **keep until cutover** — derives version from the `rc/<version>` branch name; gated off by `RELMAN_PIPELINE_ACTIVE=true`, delete afterwards |
 | `final-tag-on-stable.yml` | **keep until cutover** — same branch-name→version coupling; gated off by `RELMAN_PIPELINE_ACTIVE=true`, replaced by blessing-time tagging from changesets |
-| `release.yaml` | **reworked** — also fires on the `zainod-X.Y.Z` provenance tag and takes the image version from it; the GitHub Release job runs only for legacy tags |
+| `release.yaml` | **reworked** — also fires on the `zainod-X.Y.Z` provenance tag and takes the image version from it; the GitHub Release job runs only for legacy tags; publishes multi-arch (`linux/amd64` + `linux/arm64`) manifests via `docker/github-builder` |
 | `publish-dry-run.yml` + `check-published-versions` | **kept** — blocking on `stable` pushes, advisory elsewhere (`rc` is version-agnostic); the Rust guard also runs in blessing's pre-flight |
 | `ci.yml`, `ci-nightly.yaml` | **rework** into the `dev`-gate and `rc`-gate suite runners |
 | `compute-tag.yml`, `build-n-push-ci-image.yaml`, `trigger-integration-tests.yml`, `shellcheck.yaml` | **keep** — orthogonal to release versioning |


### PR DESCRIPTION
Fixes #1164. Supersedes #1165.

Publishes `linux/amd64` + `linux/arm64` manifests for both image variants

Credit to @nmarley for #1165 and the arm64 verification.

@nachog00 lets get this in next release