### PR TITLE
docs: restore ADRs 0002-0004 deleted in #1265

### DIFF
--- a/docs/adr/0002-live-tests-rejoin-root-workspace.md
+++ b/docs/adr/0002-live-tests-rejoin-root-workspace.md
@@ -1,0 +1,62 @@
+# Live tests rejoin the root workspace under a single lock
+
+## Status
+
+accepted
+
+## Context and decision
+
+The integration tests were split into two standalone Cargo workspaces —
+`integration-tests/` (walletless) and `integration-tests/wallet-tests/` —
+primarily to isolate **zingolib**'s conflicting dependency resolution
+(orchard / zebra / `time`), with both lockfiles **gitignored**. zingolib has
+since been fully removed from the tree (no occurrences in `Cargo.lock`), so the
+isolation no longer buys anything.
+
+We therefore reintegrate the live-test crates (`e2e`, `integration`,
+`zaino-testutils`) as **members of the root workspace**, and keep them out of
+the fast development loop with **`default-members`**:
+
+- `members` gains `live-tests/{e2e, integration, zaino-testutils}`.
+- `default-members = [packages/*]` (the six production crates only).
+- `container-test` runs a bare `cargo nextest run` (no `--workspace`, no `-p`),
+  so it operates on `default-members` and **never builds or tests the live
+  suite**; the production crates don't depend on `zcash_local_net`, so the git
+  dep isn't even fetched in the dev loop. The live suite is reached explicitly
+  via `cargo nextest run -p e2e` / `-p integration` (the `live` task family).
+- A **single committed root `Cargo.lock`** now resolves the entire graph,
+  including the `zcash_local_net` git dependency (pinned by rev) and the
+  zebra/zcash test stack. The two gitignored integration lockfiles are deleted.
+
+## Considered options
+
+- **Keep separate workspaces (status quo).** Isolates the production lock from
+  the test graph, but duplicates dependency resolution, *requires* gitignored
+  locks (so each machine re-resolves a moving git branch — the source of the
+  `time` 0.3.x drift flakiness), and prevents shared compilation across the two
+  partitions.
+- **Use `optional` / `dev-dependencies` to keep the test graph out of the
+  production lock.** Impossible: a workspace `Cargo.lock` is the *maximal*
+  resolution over **all** members, including every `dev-dependency` and
+  feature-gated `optional` dependency. The only way to keep a dependency graph
+  out of a lock is for the crate not to be a member — i.e. the status quo we are
+  deliberately ending.
+
+## Consequences
+
+- The production lockfile carries the test graph and a git-sourced dependency.
+  This is **inert for production builds** (`cargo build -p zainod` still
+  resolves only zainod's own graph) and **temporary for the git dep**
+  (zingolabs/infrastructure#269 will restore a published `zcash_local_net`
+  release, after which the lock shows an ordinary registry dependency).
+  `cargo deny` / audit now also scan the test dependencies — arguably a feature.
+- The single committed lock **fixes** the `time`-drift flakiness by pinning one
+  resolution for every machine. Add an explicit `time = "=<good>"` to root
+  `[workspace.dependencies]` only if a future resolution lands on a broken
+  version.
+- `[profile.test]` is hoisted to the root workspace (it only takes effect from
+  the workspace root anyway), and the shared dependency stack compiles **once**
+  when the two partitions request the same feature set — which the default
+  feature build does.
+- The vestigial `exclude = ["zaino-testutils"]` entry (a path that never
+  existed at the root) is removed along with `exclude = ["integration-tests"]`.

--- a/docs/adr/0003-live-test-taxonomy-and-two-crate-split.md
+++ b/docs/adr/0003-live-test-taxonomy-and-two-crate-split.md
@@ -1,0 +1,77 @@
+# Live-test taxonomy and two-crate split
+
+## Status
+
+accepted — naming (`integration` → `clientless`) and the three-front-door task
+surface are superseded by [ADR-0004](0004-rename-integration-partition-to-clientless.md);
+the two-crate split and the `live` umbrella still stand.
+
+## Context and decision
+
+With zingolib removed, the two test packages are reunified — and renamed, because
+"integration-tests" both **collides with Cargo's own vocabulary** (every
+`tests/*.rs` is, to Cargo, an "integration test") and **undersells** what the
+suite does: it stands up real external processes and exercises the assembled,
+running system.
+
+We adopt this taxonomy, captured as ubiquitous language in the suite's
+`CONTEXT.md`:
+
+- **`live`** — the umbrella (directory `live-tests/`). The defining property of
+  the suite is that it requires a **live validator** process (Zebra or the legacy full node),
+  and optionally a live wallet client. That property — not "it has a `tests/`
+  folder" — is what separates it from the inline unit tests `container-test`
+  runs, and is the reason it is excluded from the default flow.
+- **`e2e`** (was `wallet-tests`) — the partition driven end-to-end by a real
+  wallet client through Zaino's gRPC surface to a live validator.
+- **`integration`** (was `walletless-tests`) — the partition that drives Zaino's
+  service layer (`FetchService` / `StateService`, RPC surface) directly against
+  a live validator, with no wallet client.
+
+The two partitions are **separate member crates**, not sibling modules of one
+package. `zaino-testutils` remains a separate, client-agnostic shared crate that
+both depend on.
+
+## Considered options
+
+- **Naming.** `integration` (status quo) was rejected as overloaded and
+  uninformative — and it collides with Cargo's term. `e2e` as the *umbrella* was
+  rejected as overclaiming: roughly half the tests (the `integration` partition)
+  have no client "end" and don't cross the gRPC boundary. `system` was rejected
+  for faint redundancy with the `e2e` partition and a black-box/acceptance
+  connotation these developer-facing differential tests don't fit. `live` won
+  because it names the literal distinguishing property (needs a live validator)
+  with zero redundancy.
+- **One package with `e2e` / `integration` sibling mods** (the initial plan) vs.
+  **two member crates.** Two crates won: the partitions have **zero
+  cross-references** (verified — nothing in `e2e` touches `walletless_tests`,
+  nothing in `integration` touches `wallet_tests`) and everything genuinely
+  shared already lives in `zaino-testutils`, so splitting duplicates **no code**.
+  Two crates also yield **disjoint, precise feature tables** (`devtool-incompatible`
+  is e2e-only; `experimental_features` / `transparent_address_history_experimental`
+  is integration-only) instead of a muddier merged union, and match the natural
+  `live-tests/{e2e, integration}` layout without a redundant `live/live` nesting.
+
+## Consequences
+
+- A crate **literally named `integration`** sits inside `live-tests/`. This is
+  intentional: at the leaf it precisely denotes the no-client partition, and the
+  `e2e` sibling disambiguates it — the overload that sank "integration" as the
+  *umbrella* is resolved by the contrast.
+- The developer task surface is three front doors — `offline-tests` (the
+  `packages/*` set needing no live validator), `live-tests` (both live
+  partitions, aggregated), and `all-tests` (both) — delegating to the engines
+  `container-test`, `live-integration`, and `live-e2e` (partition selection
+  `-p e2e` / `-p integration`). "offline" is the glossary contrast to "live"
+  (see `live-tests/CONTEXT.md`).
+- Per-crate manifest boilerplate is the only duplication, and it is minimized by
+  `[workspace.package]` inheritance, `[workspace.dependencies]`, a root
+  `[profile.test]`, and a single root `.config/nextest.toml`.
+- The `e2e` partition is **compiled but not executed in CI**: it is part of the
+  `cargo nextest archive --workspace` build (so compilation regressions are
+  caught), but it is absent from the CI test matrix (the per-partition
+  `binary_id` selection in `ci.yml` simply never names an `e2e` binary). Adding
+  the validator-heavy e2e suite to CI is a
+  capacity decision deferred to
+  [#1308](https://github.com/zingolabs/zaino/issues/1308); until then, e2e
+  *runtime* regressions are ungated. This is a logged trade-off, not an oversight.

--- a/docs/adr/0004-rename-integration-partition-to-clientless.md
+++ b/docs/adr/0004-rename-integration-partition-to-clientless.md
@@ -1,0 +1,55 @@
+# Rename the `integration` live-test partition to `clientless`; single `makers test` front door
+
+## Status
+
+accepted (supersedes the naming and task-surface decisions in ADR-0003)
+
+## Context and decision
+
+ADR-0003 kept the no-client live partition named `integration`, betting that the
+`e2e` sibling disambiguated it. In practice the name still collided with Cargo's
+vocabulary — every `tests/*.rs` is, to Cargo, an "integration test" — at every
+grep, in the nextest filters (`package(integration)`), and in the CI binary-id
+matrix (`integration::*`); "integration partition" also read ambiguously in
+prose. We rename the partition everywhere it denotes that partition — crate,
+directory, `-p` selector, nextest filters, CI matrix, glossary, and docs — to
+**`clientless`**, which names the partition's actual distinguishing property (it
+drives Zaino's service layer with **no wallet client**) and never collides with
+Cargo's term. `integration` is thereby freed to mean only Cargo's sense.
+
+We also collapse the three front-door tasks ADR-0003 introduced
+(`offline-tests` / `live-tests` / `all-tests`, none of which shipped) into a
+**single `makers test [SET]`** task, `SET ∈ {package, e2e, clientless, live,
+all}`, default `package`. `live` = both live partitions (with the combined
+summary); `all` = `package` then `live`. The set names mirror the crate/dir
+names; the engines (`container-test`, `live-clientless`, `live-e2e`) are
+unchanged.
+
+## Considered options
+
+- **Keep `integration` (ADR-0003's choice).** Rejected: the Cargo-vocabulary
+  collision ADR-0003 tolerated is real and recurring (grep, nextest filters, CI
+  `integration::*`). `clientless`/`e2e` is also a cleaner antonym pair than
+  `integration`/`e2e`.
+- **Term: `walletless` / `no-client` / `clientless`.** `walletless` was the
+  pre-ADR-0003 name, but the e2e "client" is the `zcash_local_net` devtool
+  client, not strictly a wallet. `clientless` is precise and pairs with `e2e`.
+  (It had previously been listed under `_Avoid_`; that listing is reversed here.)
+- **Three task front doors vs one.** ADR-0003's `offline-tests` /
+  `live-tests` / `all-tests` were never released; one `makers test <set>` is a
+  smaller, discoverable surface and keeps the set names aligned with the crate
+  names.
+
+## Consequences
+
+- The crate/dir is `live-tests/clientless` (package `clientless`); selected via
+  `-p clientless`, nextest `package(clientless)`, and CI `clientless::*`
+  binary-id filters. `update-test-targets` regenerates the CI matrix from these.
+- `integration` is now reserved for Cargo's sense; the `CONTEXT.md` `_Avoid_`
+  lists are updated so "integration test" points at Cargo's meaning and
+  "clientless" is no longer avoided.
+- ADR-0003's naming bullet and its three-front-door task surface are superseded;
+  its two-crate split and the `live` umbrella decision still stand.
+
+> **Later note:** the `package` set was renamed `packages` (plural, matching the
+> `packages/` dir); `makers test package` now errors. See `live-tests/CONTEXT.md`.


### PR DESCRIPTION
PR #1265 (feat_migrate_tests) deleted three ADRs along with the live-test migration. They are restored here byte-for-byte from `12dd84a7^1`:

- `docs/adr/0002-live-tests-rejoin-root-workspace.md`
- `docs/adr/0003-live-test-taxonomy-and-two-crate-split.md`
- `docs/adr/0004-rename-integration-partition-to-clientless.md`

No content changes, no index edits — pure un-delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvjLSB7PZKDD3mU9UJc3sm