### PR TITLE
docs(adr): restructure ADR-0013 and align the Zatoshis definitions with it

### DIFF
--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -11,9 +11,10 @@ than one place, and the sums do not share the same invariants.
 
   - **The Balance Sum Maximum.** A sum of balances that exist at one moment
     cannot exceed the supply.
-  - **The Movement Sum Maximum.** A sum of movements — outputs paid to an
-    address, inputs it spent — counts the same coins each time they move and is
-    not bounded by the supply at all.
+  - **The Movement Sum Maximum.** A sum of value movements over time is a
+    flow, not a holding: one coin moving many times is counted at each move, so
+    the total can exceed the supply and is bounded only by the `u128` that
+    accumulates it.
 
 The type of each value being summed—Zatoshis—and the addition operation are
 identical in both cases; only the meaning of the total differs.

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -107,7 +107,7 @@ The correction is a doctrine about primitive quantity types, illustrated here on
 
 `zaino-primitives::types::zatoshis`:
 
-- `Zatoshis` — an amount held. `0 ..= supply`.
+- `Zatoshis` — an amount of ZEC counted in zatoshis. `0 ..= supply`.
 - `ZatoshisFlowSum` — an accumulation of movements. Bounded only by machine
   representability; deliberately not by the supply.
 - `SignedZatoshis` — a signed value: a directional movement, or the difference

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -35,12 +35,13 @@ constructor validated nothing. Two faults followed:
 The correction is a doctrine about primitive quantity types, illustrated here on
 `Zatoshis` and meant to generalise:
 
-1. **A quantity is not always closed under its own operation.** Two supply-sized
-   amounts can sum past the supply, so summing amounts as flow cannot honestly
-   return the same type; that result is a *different* type. We do not give
-   `Zatoshis` an unconditional addition that pretends otherwise. Whether a sum
-   is closed is decided by the meaning of the total, not by the `+` sign — the
-   type family below has one sum that is.
+1. **The set of `Zatoshis` is not closed under addition.** Two supply-sized
+   amounts sum past the supply, so the sum of two `Zatoshis` is not always a
+   `Zatoshis`. The result of summing `Zatoshis` as movements is therefore a
+   different type. We do not define an unconditional addition on `Zatoshis`
+   that pretends otherwise; the one fold that lands back in `Zatoshis`,
+   `sum_balances` in the type family below, does so under a precondition and
+   refuses inputs that break it.
 
 2. **The invariant belongs to the result type, chosen by provenance — not to the
    operator or the element.** The same `Zatoshis` values summed as flow yield an

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -19,13 +19,13 @@ than one place, and the sums do not share the same invariants.
 The type of each value being summed—Zatoshis—and the addition operation are
 identical in both cases; only the meaning of the total differs.
 
-The earlier code expressed this with a single amount type, a supply cap applied
-to every sum, and a bare signed type whose constructor validated nothing. Two
-faults followed from putting the bound in the wrong place. A legitimate movement
-total past the supply was rejected as if corrupt, because the cap sat on the
-operator rather than on the result. And a signed value off the wire could be any
-integer, because the type's "a balance change" claim was made in prose while its
-only constructor enforced nothing.
+The earlier code attempted to express these conflicting invariants with a single
+amount type, a supply cap applied to every sum, and a bare signed type whose
+constructor validated nothing. Two faults followed from putting the bound in the
+wrong place. A legitimate movement total past the supply was rejected as if
+corrupt, because the cap sat on the operator rather than on the result. And a
+signed value off the wire could be any integer, because the type's "a balance
+change" claim was made in prose while its only constructor enforced nothing.
 
 The correction is a doctrine about primitive quantity types, illustrated here on
 `Zatoshis` and meant to generalise:

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -9,9 +9,11 @@ proposed
 `Zatoshis` is a validated amount: at most the money supply. It is summed in more
 than one place, and the sums do not share the same invariants.
 
-  - A sum of balances that exist at one moment cannot exceed the supply.
-  - A sum of movements — outputs paid to an address, inputs it spent — counts
-    the same coins each time they move and is not bounded by the supply at all.
+  - **The Balance Sum Maximum.** A sum of balances that exist at one moment
+    cannot exceed the supply.
+  - **The Movement Sum Maximum.** A sum of movements — outputs paid to an
+    address, inputs it spent — counts the same coins each time they move and is
+    not bounded by the supply at all.
 
 The type of each value being summed—Zatoshis—and the addition operation are
 identical in both cases; only the meaning of the total differs.

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -4,7 +4,7 @@
 
 proposed
 
-## Context and decision
+## Context
 
 `Zatoshis` is a validated amount: at most the money supply. It is summed in more
 than one place, and the sums do not share the same invariants.
@@ -23,12 +23,14 @@ The earlier code attempted to express these conflicting invariants with a single
 amount type, a supply cap applied to every sum, and a bare signed type whose
 constructor validated nothing. Two faults followed:
 
-  (1) A legitimate movement total past the supply was rejected as if corrupt,
-      because the cap sat on the operator rather than on the result.
+  1. A legitimate movement total past the supply was rejected as if corrupt,
+     because the cap sat on the operator rather than on the result.
 
-  (2) A signed value could be any integer, because the type's "a balance
-      change" claim was made in prose while its only constructor enforced
-      nothing.
+  2. A signed value could be any integer, because the type's "a balance
+     change" claim was made in prose while its only constructor enforced
+     nothing.
+
+## Doctrine
 
 The correction is a doctrine about primitive quantity types, illustrated here on
 `Zatoshis` and meant to generalise:

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -21,11 +21,14 @@ identical in both cases; only the meaning of the total differs.
 
 The earlier code attempted to express these conflicting invariants with a single
 amount type, a supply cap applied to every sum, and a bare signed type whose
-constructor validated nothing. Two faults followed from putting the bound in the
-wrong place. A legitimate movement total past the supply was rejected as if
-corrupt, because the cap sat on the operator rather than on the result. And a
-signed value off the wire could be any integer, because the type's "a balance
-change" claim was made in prose while its only constructor enforced nothing.
+constructor validated nothing. Two faults followed:
+
+  (1) A legitimate movement total past the supply was rejected as if corrupt,
+      because the cap sat on the operator rather than on the result.
+
+  (2) A signed value could be any integer, because the type's "a balance
+      change" claim was made in prose while its only constructor enforced
+      nothing.
 
 The correction is a doctrine about primitive quantity types, illustrated here on
 `Zatoshis` and meant to generalise:

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -32,6 +32,22 @@ constructor validated nothing. Two faults followed:
 
 ## Doctrine
 
+### Terminology
+
+  - **Zatoshi.** The unit of one hundred-millionth of a ZEC, in which every
+    amount below is counted.
+  - **`Zatoshis`.** The set of integers from zero to the money supply
+    inclusive, each an amount of ZEC counted in zatoshis; the Rust type of the
+    same name represents this set.
+  - **Element.** One member of `Zatoshis`, such as the value of a single
+    transaction output or input, or a balance.
+  - **Balance.** An element read as the amount held by one owner at one
+    moment.
+  - **Movement.** An element read as the amount one transaction transfers into
+    or out of an ownership.
+  - **Sum.** The result of adding elements, whose type is chosen by which
+    reading, balance or movement, the elements carry.
+
 The correction is a doctrine about primitive quantity types, illustrated here on
 `Zatoshis` and meant to generalise:
 

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -61,11 +61,12 @@ The correction is a doctrine about primitive quantity types, illustrated here on
 
 2. **The invariant belongs to the result type, chosen by the reading of the
    elements — not to the operator or the element.** The same `Zatoshis` values
-   summed as movements yield an unbounded accumulator; summed as coexisting
-   balances they yield a supply-bounded total. The caller, who knows which
-   reading the values carry, picks the landing type, and that choice is where
-   the bound is declared and enforced — once, in the type, not re-derived at
-   each call site.
+   summed as movements land in `ZatoshisFlowSum`, bounded only by the machine;
+   summed as coexisting balances they land back in `Zatoshis` through
+   `sum_balances`, bounded by the supply. The caller, who knows which reading
+   the values carry, picks the landing type, and that choice is where the bound
+   is declared and enforced — once, in the type, not re-derived at each call
+   site.
 
 3. **A signed zatoshi value is its own type, bounded by ±supply.** A single
    movement is one amount; a change in a balance is a difference of two. A
@@ -117,13 +118,15 @@ The correction is a doctrine about primitive quantity types, illustrated here on
 `ZatoshisFlowSum` earns a distinct type by carrying a new invariant.
 `SignedZatoshis` earns one by being a different quantity. A sum of coexisting
 balances earns neither: balances that coexist at one moment cannot total more
-than the coins that exist, so the total is itself in `[0, supply]` and
-`Zatoshis` is closed under that sum. A distinct type is warranted only when a
-result escapes the element's invariant; this one does not. What the algebra
-gains is its second accumulate as an *operation* — `Zatoshis::sum_balances`, a
-supply-capped checked fold landing back in `Zatoshis`. Under its coexistence
-contract a total past the supply is not a large number but evidence that the
-operands overlap or double-count, so the fold refuses it.
+than the coins that exist, so under that precondition the total is itself in
+`[0, supply]`. The set of `Zatoshis` is still not closed under addition; what
+holds is narrower, that the precondition keeps this particular result inside
+the set. A distinct type is warranted only when a result escapes the element's
+invariant, and this one does not, so the algebra gains its second accumulate
+as an *operation* — `Zatoshis::sum_balances`, a supply-capped checked fold that
+lands back in `Zatoshis`. A total past the supply is not a large number but
+evidence that the operands overlap or double-count, so the fold refuses it
+rather than pretend the precondition held.
 
 ## Considered options
 

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -7,12 +7,14 @@ proposed
 ## Context and decision
 
 `Zatoshis` is a validated amount: at most the money supply. It is summed in more
-than one place, and the sums do not share the same invariants. A sum of balances
-that exist at one moment cannot exceed the supply; a sum of movements — outputs
-paid to an address, inputs it spent — counts the same coins each time they move
-and is not bounded by the supply at all. The type of each value being
-summed—Zatoshis—and the addition operation are identical in both cases; only the
-meaning of the total differs.
+than one place, and the sums do not share the same invariants.
+
+  - A sum of balances that exist at one moment cannot exceed the supply.
+  - A sum of movements — outputs paid to an address, inputs it spent — counts
+    the same coins each time they move and is not bounded by the supply at all.
+
+The type of each value being summed—Zatoshis—and the addition operation are
+identical in both cases; only the meaning of the total differs.
 
 The earlier code expressed this with a single amount type, a supply cap applied
 to every sum, and a bare signed type whose constructor validated nothing. Two

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -6,12 +6,13 @@ proposed
 
 ## Context and decision
 
-`Zatoshis` is a validated amount: at most the money supply. It is summed in
-more than one place, and the sums do not share an invariant. A sum of balances
+`Zatoshis` is a validated amount: at most the money supply. It is summed in more
+than one place, and the sums do not share the same invariants. A sum of balances
 that exist at one moment cannot exceed the supply; a sum of movements — outputs
 paid to an address, inputs it spent — counts the same coins each time they move
-and is not bounded by the supply at all. The element type and the `+` sign are
-identical in both cases; only the *meaning of the total* differs.
+and is not bounded by the supply at all. The type of each value being
+summed—Zatoshis—and the addition operation are identical in both cases; only the
+meaning of the total differs.
 
 The earlier code expressed this with a single amount type, a supply cap applied
 to every sum, and a bare signed type whose constructor validated nothing. Two

--- a/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
+++ b/docs/adr/0013-quantity-arithmetic-result-types-carry-invariants.md
@@ -59,12 +59,13 @@ The correction is a doctrine about primitive quantity types, illustrated here on
    `sum_balances` in the type family below, does so under a precondition and
    refuses inputs that break it.
 
-2. **The invariant belongs to the result type, chosen by provenance — not to the
-   operator or the element.** The same `Zatoshis` values summed as flow yield an
-   unbounded accumulator; summed as coexisting balances they yield a
-   supply-bounded total. The caller, who knows which the values are, picks the
-   landing type, and that choice is where the bound is declared and enforced —
-   once, in the type, not re-derived at each call site.
+2. **The invariant belongs to the result type, chosen by the reading of the
+   elements — not to the operator or the element.** The same `Zatoshis` values
+   summed as movements yield an unbounded accumulator; summed as coexisting
+   balances they yield a supply-bounded total. The caller, who knows which
+   reading the values carry, picks the landing type, and that choice is where
+   the bound is declared and enforced — once, in the type, not re-derived at
+   each call site.
 
 3. **A signed zatoshi value is its own type, bounded by ±supply.** A single
    movement is one amount; a change in a balance is a difference of two. A

--- a/packages/zaino-primitives/src/types/zatoshis.rs
+++ b/packages/zaino-primitives/src/types/zatoshis.rs
@@ -9,7 +9,7 @@
 //! `+`. So each quantity is its own type, and each summation lands in the type
 //! whose invariant it satisfies:
 //!
-//! - [`Zatoshis`] — an amount held, in `0 ..= supply`.
+//! - [`Zatoshis`] — an amount of ZEC counted in zatoshis, in `0 ..= supply`.
 //! - [`ZatoshisFlowSum`] — an accumulation of movements, bounded only by machine
 //!   representability and deliberately not by the supply.
 //! - [`SignedZatoshis`] — a signed value (a movement or a difference), in

--- a/packages/zaino-primitives/src/types/zatoshis/arithmetic.rs
+++ b/packages/zaino-primitives/src/types/zatoshis/arithmetic.rs
@@ -21,7 +21,7 @@
 //! ```text
 //! accumulate          : [A] → F   Σ aᵢ, counting each movement
 //! accumulate_balances : [A] → A?  Σ aᵢ, of balances that coexist
-//!                                 (supply-capped; closed — lands back in A)
+//!                                 (supply-capped; lands back in A or refused)
 //! net                 : F × F → D received − spent, landing in [−S, S] or refused
 //! ```
 //!
@@ -30,9 +30,10 @@
 //! fails only if the machine integer overflows. `accumulate_balances` is the
 //! second accumulate — the same fold shape with a different landing: balances
 //! that coexist at one moment cannot total more than the coins that exist, so
-//! the sum is itself in `[0, S]` and `A` is closed under it; the fold lands
-//! back in [`Zatoshis`] rather than a new type, refusing a total past the
-//! supply. `net` subtracts a spent flow from a received one and admits the
+//! under that precondition the sum is itself in `[0, S]`; the fold lands back
+//! in [`Zatoshis`] rather than a new type, refusing a total past the supply.
+//! `A` is still not closed under addition — the precondition, not the set,
+//! keeps this result inside it. `net` subtracts a spent flow from a received one and admits the
 //! result only as a signed value: a balance change lives in `[−S, S]`, so a
 //! result outside it is refused. That bound is a property of a balance change,
 //! which the two sums are only when they are the received and spent flow of
@@ -57,9 +58,10 @@ impl Zatoshis {
     ///
     /// This is the second accumulate of the algebra: the same fold shape as
     /// [`ZatoshisFlowSum::try_accumulate`], with a different landing and
-    /// bound. Because a sum of coexisting balances stays within `[0, supply]`,
-    /// [`Zatoshis`] is closed under it — so this is deliberately an operation
-    /// returning [`Zatoshis`], not a new quantity type.
+    /// bound. Because a sum of coexisting balances stays within `[0, supply]`
+    /// under its precondition, this is deliberately an operation returning
+    /// [`Zatoshis`], not a new quantity type; the set is not closed under
+    /// addition, so the fold is checked and refuses a total past the supply.
     pub fn sum_balances(mut values: impl Iterator<Item = Zatoshis>) -> Option<Zatoshis> {
         values.try_fold(Zatoshis::ZERO, Zatoshis::checked_add)
     }

--- a/packages/zaino-primitives/src/types/zatoshis/arithmetic.rs
+++ b/packages/zaino-primitives/src/types/zatoshis/arithmetic.rs
@@ -11,7 +11,7 @@
 //! and `S` for the money supply. The quantities occupy nested ranges:
 //!
 //! ```text
-//! A ∈ [0, S]          an amount held
+//! A ∈ [0, S]          an amount of ZEC counted in zatoshis
 //! F ∈ [0, ∞)          a sum of movements  (machine-bounded, not supply-bounded)
 //! D ∈ [−S, S]         a signed value (a movement or a difference)
 //! ```

--- a/packages/zaino-primitives/usage.md
+++ b/packages/zaino-primitives/usage.md
@@ -79,8 +79,11 @@ A sum of *movements* — every output paying an address, every input it spent �
 counts the same coins each time they move, so it is not bounded by the supply;
 that is why it is its own type and not another `Zatoshis`. A sum of *coexisting*
 balances stays supply-bounded — coins that coexist cannot total more than
-exist — so `Zatoshis` is closed under it and there is no fourth type: that sum
-is the operation `Zatoshis::sum_balances`, landing back in `Zatoshis`.
+exist — so that precondition keeps the total inside `Zatoshis` and there is no
+fourth type: that sum is the operation `Zatoshis::sum_balances`, a checked fold
+landing back in `Zatoshis`. The set of `Zatoshis` is still not closed under
+addition; the fold refuses a total past the supply rather than pretend the
+precondition held.
 
 The operations relate the types and live beside them:
 
@@ -101,10 +104,10 @@ let lifetime = ZatoshisFlowSum::from_summed(received_total);
 // value. `None` if the two flows don't describe a coherent balance.
 let net: Option<SignedZatoshis> = received.net(spent);
 
-// Sum balances that coexist at one moment. Supply-capped and closed: the
-// total lands back in `Zatoshis`. `None` means the total passed the supply,
-// which under the coexistence contract is overlapping or double-counted
-// input, not a large number.
+// Sum balances that coexist at one moment. Supply-capped, and under that
+// precondition the total lands back in `Zatoshis`. `None` means the total
+// passed the supply, which under the coexistence contract is overlapping or
+// double-counted input, not a large number.
 let held: Option<Zatoshis> = Zatoshis::sum_balances(balances.iter().copied());
 ```
 

--- a/packages/zaino-primitives/usage.md
+++ b/packages/zaino-primitives/usage.md
@@ -71,7 +71,7 @@ ADR-0013 for the doctrine.
 
 | type | range | is |
 |---|---|---|
-| `Zatoshis` | `0 ..= supply` | an amount held — a balance, a UTXO value |
+| `Zatoshis` | `0 ..= supply` | an amount of ZEC counted in zatoshis — a balance, a UTXO value, a single movement |
 | `ZatoshisFlowSum` | `0 ..= u128::MAX` | an accumulation of movements, **not** supply-bounded |
 | `SignedZatoshis` | `-supply ..= supply` | a signed value: a movement or a difference |
 


### PR DESCRIPTION
## Summary

This PR edits ADR-0013 on top of #1509 (`fix/address-balance-flow`), which itself stacks on #1508, and aligns three definitions of `Zatoshis` with it. The doctrine is unchanged; the wording and structure are tightened, and the closure claims are stated correctly.

## ADR-0013

- The first section is now **Context** alone, and the doctrine has its own **Doctrine** section.
- The opening paragraph names the two summation invariants as an indented list: **The Balance Sum Maximum** and **The Movement Sum Maximum**. The movement item drops the transparent-specific wording and names the `u128` accumulator as the only bound.
- The second paragraph says the earlier code attempted to express these conflicting invariants, and lists its two faults as an ordered list.
- **Doctrine** opens with a **Terminology** subsection that defines zatoshi, `Zatoshis`, element, balance, movement, and sum. The unit is lowercase; the set and the type keep the capitalised name.
- Doctrine point 1 now states closure correctly: the set of `Zatoshis` is not closed under addition, so the sum of two `Zatoshis` is not always a `Zatoshis`.
- Doctrine point 2 names both landing types: movements land in `ZatoshisFlowSum`, coexisting balances land back in `Zatoshis` through `sum_balances`.
- **The type family** no longer says `Zatoshis` is closed under the balance sum. A checked fold that refuses out-of-range inputs is a partial operation under a precondition. The set stays not closed under addition; the precondition keeps this one result inside it.

## Doc comments and usage guide

The definition "an amount held" was narrower than the type, since a single movement is a `Zatoshis` too. Four sites now use the Terminology definition, an amount of ZEC counted in zatoshis:

- the type-family bullet in ADR-0013;
- the `//!` header of `packages/zaino-primitives/src/types/zatoshis.rs`;
- the `A ∈ [0, S]` line in the `//!` header of `packages/zaino-primitives/src/types/zatoshis/arithmetic.rs`;
- the `Zatoshis` row of `packages/zaino-primitives/usage.md`, which also lists a single movement among the examples.

The same closure claim appeared five times in #1509's text: twice in `packages/zaino-primitives/usage.md` and three times in the `//!` and `///` docs of `packages/zaino-primitives/src/types/zatoshis/arithmetic.rs`. Each now says the coexistence precondition keeps the result inside `Zatoshis` and that the fold refuses inputs which break it.

Every Rust edit is a comment. Nothing compiles differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7JrRSnyK9FFRWjXGj43ZS
